### PR TITLE
release: 0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,6 +348,16 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
+          # GitHub's macos-*-intel images sometimes ship third-party taps
+          # (e.g. aws/tap) that Homebrew now refuses without explicit trust.
+          # That prints a scary warning but doesn't affect homebrew-core
+          # formulae — still, drop untrusted taps so logs stay clean.
+          for tap in $(brew tap 2>/dev/null); do
+            case "$tap" in
+              homebrew/*|Homebrew/*) ;;
+              *) brew untap "$tap" 2>/dev/null || true ;;
+            esac
+          done
           brew install create-dmg
           create-dmg \
             --volname "EXR Converter" \

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ help:
 	@echo "  make clean                             # remove build artifacts"
 	@echo ""
 	@echo "  make bump PART=patch|minor|major       # bump version (no git)"
-	@echo "  make release PART=patch|minor|major    # bump + commit + tag + push (Release workflow)"
-	@echo "  make release PUSH=0                    # bump + commit + tag only (push manually for CI)"
+	@echo "  make release PART=… PUSH=0             # preferred: bump+commit+tag on release/* branch"
+	@echo "  make release PART=…                    # also pushes (fails if main is protected)"
 	@echo ""
-	@echo "  Docs: docs/releasing.md  (process + gh CLI)"
+	@echo "  Docs: docs/releasing.md  (PR + gh CLI; main is protected)"
 	@echo "        docs/plan-12bit-prores-oxideav.md"
 	@echo "Current tags: git tag -l 'v*' --sort=-v:refname | head"
 

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,11 @@ help:
 	@echo "  make clean                             # remove build artifacts"
 	@echo ""
 	@echo "  make bump PART=patch|minor|major       # bump version (no git)"
-	@echo "  make release PART=patch                # bump + commit + tag + push (Release workflow)"
+	@echo "  make release PART=patch|minor|major    # bump + commit + tag + push (Release workflow)"
 	@echo "  make release PUSH=0                    # bump + commit + tag only (push manually for CI)"
 	@echo ""
+	@echo "  Docs: docs/releasing.md  (process + gh CLI)"
+	@echo "        docs/plan-12bit-prores-oxideav.md"
 	@echo "Current tags: git tag -l 'v*' --sort=-v:refname | head"
 
 # ── Dependencies ─────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -137,14 +137,17 @@ All static assets live under `resources/`: icons in `resources/icons/` (`icon.ic
 
 Tags use plain semver: `v1.2.3`. Pushing a tag runs [`.github/workflows/release.yml`](.github/workflows/release.yml) and publishes a GitHub Release with Linux AppImage, macOS DMGs (ARM64 + Intel), and a Windows installer.
 
-**Full process** (Makefile, `gh` CLI, checklist): see **[docs/releasing.md](docs/releasing.md)**.
+**Full process** (protected `main`, PR, Makefile, `gh` CLI): see **[docs/releasing.md](docs/releasing.md)**.
 
 ```bash
-make help
-make release PART=patch        # bump + commit + tag + push (triggers Release workflow)
-make release PART=minor        # new features / codecs
-make release PUSH=0            # local only; push branch + tag yourself when ready
-gh run watch                   # follow the Release workflow
+git checkout -b release/X.Y.Z
+make release PART=minor PUSH=0   # bump + commit + local tag (main is PR-only)
+git push -u origin HEAD
+gh pr create --base main --title "release: X.Y.Z"
+# after merge:
+git checkout main && git pull
+git push origin vX.Y.Z           # triggers Release workflow (Nuitka + GitHub Release)
+gh run watch
 gh release list --limit 5
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Common options:
 | `--workers N` | both | `0` = auto, `1` = single-threaded |
 | `--scale FACTOR` | both | e.g. `0.5` for half resolution |
 | `--exr-compression NAME` | `video2exr` | e.g. `dwaa`, `zip`, `none` (see `--help`) |
-| `--codec KEY` | `exr2video` | Full ladder with bit depth in names: ProRes Proxy…XQ, DNxHR LB…444, CineForm, HEVC 8/10-bit, H.264, FFV1. **VideoToolbox ProRes** keys (`prores_vt_*`) are **macOS-only**. |
+| `--codec KEY` | `exr2video` | Full ladder with honest bit depths: ProRes Proxy…XQ (software = 10-bit encode), DNxHR LB…444, CineForm 10/12-bit, HEVC 8/10/12-bit, H.264, FFV1 10/12-bit. **VideoToolbox ProRes** (`prores_vt_*`) is **macOS-only**; VT 4444/XQ are ~12-bit. |
 
 Run `uv run python main.py video2exr --help` or `exr2video --help` for the full list.
 
@@ -137,10 +137,15 @@ All static assets live under `resources/`: icons in `resources/icons/` (`icon.ic
 
 Tags use plain semver: `v1.2.3`. Pushing a tag runs [`.github/workflows/release.yml`](.github/workflows/release.yml) and publishes a GitHub Release with Linux AppImage, macOS DMGs (ARM64 + Intel), and a Windows installer.
 
+**Full process** (Makefile, `gh` CLI, checklist): see **[docs/releasing.md](docs/releasing.md)**.
+
 ```bash
 make help
 make release PART=patch        # bump + commit + tag + push (triggers Release workflow)
+make release PART=minor        # new features / codecs
 make release PUSH=0            # local only; push branch + tag yourself when ready
+gh run watch                   # follow the Release workflow
+gh release list --limit 5
 ```
 
 ### CI / release gates

--- a/docs/plan-12bit-prores-oxideav.md
+++ b/docs/plan-12bit-prores-oxideav.md
@@ -1,0 +1,366 @@
+# Plan: Cross-platform 12-bit ProRes via oxideav
+
+**Status:** research complete · implementation not started  
+**Date:** 2026-08-06  
+**Related code:** `src/core/constants.py`, `tests/test_codecs.py`, Nuitka `Makefile` / `.github/workflows/release.yml`
+
+This document records bit-depth findings for FFmpeg/ProRes in EXR Converter, why software ProRes is 10-bit only, and a concrete plan to ship **true 12-bit ProRes-compatible** encodes on Windows, Linux, and macOS using the pure-Rust **oxideav-prores** stack, bundled with **Nuitka**.
+
+---
+
+## 1. Goals
+
+| Goal | Notes |
+|------|--------|
+| True **12-bit** encode precision for a ProRes-family intermediate | Not just probe metadata that *says* 12-bit |
+| **Cross-platform** | Win / Linux / macOS (arm64 + x86_64) in release CI |
+| Fits existing **Nuitka standalone** packaging | No PyOxidizer migration |
+| Honest UI | Experimental until interop is proven; never overclaim |
+| Keep FFmpeg path for everything else | PyAV remains default for ProRes 10-bit, DNxHR, HEVC, etc. |
+
+**Non-goals (v1):**
+
+- Replacing all ProRes with oxideav  
+- Apple-licensed / certified ProRes branding  
+- ProRes RAW  
+- In-process PyO3 until the sidecar is proven  
+
+---
+
+## 2. Findings: bit depth today
+
+### 2.1 Measurement method (solid-patch mid-bin)
+
+Encode two constant full-frame RGB fields in `rgb48le`:
+
+- **B** — 10-bit lattice point in full-range 16-bit (e.g. `16384`, multiple of 64)  
+- **B+32** — mid-bin between two 10-bit codes (needs **>10 bits** to distinguish)
+
+Decode back to `rgb48le`, compare center-crop means:
+
+| Δ (mean(B+32) − mean(B)) | Interpretation |
+|--------------------------|----------------|
+| **≈ 0** | Mid-bin collapsed → effective **≤10-bit** encode |
+| **≈ 32** (or clearly >12) | Mid-bin kept → **12-bit-class** (or deeper) |
+
+ProRes is lossy; exact 32 is not required, but collapse to 0 is definitive for 10-bit quantization.
+
+Automated regressions live in `tests/test_codecs.py` (`TestBitDepthRoundtrip`).
+
+### 2.2 Results (FFmpeg 8.1.1 + PyAV, local)
+
+| Encoder | Path / pix_fmt | Mid-bin Δ | Claimed by probe | **True encode depth** |
+|---------|----------------|-----------|------------------|------------------------|
+| `prores_ks` 422 HQ | `yuv422p10le` | **0** | 10 | **10** |
+| `prores_ks` 4444 | `yuva444p10le` | **0** | often **12** (`yuva444p12le`) | **10** |
+| `prores_ks` XQ | `yuva444p10le` | **0** | often **12** | **10** |
+| `prores_ks` + `yuva444p12le` | — | **rejected** | — | cannot open |
+| `prores_videotoolbox` 422 | `p210le` | **0** | 10 | **10** |
+| `prores_videotoolbox` 4444/XQ | `ayuv64le` | **~18–37** | 12 | **~12-bit class** |
+| `libx265` 10 | `yuv420p10le` | **0** | 10 | **10** |
+| `libx265` 12 | `yuv420p12le` | **~37** | 12 | **12** |
+| `ffv1` 12 | `yuv444p12le` | **~32** | 12 | **12** |
+| `cfhd` RGB | `gbrp12le` | **32** | 12 | **12** |
+
+### 2.3 Why “FFmpeg ProRes is 12-bit” is a myth
+
+1. **Encoder capability list** for `prores_ks` / `prores_aw`:
+   ```text
+   Supported pixel formats: yuv422p10le yuv444p10le yuva444p10le
+   ```
+   No `*12le` formats. Requesting 12-bit → auto-select or open failure.
+
+2. **Decoder presentation:** FFmpeg often surfaces 4444/XQ as `yuva444p12le` with `bits_per_raw_sample=12` even when only 10 bits of precision were encoded. **Do not trust probe alone.**
+
+3. **Industry sources agree** (encode, not decode):
+   - [ASWF Encoding Guidelines — ProRes](https://academysoftwarefoundation.github.io/EncodingGuidelines/EncodeProres.html): *“prores_ks can only encode to 10-bits”*; 4444xq row notes *“ffmpeg will only generate up to 10-bit.”*
+   - FFmpeg Trac **#8054** — *prores_ks codec does not allow 12bit pix_fmt* (open enhancement for years).
+   - FFmpeg Trac **#7163** — 12-bit *decode* improvements; does not fix encode.
+   - Community (BMD forums, Hybrid/Selur, vhs-decode wiki): same conclusion — FFmpeg still cannot *render* true 12-bit ProRes.
+
+4. **Historical “max 10-bit FFmpeg” confusion** often mixed:
+   - Old separate 8-bit vs 10-bit **libx264** builds  
+   - Hardware encoders (NVENC, SVT-AV1) capped at 10  
+   - ProRes software encode cap  
+   with the FFmpeg **pixel format** layer, which fully supports 8–16-bit.
+
+### 2.4 App alignment (already done)
+
+After measurement, presets were corrected so labels match encode reality:
+
+| Key family | `bit_depth` | Notes |
+|------------|-------------|--------|
+| `prores_*` (`prores_ks`) | **10** including 4444/XQ | `yuva444p10le` |
+| `prores_vt_*` 422 | **10** | macOS |
+| `prores_vt_4444` / `prores_vt_xq` | **12** | VT mid-bin keep |
+| `hevc_12` | **12** | `yuv420p12le` Main 12 |
+| `ffv1_12` | **12** | `yuv444p12le` |
+| `cineform_rgb` | **12** | `gbrp12le` |
+
+Cross-platform **true 12-bit** options today: **CineForm RGB**, **HEVC 12**, **FFV1 12**.  
+Cross-platform **ProRes** with true 12-bit: **not available via FFmpeg**.
+
+### 2.5 Licensed / NLE paths (not embeddable)
+
+True cross-platform 12-bit ProRes exists in **closed tools**, not as a free library we can ship:
+
+- Apple **VideoToolbox** — macOS only (we already expose this).  
+- **Adobe** Premiere / Media Encoder — Win + Mac, licensed.  
+- **DaVinci Resolve 19.1.4+** — ProRes encode on Win/Linux (2025); not a library.  
+- Apple **ProRes Program** / commercial SDKs — license + redistribution terms.
+
+These do not help a Nuitka-shipped Python app without a full NLE dependency.
+
+---
+
+## 3. Candidate: oxideav-prores
+
+### 3.1 What it is
+
+| Item | Detail |
+|------|--------|
+| Crate | [`oxideav-prores`](https://crates.io/crates/oxideav-prores) (docs: [docs.rs](https://docs.rs/oxideav-prores/)) |
+| Org | [OxideAV](https://github.com/OxideAV) — pure-Rust media framework |
+| Spec | **SMPTE RDD 36:2022** (published ProRes bitstream) |
+| Profiles | All six: 422 Proxy/LT/Standard/HQ, **4444**, **4444 XQ** |
+| Depths | **8 / 10 / 12 / 16-bit** YUV (`*P12Le`, `Yuva*P12Le`, etc.) |
+| Alpha | Lossless alpha on 4444/XQ (per docs) |
+| License | **MIT** |
+| Dependencies | No `*-sys` / no system FFmpeg for the codec itself |
+
+CLI surface of the wider project: `cargo install oxideav-cli` → `oxideav` (probe / remux / transcode). Codec can also be used as a library with oxideav container crates for MOV.
+
+### 3.2 Why it fits EXR Converter
+
+- Only public **cross-platform** stack that **claims** what FFmpeg never shipped: **encode** 12-bit 4444/XQ.  
+- Pure Rust → static-ish helper binary, easy to CI-build on Win/Linux/macOS.  
+- Same packaging model as “ship a native helper next to the frozen app.”  
+- Leaves PyAV/FFmpeg for the rest of the codec ladder.
+
+### 3.3 Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Interop (FCP / Premiere / Resolve reject or mis-decode) | **High** | Gate release on open-in-NLE tests + mid-bin proof |
+| Young crate (0.x) | Medium | Pin version; experimental preset; optional disable |
+| Not Apple-licensed | Medium (product/legal) | UI: “RDD-36 ProRes-compatible (experimental)” — avoid implying Apple certification |
+| Mux / color metadata / alpha edge cases | Medium | v1: progressive 4444 12-bit, no alpha, explicit BT.709 tags |
+| Encode speed vs `prores_ks` / VT | Unknown | Benchmark before making default |
+| Maintenance of custom CLI + CI | Medium | Thin binary; pin Cargo.lock in repo |
+
+---
+
+## 4. Architecture
+
+### 4.1 Chosen approach: sidecar helper (v1)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  EXR Converter (Python / Nuitka)                            │
+│  OIIO + OCIO → display/working RGB (rgb48le)                │
+│  slate / burn-in / watermark (existing path)                │
+└───────────────────────────┬─────────────────────────────────┘
+                            │ frames: temp PNG16 / raw planar
+                            │ or stdin protocol (later)
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  helpers/exr-prores  (Rust, release binary)                 │
+│  oxideav-prores encode 12-bit 4444 / XQ                     │
+│  oxideav MOV mux → .mov                                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Why not PyO3 first:** binding + maturin wheels for four OS targets before the codec is proven is wasted work. Sidecar is testable with CLI alone and matches Nuitka `--include-data-files`.
+
+**Why not full oxideav replace PyAV:** EXR, OCIO, and most codecs stay on OIIO/PyAV; only the 12-bit ProRes *output* path needs oxideav.
+
+### 4.2 Suggested helper CLI (draft)
+
+```text
+exr-prores encode \
+  --input-glob './tmp/frame.%04d.png' \
+  --fps 24 \
+  --profile 4444|xq \
+  --bit-depth 12 \
+  --pix-fmt yuv444p12   # or yuva444p12 when alpha ready \
+  --color-primaries bt709 --color-trc bt709 --colorspace bt709 \
+  --output out.mov
+```
+
+Constraints for v1:
+
+- Progressive only  
+- Even dimensions (ProRes macroblock rules)  
+- Explicit colour tags (oxideav docs warn unknown 4444 metadata can break some decoders)  
+- Exit non-zero on failure; print progress to stderr  
+
+### 4.3 App integration points
+
+| Area | Change |
+|------|--------|
+| `src/core/constants.py` | New keys e.g. `prores_ox_4444`, `prores_ox_xq` — `bit_depth=12`, chroma `4:4:4` / `4:4:4:4`, libav placeholder or custom flag |
+| `src/core/convert.py` | Branch: if oxideav preset → write frame sequence (or pipe) → run helper → skip PyAV ProRes encode |
+| `src/gui/widgets.py` | Help text: experimental; require helper present |
+| `src/cli.py` | Same keys in `--codec` choices; default `.mov` |
+| Helper discovery | Mirror OCIO frozen-path logic (`sys.executable` parent, macOS `Contents/MacOS/helpers/`, dev `helpers/`) |
+| Absence of helper | Hide presets or disable with clear message (dev without Rust still works) |
+
+Do **not** set `bit_depth=12` on `prores_ks` keys. Keep FFmpeg software ProRes honest at 10-bit.
+
+### 4.4 Packaging (Nuitka — already the release path)
+
+Repo already uses Nuitka standalone (`make bundle`, release matrix). **No PyOxidizer.**
+
+1. **CI build job (each OS):** install Rust → `cargo build --release -p exr-prores` → place binary in `helpers/`.  
+2. **Nuitka:**  
+   ```text
+   --include-data-files=helpers/exr-prores=helpers/exr-prores
+   ```  
+   (Windows: `exr-prores.exe`; post-step for `.app` layout if needed.)  
+3. **Runtime:** resolve `helpers/exr-prores` next to the frozen executable.  
+4. **Size:** expect a few MB for a focused binary; acceptable next to Qt/OIIO.
+
+Dev: optional `make helper` / document `cargo build` so contributors can test without waiting for CI artifacts.
+
+---
+
+## 5. Implementation phases
+
+### Phase 0 — Spike (local only) ✅ research done · ⬜ binary not built
+
+- [ ] Create `tools/exr-prores/` (or `helpers/exr-prores/`) Cargo project  
+- [ ] Depend on pinned `oxideav-prores` + MOV mux crates  
+- [ ] Encode one solid-color 12-bit frame to `.mov`  
+- [ ] Run **mid-bin test** (B vs B+32) on oxideav output  
+- [ ] Open file in **Resolve** and **ffmpeg/ffprobe** (note: probe may still say 12-bit; trust mid-bin + visual/NLE)  
+- [ ] Go/no-go: mid-bin kept **and** Resolve opens without black/error  
+
+**Exit criteria:** mid-bin Δ clearly > 12; file plays in at least one major NLE on one OS.
+
+### Phase 1 — Helper CLI + tests
+
+- [ ] Stable CLI contract (args as above)  
+- [ ] Cargo.lock committed; pinned crate versions  
+- [ ] Unit/integration: mid-bin for 4444 and XQ at 12-bit  
+- [ ] Optional: 10-bit encode path for parity comparison with `prores_ks`  
+- [ ] Document build: `cargo build --release -p exr-prores`  
+
+### Phase 2 — App wiring (behind experimental flag)
+
+- [ ] Presets `prores_ox_4444` / `prores_ox_xq` in `VIDEO_CODECS`  
+- [ ] Convert path: temp frame dump → subprocess → output `.mov`  
+- [ ] Progress/cancel: kill helper process; clean temp dir  
+- [ ] UI badge: “experimental · RDD-36 · requires helper”  
+- [ ] Tests: skip if helper missing; run mid-bin when present  
+
+### Phase 3 — CI + Nuitka
+
+- [ ] `release.yml` / local `make bundle`: Rust toolchain + helper build  
+- [ ] Include helper in all four artifacts (linux-x64, macos-arm64, macos-x86_64, windows-x64)  
+- [ ] Smoke: mid-bin on each platform in CI (headless)  
+- [ ] Manual checklist: open sample MOV in Resolve/Premiere/FCP before marking non-experimental  
+
+### Phase 4 — Harden (only if Phase 0–3 pass)
+
+- [ ] Alpha channel if needed  
+- [ ] Pipe/raw protocol to avoid PNG temp I/O  
+- [ ] Performance pass (threads, fewer copies)  
+- [ ] Consider PyO3 only if subprocess overhead is a real problem  
+- [ ] Promote UI copy from experimental → stable if interop is solid  
+
+---
+
+## 6. Acceptance tests
+
+| Test | Pass criteria |
+|------|----------------|
+| Mid-bin solid patch | Δ(B+32 − B) **> 12** (ideally ~32) for oxideav 12-bit 4444 |
+| Contrast with `prores_ks` | Same sources: `prores_ks` Δ **≈ 0** (regression guard) |
+| Encode smoke | Helper produces non-empty `.mov`; ffprobe shows ProRes 4444/XQ |
+| NLE open | Resolve (Win/Mac/Linux as available) opens timeline, no black frame |
+| Frozen path | Nuitka app finds helper; experimental preset completes end-to-end |
+| Cancel | Killing job terminates helper; no orphan processes |
+| Missing helper | Clear error; no crash; FFmpeg codecs still work |
+
+---
+
+## 7. Labeling & honesty policy
+
+| Product surface | Copy |
+|-----------------|------|
+| Software FFmpeg ProRes 4444/XQ | **10-bit** encode (`prores_ks`) |
+| VideoToolbox 4444/XQ | **12-bit class** (macOS) |
+| oxideav presets (v1) | **12-bit · experimental · RDD-36 ProRes-compatible** |
+| Marketing | Do not say “Apple ProRes certified” or “identical to Final Cut ProRes” until interop matrix is complete |
+
+This matches the project rule already encoded in `VideoCodecSpec`: *never imply higher precision than we actually encode.*
+
+---
+
+## 8. Alternatives if oxideav fails go/no-go
+
+| Need | Path already in app |
+|------|---------------------|
+| Cross-platform true 12-bit intermediate | `cineform_rgb`, `ffv1_12` |
+| Cross-platform 12-bit delivery | `hevc_12` |
+| macOS true high-depth ProRes | `prores_vt_4444` / `prores_vt_xq` |
+| Cross-platform ProRes for review | `prores` / `prores_ks` **10-bit** (honest) |
+
+ASWF also pushes **OpenAPV** as a modern open intermediate; optional future preset, separate from ProRes.
+
+---
+
+## 9. Rough effort estimate
+
+| Phase | Effort (order of magnitude) |
+|-------|-----------------------------|
+| Phase 0 spike | 1–2 days (including NLE checks) |
+| Phase 1 CLI + tests | 2–4 days |
+| Phase 2 app wiring | 2–3 days |
+| Phase 3 CI + Nuitka | 1–2 days |
+| Phase 4 harden | as needed |
+
+Blocked primarily on **interop confidence**, not packaging.
+
+---
+
+## 10. References
+
+### Internal
+
+- `src/core/constants.py` — codec ladder + FFmpeg bit-depth comments  
+- `tests/test_codecs.py` — mid-bin / pix_fmt honesty tests  
+- `Makefile` — `make bundle` (Nuitka)  
+- `.github/workflows/release.yml` — multi-OS release gate + build  
+
+### External
+
+- [ASWF Encode ProRes](https://academysoftwarefoundation.github.io/EncodingGuidelines/EncodeProres.html)  
+- [ASWF Encode HEVC](https://academysoftwarefoundation.github.io/EncodingGuidelines/EncodeHevc.html)  
+- FFmpeg Trac [#8054](https://trac.ffmpeg.org/ticket/8054), [#7163](https://trac.ffmpeg.org/ticket/7163)  
+- [oxideav-prores](https://github.com/OxideAV/oxideav-prores) · [docs.rs](https://docs.rs/oxideav-prores/) · [OxideAV site](https://oxideav.github.io/)  
+- SMPTE **RDD 36** (ProRes bitstream)  
+- Apple ProRes white paper (format capability “up to 12-bit”; not FFmpeg software encode capability)  
+
+### Local measurement note
+
+Solid-patch mid-bin runs (2026-08) confirmed `prores_ks` 4444/XQ Δ=0 and VT 4444/XQ mid-bin keep; results drove the preset relabel and the decision to pursue oxideav rather than further FFmpeg flags.
+
+---
+
+## 11. Decision log
+
+| Date | Decision |
+|------|----------|
+| 2026-08-06 | Confirmed FFmpeg `prores_ks` cannot encode true 12-bit; app labels fixed |
+| 2026-08-06 | Added `hevc_12` and `ffv1_12` as honest cross-platform 12-bit options |
+| 2026-08-06 | Chose **oxideav sidecar + Nuitka include** as plan for experimental cross-platform 12-bit ProRes-compatible output |
+| — | *Pending:* Phase 0 go/no-go on mid-bin + Resolve open |
+
+---
+
+## 12. Next action
+
+1. Scaffold `tools/exr-prores` and prove mid-bin + NLE open (**Phase 0**).  
+2. If green, pin crates and land Phase 1 CLI under the repo with CI-optional build.  
+3. Only then wire experimental presets and Nuitka packaging.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -49,7 +49,50 @@ Tags are plain semver: **`v1.2.3`**. The tag is the source of truth for the publ
 
 ## Everyday release (recommended)
 
-From a clean tree with feature work already on `main` (or your release branch merged):
+`main` is **branch-protected**: direct pushes are rejected (required status checks + **changes must be made through a pull request**). Do **not** rely on `make release` with `PUSH=1` while on `main` — the version commit may land locally and the push will fail.
+
+### Protected `main` (current process)
+
+```bash
+# 0. Start from up-to-date main, clean tree
+git checkout main
+git pull origin main
+
+# 1. Feature work (optional separate commits), then cut a release branch
+git checkout -b release/X.Y.Z
+
+# 2. Bump + commit + local tag only (do not push main)
+make release PART=minor PUSH=0    # or patch / major
+# → commit "release: X.Y.Z" + local tag vX.Y.Z
+
+# 3. Push the branch and open a PR into main
+git push -u origin HEAD
+gh pr create --base main --title "release: X.Y.Z" --body "…"
+
+# 4. Wait for CI on the PR
+gh pr checks
+# or: gh run watch
+
+# 5. Merge when green (squash or merge per repo preference)
+gh pr merge --merge          # or --squash
+
+# 6. Update local main, ensure tag points at the release commit on main
+git checkout main
+git pull origin main
+# If the tag still points at the pre-merge commit SHA, move it only if
+# that commit is an ancestor of main (typical for merge commits):
+git tag -d vX.Y.Z 2>/dev/null || true
+git tag vX.Y.Z
+git push origin vX.Y.Z       # triggers Release workflow (Nuitka + GitHub Release)
+
+# 7. Watch publish
+gh run watch
+gh release view vX.Y.Z
+```
+
+Historical example: `release/0.3.0` → PR #1; `release/0.4.0` → PR #2.
+
+### If `main` were unprotected (not our case)
 
 ```bash
 # Optional: see current version
@@ -66,18 +109,18 @@ make release PART=minor          # 0.3.0 → 0.4.0
 make release PART=major          # 0.3.0 → 1.0.0
 ```
 
-Defaults:
+### Make variables
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
 | `PART` | `patch` | Which semver segment to increment |
-| `PUSH` | `1` | Push branch + tag to `origin` |
+| `PUSH` | `1` | Push branch + tag to `origin` — use **`PUSH=0`** under branch protection |
 
 Local-only tag (no push — push yourself when ready):
 
 ```bash
 make release PART=patch PUSH=0
-git push origin HEAD
+git push origin HEAD            # only works if the branch is not protected
 git push origin vX.Y.Z
 ```
 
@@ -191,13 +234,15 @@ Nuitka is also available locally: `make bundle` (does **not** publish a GitHub R
 
 ---
 
-## Checklist before `make release`
+## Checklist before shipping
 
-- [ ] Feature commits are done and tested (`make test` or rely on CI after push)  
+- [ ] Feature commits are done and tested (`make test` or rely on PR CI)  
+- [ ] On a **`release/X.Y.Z` branch** (not a direct push to protected `main`)  
 - [ ] Working tree has no *other* unstaged changes you still need (release only commits version files)  
 - [ ] `PART` chosen correctly (patch / minor / major)  
-- [ ] You intend to trigger a full multi-OS Nuitka build (time + minutes on Actions)  
-- [ ] After push: `gh run watch` until green; confirm `gh release view vX.Y.Z`  
+- [ ] `make release … PUSH=0`, then `gh pr create`  
+- [ ] PR CI green → merge → `git push origin vX.Y.Z`  
+- [ ] `gh run watch` until Release workflow green; confirm `gh release view vX.Y.Z`  
 
 ---
 
@@ -205,11 +250,13 @@ Nuitka is also available locally: `make bundle` (does **not** publish a GitHub R
 
 | Symptom | What to do |
 |---------|------------|
+| `GH013` / *Changes must be made through a pull request* | Expected on protected `main`. Use `release/X.Y.Z` + PR; `make release PUSH=0` |
+| *5 of 5 required status checks are expected* | Push was blocked before CI could run on `main`. Ship via PR so checks run on the PR head |
 | `No changes to commit` from `make release` | Version files already match the bump target, or bump failed; run `python3 scripts/bump_app_version.py show` and check `git status` |
-| Tag already exists | Bump again, or delete local tag only if it was never pushed (`git tag -d vX.Y.Z`) — **never** force-push tags that already built a public release without a deliberate process |
-| Gate red | Fix tests/lint on `main`, push a fix commit, then either retag carefully or cut `PART=patch` again — prefer a new patch version over rewriting history |
+| Tag already exists locally but not on remote | After merge: retag the commit on `main` if needed, then `git push origin vX.Y.Z`. **Never** force-push tags that already built a public release without a deliberate process |
+| Gate red on Release workflow | Fix on a follow-up commit / patch version; prefer a new patch over rewriting a published tag |
 | Wrong version in the GUI binary | Confirm tag is `vX.Y.Z` and the workflow’s “Inject version from tag” step ran; `APP_VERSION` in the tagged commit should match |
-| Need a release without pushing yet | `make release PUSH=0`, then push branch + tag when ready |
+| Need a release without pushing yet | `make release PUSH=0`, then PR + push tag when ready |
 
 ---
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,233 @@
+# Releasing EXR Converter
+
+How versions are bumped, tagged, and published. Canonical automation lives in the **Makefile** and **`.github/workflows/release.yml`**. Use **`gh`** to watch CI and inspect GitHub Releases.
+
+Related docs: [plan-12bit-prores-oxideav.md](./plan-12bit-prores-oxideav.md) (future codec work — not part of the release machinery).
+
+---
+
+## Overview
+
+```text
+feature commits on main
+        │
+        ▼
+ make release PART=patch|minor|major
+        │  1. scripts/bump_app_version.py → pyproject + APP_VERSION
+        │  2. uv lock
+        │  3. commit: "release: X.Y.Z"  (only version files)
+        │  4. tag: vX.Y.Z
+        │  5. push branch + tag  (unless PUSH=0)
+        ▼
+ GitHub Actions “Release” workflow (on tag v*)
+        │  lint → test (3 OS) → gate → Nuitka builds → sign → GitHub Release
+        ▼
+ Artifacts: Linux AppImage, macOS DMG (arm64 + x86_64), Windows installer
+```
+
+Tags are plain semver: **`v1.2.3`**. The tag is the source of truth for the published app version (the workflow also injects `APP_VERSION` from the tag during the Nuitka build).
+
+---
+
+## Prerequisites
+
+- Clean **intent**: all feature work committed (or stashed) *before* `make release`.  
+  The release target only stages:
+  - `pyproject.toml`
+  - `src/core/constants.py` (`APP_VERSION`)
+  - `uv.lock`
+- `uv` available; `scripts/bump_app_version.py` is plain Python 3.
+- Push access to `origin` and permission to create tags.
+- [GitHub CLI](https://cli.github.com/) (`gh`) authenticated for status / release inspection:
+
+  ```bash
+  gh auth status
+  # expect: Logged in to github.com
+  ```
+
+---
+
+## Everyday release (recommended)
+
+From a clean tree with feature work already on `main` (or your release branch merged):
+
+```bash
+# Optional: see current version
+python3 scripts/bump_app_version.py show
+# → VERSION="0.3.0"
+# → TAG="v0.3.0"
+
+# Dry-run bump only (no files written)
+python3 scripts/bump_app_version.py bump patch --dry-run
+
+# Full release: bump + commit + tag + push (triggers CI)
+make release PART=patch          # 0.3.0 → 0.3.1
+make release PART=minor          # 0.3.0 → 0.4.0
+make release PART=major          # 0.3.0 → 1.0.0
+```
+
+Defaults:
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `PART` | `patch` | Which semver segment to increment |
+| `PUSH` | `1` | Push branch + tag to `origin` |
+
+Local-only tag (no push — push yourself when ready):
+
+```bash
+make release PART=patch PUSH=0
+git push origin HEAD
+git push origin vX.Y.Z
+```
+
+Version-only bump without git (review, then commit yourself):
+
+```bash
+make bump PART=patch
+# edits pyproject.toml, constants.py, runs uv lock
+```
+
+---
+
+## What `make release` does (step by step)
+
+Implemented in the Makefile `release` target:
+
+1. **`scripts/bump_app_version.py bump $(PART)`**  
+   - Reads `version = "…"` from `pyproject.toml`  
+   - Writes new semver there  
+   - Syncs `APP_VERSION = "…"` in `src/core/constants.py`  
+2. **`uv lock`** — refresh lockfile if needed  
+3. **`scripts/bump_app_version.py show`** — export `VERSION` / `TAG` for the shell  
+4. **`git add`** only the three version-related files  
+5. **`git commit -m "release: $${VERSION}"`**  
+6. **`git tag "v$${VERSION}"`** (annotated? lightweight — plain `git tag`)  
+7. If `PUSH=1`: **`git push origin HEAD`** and **`git push origin "v…"`**  
+
+The Release workflow starts on **tag push** (`on.push.tags: v*`).
+
+---
+
+## Choosing patch vs minor vs major
+
+| Bump | Use when |
+|------|----------|
+| **patch** | Fixes, CI, docs-only, no new user-facing capabilities |
+| **minor** | New codecs/presets, visible feature work, honest label changes that add options |
+| **major** | Breaking CLI/API or intentional 1.0-style cut |
+
+Examples from this project’s history: codec expansions and pipeline features have shipped as minor/patch releases via the same `make release` path.
+
+---
+
+## After push: GitHub CLI
+
+### Watch the Release workflow
+
+```bash
+# Runs for this repo (must be inside the clone or pass -R owner/repo)
+gh run list --workflow=Release --limit 5
+
+# Follow the newest run live
+gh run watch
+
+# Or open in the browser
+gh run view --web
+```
+
+If a run fails:
+
+```bash
+gh run list --workflow=Release --limit 3
+gh run view <run-id> --log-failed
+```
+
+### Inspect published releases
+
+```bash
+gh release list --limit 10
+gh release view v0.4.0
+gh release view v0.4.0 --web
+```
+
+Download an asset:
+
+```bash
+gh release download v0.4.0 --pattern '*.dmg' --dir /tmp/exr-assets
+```
+
+### CI on pull requests / main
+
+```bash
+gh run list --workflow=CI --limit 5
+gh pr checks   # when on a PR branch
+```
+
+Release **gate** (must be green before Nuitka): lint + full pytest on Linux, macOS, and Windows. A red gate aborts the release; no artifacts are published.
+
+---
+
+## Release workflow contents (summary)
+
+File: [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+
+| Job | Role |
+|-----|------|
+| `lint` | Ruff check + format |
+| `test` | Full pytest (unit + integration) on ubuntu / macos / windows |
+| `gate` | Fails the whole release if lint or any test matrix cell failed |
+| `build` | Nuitka standalone → AppImage / DMG / Windows setup (matrix) |
+| (sign / publish) | Cosign + GitHub Release upload (see workflow for current steps) |
+
+Build matrix (as of this writing):
+
+- Linux x86_64 → AppImage  
+- macOS arm64 → DMG  
+- macOS x86_64 → DMG  
+- Windows x86_64 → installer  
+
+Nuitka is also available locally: `make bundle` (does **not** publish a GitHub Release).
+
+---
+
+## Checklist before `make release`
+
+- [ ] Feature commits are done and tested (`make test` or rely on CI after push)  
+- [ ] Working tree has no *other* unstaged changes you still need (release only commits version files)  
+- [ ] `PART` chosen correctly (patch / minor / major)  
+- [ ] You intend to trigger a full multi-OS Nuitka build (time + minutes on Actions)  
+- [ ] After push: `gh run watch` until green; confirm `gh release view vX.Y.Z`  
+
+---
+
+## Troubleshooting
+
+| Symptom | What to do |
+|---------|------------|
+| `No changes to commit` from `make release` | Version files already match the bump target, or bump failed; run `python3 scripts/bump_app_version.py show` and check `git status` |
+| Tag already exists | Bump again, or delete local tag only if it was never pushed (`git tag -d vX.Y.Z`) — **never** force-push tags that already built a public release without a deliberate process |
+| Gate red | Fix tests/lint on `main`, push a fix commit, then either retag carefully or cut `PART=patch` again — prefer a new patch version over rewriting history |
+| Wrong version in the GUI binary | Confirm tag is `vX.Y.Z` and the workflow’s “Inject version from tag” step ran; `APP_VERSION` in the tagged commit should match |
+| Need a release without pushing yet | `make release PUSH=0`, then push branch + tag when ready |
+
+---
+
+## Quick reference
+
+```bash
+# Status
+python3 scripts/bump_app_version.py show
+git tag -l 'v*' --sort=-v:refname | head
+gh release list --limit 5
+gh run list --workflow=Release --limit 3
+
+# Ship a patch
+make release PART=patch
+
+# Ship a minor (new features / codecs)
+make release PART=minor
+
+# Watch
+gh run watch
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.3.0"
+version = "0.4.0"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/cli.py
+++ b/src/cli.py
@@ -283,11 +283,11 @@ def default_e2v_output_path(input_path: str, codec_key: str = DEFAULT_VIDEO_CODE
     spec = _by_key(codec_key)
     if spec is not None:
         # Keep container sensible for the codec family.
-        if codec_key in ("h264", "hevc", "hevc_8"):
+        if codec_key in ("h264", "hevc", "hevc_8", "hevc_12"):
             ext = ".mp4"
         elif str(codec_key).startswith("dnxhr"):
             ext = ".mxf"
-        elif codec_key == "ffv1":
+        elif codec_key in ("ffv1", "ffv1_12"):
             ext = ".mkv"
     return base.parent / f"{name}{ext}"
 

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -140,26 +140,33 @@ def _dnxhr(
 
 # Display names include bit depth + chroma. Pipeline: rgb48le → reformat(pix_fmt).
 #
-# FFmpeg notes:
-# - prores_ks profiles 0–3 → 10-bit 4:2:2; 4–5 (4444/XQ) → 12-bit 4:4:4:4 in practice.
+# FFmpeg bit-depth truth (verified with solid-patch mid-bin roundtrips):
+# - prores_ks: only accepts yuv422p10le / yuv444p10le / yuva444p10le.
+#   Profiles 0–5 all encode at 10-bit. 4444/XQ may *probe* as yuva444p12le
+#   after decode (FFmpeg presentation), but +32 mid-bin vs 10-bit lattice
+#   collapses to delta 0 — true encode precision is 10-bit.
+# - prores_videotoolbox 422: 10-bit (p210le). 4444/XQ with ayuv64le preserve
+#   mid-bin steps beyond 10-bit (Apple HW ~12-bit class).
 # - DNxHR LB/SQ/HQ → 8-bit 4:2:2; HQX → 10-bit 4:2:2; 444 → 10-bit 4:4:4.
-# - cfhd: yuv422p10le / gbrp12le.
-# - libx265: 8/10-bit depending on pix_fmt.
-# - prores_videotoolbox: Apple hardware encoder, Darwin only.
+# - cfhd: yuv422p10le (10) / gbrp12le (true 12).
+# - libx265: 8 / 10 / 12 via pix_fmt (Main / Main 10 / Main 12).
+# - ffv1: lossless 10 or 12 via pix_fmt.
+# - libx264: max 10-bit (High 10); no 12-bit.
 VIDEO_CODECS: list[VideoCodecSpec] = [
-    # ── ProRes (software, cross-platform) ─────────────────────────────────
+    # ── ProRes (software, cross-platform) — all 10-bit encode ─────────────
     _prores_ks("prores_proxy", "Apple ProRes 422 Proxy", "0", "yuv422p10le", 10, "4:2:2"),
     _prores_ks("prores_lt", "Apple ProRes 422 LT", "1", "yuv422p10le", 10, "4:2:2"),
     _prores_ks("prores_422", "Apple ProRes 422", "2", "yuv422p10le", 10, "4:2:2"),
     # Legacy key ``prores`` = HQ (presets / CLI compatibility).
     _prores_ks("prores", "Apple ProRes 422 HQ", "3", "yuv422p10le", 10, "4:2:2"),
-    _prores_ks("prores_4444", "Apple ProRes 4444", "4", "yuva444p10le", 12, "4:4:4:4"),
-    _prores_ks("prores_xq", "Apple ProRes 4444 XQ", "5", "yuva444p10le", 12, "4:4:4:4"),
+    _prores_ks("prores_4444", "Apple ProRes 4444", "4", "yuva444p10le", 10, "4:4:4:4"),
+    _prores_ks("prores_xq", "Apple ProRes 4444 XQ", "5", "yuva444p10le", 10, "4:4:4:4"),
     # ── ProRes VideoToolbox (macOS only) ──────────────────────────────────
     _prores_vt("prores_vt_proxy", "Apple ProRes 422 Proxy", "p210le", 10, "4:2:2"),
     _prores_vt("prores_vt_lt", "Apple ProRes 422 LT", "p210le", 10, "4:2:2"),
     _prores_vt("prores_vt_422", "Apple ProRes 422", "p210le", 10, "4:2:2"),
     _prores_vt("prores_vt_hq", "Apple ProRes 422 HQ", "p210le", 10, "4:2:2"),
+    # VT 4444/XQ: ayuv64le intermediate; HW keeps ~12-bit mid-bin (unlike prores_ks).
     _prores_vt("prores_vt_4444", "Apple ProRes 4444", "ayuv64le", 12, "4:4:4:4"),
     _prores_vt("prores_vt_xq", "Apple ProRes 4444 XQ", "ayuv64le", 12, "4:4:4:4"),
     # ── CineForm ──────────────────────────────────────────────────────────
@@ -203,6 +210,14 @@ VIDEO_CODECS: list[VideoCodecSpec] = [
         "4:2:0",
     ),
     VideoCodecSpec(
+        "hevc_12",
+        "H.265 / HEVC · 12-bit 4:2:0",
+        "libx265",
+        "yuv420p12le",
+        12,
+        "4:2:0",
+    ),
+    VideoCodecSpec(
         "hevc_8",
         "H.265 / HEVC · 8-bit 4:2:0",
         "libx265",
@@ -218,7 +233,20 @@ VIDEO_CODECS: list[VideoCodecSpec] = [
         10,
         "4:4:4",
     ),
+    VideoCodecSpec(
+        "ffv1_12",
+        "FFV1 (lossless) · 12-bit 4:4:4",
+        "ffv1",
+        "yuv444p12le",
+        12,
+        "4:4:4",
+    ),
 ]
+
+# Codec key families used by GUI/CLI option routing.
+HEVC_CODEC_KEYS: frozenset[str] = frozenset({"hevc", "hevc_8", "hevc_12"})
+FFV1_CODEC_KEYS: frozenset[str] = frozenset({"ffv1", "ffv1_12"})
+X26X_CODEC_KEYS: frozenset[str] = frozenset({"h264"}) | HEVC_CODEC_KEYS
 DEFAULT_VIDEO_CODEC = "prores"
 
 # prores_ks / prores_videotoolbox profile values keyed by our preset *key*.

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.3.0"
+APP_VERSION = "0.4.0"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/core/convert.py
+++ b/src/core/convert.py
@@ -133,11 +133,11 @@ def _default_codec_opts(codec_key: str) -> dict[str, str]:
         return {"profile": DNXHR_PROFILE[codec_key]}
     if codec_key == "h264":
         return {"crf": "18", "preset": "medium"}
-    if codec_key in ("hevc", "hevc_8"):
+    if codec_key in ("hevc", "hevc_8", "hevc_12"):
         return {"crf": "18", "preset": "medium"}
     if codec_key in ("cineform", "cineform_rgb"):
         return {"quality": DEFAULT_CINEFORM_QUALITY}
-    if codec_key == "ffv1":
+    if codec_key in ("ffv1", "ffv1_12"):
         return {"slicecrc": "1"}
     return {}
 

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -1795,7 +1795,14 @@ class VideoBrowserDialog(QDialog):
 
 _EXR_HAS_SETTINGS = {"dwaa", "dwab", "zip", "zips"}
 # Profile is selected via the codec dropdown itself for ProRes / DNxHR ladders.
-_CODEC_HAS_SETTINGS = {"h264", "hevc", "hevc_8", "cineform", "cineform_rgb"}
+_CODEC_HAS_SETTINGS = {
+    "h264",
+    "hevc",
+    "hevc_8",
+    "hevc_12",
+    "cineform",
+    "cineform_rgb",
+}
 
 _EXR_COMPRESSION_HELP: dict[str, str] = {
     "none": "No compression. Fastest write, largest files.",
@@ -1917,26 +1924,40 @@ class ExrCompressionSettingsDialog(QDialog):
 # ---------------------------------------------------------------------------
 
 _CODEC_HELP: dict[str, str] = {
-    "prores_proxy": "ProRes 422 Proxy — lightest ProRes; 10-bit 4:2:2 offline/proxy.",
-    "prores_lt": "ProRes 422 LT — lighter intermediate; 10-bit 4:2:2.",
-    "prores_422": "ProRes 422 (Standard) — balanced intermediate; 10-bit 4:2:2.",
+    "prores_proxy": "ProRes 422 Proxy — lightest ProRes; 10-bit 4:2:2 offline/proxy (prores_ks).",
+    "prores_lt": "ProRes 422 LT — lighter intermediate; 10-bit 4:2:2 (prores_ks).",
+    "prores_422": "ProRes 422 (Standard) — balanced intermediate; 10-bit 4:2:2 (prores_ks).",
     "prores": "ProRes 422 HQ — default finishing intermediate; 10-bit 4:2:2 (prores_ks).",
-    "prores_4444": "ProRes 4444 — 12-bit 4:4:4:4 with alpha; compositing/delivery.",
-    "prores_xq": "ProRes 4444 XQ — highest ProRes tier; 12-bit 4:4:4:4 with alpha.",
+    "prores_4444": (
+        "ProRes 4444 — 4:4:4:4 with alpha (prores_ks). FFmpeg software encodes at "
+        "10-bit only (yuva444p10le); Apple's format can be 12-bit, but prores_ks "
+        "does not. Prefer VideoToolbox 4444 on macOS for ~12-bit precision."
+    ),
+    "prores_xq": (
+        "ProRes 4444 XQ — highest ProRes tier, 4:4:4:4 with alpha (prores_ks). "
+        "Software encode is still 10-bit only; use prores_vt_xq on macOS for "
+        "true 12-bit-class precision."
+    ),
     "prores_vt_proxy": (
         "Hardware ProRes Proxy via Apple VideoToolbox. macOS only; faster, "
-        "quality/controls differ slightly from software prores_ks."
+        "quality/controls differ slightly from software prores_ks. 10-bit 4:2:2."
     ),
-    "prores_vt_lt": "Hardware ProRes LT via VideoToolbox (macOS only).",
-    "prores_vt_422": "Hardware ProRes 422 via VideoToolbox (macOS only).",
-    "prores_vt_hq": "Hardware ProRes HQ via VideoToolbox (macOS only).",
-    "prores_vt_4444": "Hardware ProRes 4444 via VideoToolbox (macOS only).",
-    "prores_vt_xq": "Hardware ProRes 4444 XQ via VideoToolbox (macOS only).",
+    "prores_vt_lt": "Hardware ProRes LT via VideoToolbox (macOS only); 10-bit 4:2:2.",
+    "prores_vt_422": "Hardware ProRes 422 via VideoToolbox (macOS only); 10-bit 4:2:2.",
+    "prores_vt_hq": "Hardware ProRes HQ via VideoToolbox (macOS only); 10-bit 4:2:2.",
+    "prores_vt_4444": (
+        "Hardware ProRes 4444 via VideoToolbox (macOS only). ~12-bit class with "
+        "ayuv64le intermediate — better precision than software prores_ks 4444."
+    ),
+    "prores_vt_xq": (
+        "Hardware ProRes 4444 XQ via VideoToolbox (macOS only). ~12-bit class "
+        "precision; preferred over software XQ when bit depth matters."
+    ),
     "cineform": (
         "GoPro CineForm (cfhd) — 10-bit 4:2:2 wavelet intermediate. "
         "Quality ladder film3+…low in settings."
     ),
-    "cineform_rgb": ("GoPro CineForm RGB — 12-bit planar RGB (gbrp12le) for RGB pipelines."),
+    "cineform_rgb": ("GoPro CineForm RGB — true 12-bit planar RGB (gbrp12le) for RGB pipelines."),
     "dnxhr_lb": "DNxHR LB — lightest Avid/Resolve profile; 8-bit 4:2:2.",
     "dnxhr_sq": "DNxHR SQ — standard quality; 8-bit 4:2:2.",
     "dnxhr_hq": "DNxHR HQ — high quality intermediate; 8-bit 4:2:2 (not 10-bit).",
@@ -1944,11 +1965,19 @@ _CODEC_HELP: dict[str, str] = {
     "dnxhr_444": "DNxHR 444 — 10-bit 4:4:4 for highest chroma fidelity in DNx family.",
     "h264": ("H.264 / AVC — 8-bit 4:2:0 delivery/review. Not a grading intermediate."),
     "hevc": (
-        "H.265 / HEVC — 10-bit 4:2:0 delivery (libx265). Smaller than ProRes; "
+        "H.265 / HEVC — 10-bit 4:2:0 delivery (libx265 Main 10). Smaller than ProRes; "
         "not a scene-linear intermediate."
+    ),
+    "hevc_12": (
+        "H.265 / HEVC — true 12-bit 4:2:0 (libx265 Main 12, yuv420p12le). "
+        "Playback support is rarer than Main 10."
     ),
     "hevc_8": "H.265 / HEVC — 8-bit 4:2:0 delivery for maximum player compatibility.",
     "ffv1": "FFV1 — mathematically lossless 10-bit 4:4:4 archival intermediate.",
+    "ffv1_12": (
+        "FFV1 — mathematically lossless 12-bit 4:4:4 (yuv444p12le). "
+        "Best open archival option when you need true 12-bit YUV."
+    ),
 }
 
 
@@ -2007,10 +2036,10 @@ class VideoCodecSettingsDialog(QDialog):
         self._preset: QComboBox | None = None
         self._cineform_quality: QComboBox | None = None
         self._settings_prefix = "h264"
-        if codec_key in ("hevc", "hevc_8"):
+        if codec_key in ("hevc", "hevc_8", "hevc_12"):
             self._settings_prefix = "hevc"
 
-        if codec_key in ("h264", "hevc", "hevc_8"):
+        if codec_key in ("h264", "hevc", "hevc_8", "hevc_12"):
             crf_key = f"codec_opts/{self._settings_prefix}_crf"
             preset_key = f"codec_opts/{self._settings_prefix}_preset"
             saved_crf = int(settings.value(crf_key, 18))
@@ -2078,7 +2107,7 @@ class VideoCodecSettingsDialog(QDialog):
         return result
 
     def accept(self) -> None:
-        if self._codec_key in ("h264", "hevc", "hevc_8"):
+        if self._codec_key in ("h264", "hevc", "hevc_8", "hevc_12"):
             if self._crf_spin:
                 self._settings.setValue(
                     f"codec_opts/{self._settings_prefix}_crf",
@@ -2685,7 +2714,7 @@ class ConvertTab(QWidget):
             crf = str(int(self._settings.value("codec_opts/h264_crf", 18)))
             preset = self._settings.value("codec_opts/h264_preset", "medium")
             opts.update({"crf": crf, "preset": str(preset)})
-        elif key in ("hevc", "hevc_8"):
+        elif key in ("hevc", "hevc_8", "hevc_12"):
             crf = str(int(self._settings.value("codec_opts/hevc_crf", 18)))
             preset = self._settings.value("codec_opts/hevc_preset", "medium")
             opts.update({"crf": crf, "preset": str(preset)})
@@ -2877,10 +2906,14 @@ class ConvertTab(QWidget):
             codec_key = ""
             if self.codec_combo:
                 codec_key = self.codec_combo.currentData() or ""
-            if codec_key in ("prores", "prores_4444"):
+            if codec_key in ("prores", "prores_4444", "prores_xq") or str(codec_key).startswith(
+                "prores_"
+            ):
                 filt = "Video (*.mov)"
-            elif codec_key == "ffv1":
+            elif codec_key in ("ffv1", "ffv1_12"):
                 filt = "Video (*.mkv *.avi)"
+            elif codec_key in ("h264", "hevc", "hevc_8", "hevc_12"):
+                filt = "Video (*.mp4 *.mov *.mkv)"
             else:
                 filt = "Video (*.mp4 *.mov *.mkv)"
             path, _ = QFileDialog.getSaveFileName(
@@ -2908,9 +2941,9 @@ class ConvertTab(QWidget):
         codec_key = ""
         if self.codec_combo:
             codec_key = self.codec_combo.currentData() or ""
-        if codec_key == "ffv1":
+        if codec_key in ("ffv1", "ffv1_12"):
             return ".mkv"
-        if codec_key in ("h264", "hevc", "hevc_8"):
+        if codec_key in ("h264", "hevc", "hevc_8", "hevc_12"):
             return ".mp4"
         if str(codec_key).startswith("dnxhr"):
             return ".mxf"
@@ -2996,7 +3029,7 @@ class ConvertTab(QWidget):
         if self._mode != "exr2video":
             return
         codec_key = self.codec_combo.currentData() if self.codec_combo else ""
-        if codec_key == "ffv1":
+        if codec_key in ("ffv1", "ffv1_12"):
             candidates = ["scene_linear"]
         else:
             candidates = [

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1,4 +1,10 @@
-"""Video codec preset metadata and encode smoke tests."""
+"""Video codec preset metadata, encode smoke tests, and bit-depth truth.
+
+Bit-depth claims are validated with solid-patch mid-bin roundtrips:
+a 10-bit lattice value ``B`` (multiple of 64 in rgb48) vs ``B+32``.
+If the encode only keeps 10 bits, both decode to the same mean (delta ≈ 0).
+If 12-bit precision is kept, delta stays near 32.
+"""
 
 from __future__ import annotations
 
@@ -12,6 +18,8 @@ import pytest
 from src.core.constants import (
     DEFAULT_CINEFORM_QUALITY,
     DNXHR_PROFILE,
+    FFV1_CODEC_KEYS,
+    HEVC_CODEC_KEYS,
     PRORES_KS_PROFILE,
     PRORES_VT_PROFILE,
     VIDEO_CODECS,
@@ -36,6 +44,36 @@ class TestVideoCodecSpecs:
             assert spec.chroma
             assert "bit" in spec.format_label
             assert spec.pix_fmt in spec.format_label
+
+    def test_pix_fmt_matches_claimed_bit_depth(self):
+        """pix_fmt token must not claim a higher depth than bit_depth."""
+        for spec in VIDEO_CODECS:
+            fmt = spec.pix_fmt
+            if "16" in fmt or fmt in ("ayuv64le", "rgb48le", "rgba64le"):
+                # Wide intermediate containers (VT ayuv64le) may still be 12-bit class.
+                assert spec.bit_depth >= 10
+            elif "12" in fmt:
+                assert spec.bit_depth == 12, f"{spec.key}: {fmt} vs bit_depth={spec.bit_depth}"
+            elif "10" in fmt or fmt in ("p210le", "p010le"):
+                assert spec.bit_depth == 10, f"{spec.key}: {fmt} vs bit_depth={spec.bit_depth}"
+            elif fmt in ("yuv420p", "yuv422p", "yuv444p"):
+                assert spec.bit_depth == 8, f"{spec.key}: {fmt} vs bit_depth={spec.bit_depth}"
+
+    def test_prores_ks_all_ten_bit(self):
+        """Software prores_ks cannot encode 12-bit (only *10le pix_fmts)."""
+        for key in PRORES_KS_PROFILE:
+            s = video_codec_by_key(key)
+            assert s is not None
+            assert s.libav_codec == "prores_ks"
+            assert s.bit_depth == 10, f"{key} must be labeled 10-bit"
+            assert "10" in s.pix_fmt
+
+    def test_prores_vt_4444_xq_twelve_bit(self):
+        for key in ("prores_vt_4444", "prores_vt_xq"):
+            s = video_codec_by_key(key)
+            assert s is not None
+            assert s.bit_depth == 12
+            assert s.pix_fmt == "ayuv64le"
 
     def test_prores_software_ladder(self):
         keys = {s.key for s in VIDEO_CODECS}
@@ -79,13 +117,25 @@ class TestVideoCodecSpecs:
             assert s.chroma == chroma
             assert _default_codec_opts(k)["profile"] == DNXHR_PROFILE[k]
 
-    def test_hevc_and_cineform(self):
+    def test_hevc_ladder_and_cineform(self):
         hevc = video_codec_by_key("hevc")
         hevc8 = video_codec_by_key("hevc_8")
+        hevc12 = video_codec_by_key("hevc_12")
         assert hevc is not None and hevc.bit_depth == 10 and hevc.pix_fmt == "yuv420p10le"
         assert hevc8 is not None and hevc8.bit_depth == 8 and hevc8.pix_fmt == "yuv420p"
+        assert hevc12 is not None and hevc12.bit_depth == 12 and hevc12.pix_fmt == "yuv420p12le"
+        assert HEVC_CODEC_KEYS == frozenset({"hevc", "hevc_8", "hevc_12"})
         assert _default_codec_opts("hevc")["crf"] == "18"
+        assert _default_codec_opts("hevc_12")["crf"] == "18"
         assert _default_codec_opts("cineform")["quality"] == DEFAULT_CINEFORM_QUALITY
+
+    def test_ffv1_ladder(self):
+        ff10 = video_codec_by_key("ffv1")
+        ff12 = video_codec_by_key("ffv1_12")
+        assert ff10 is not None and ff10.bit_depth == 10 and ff10.pix_fmt == "yuv444p10le"
+        assert ff12 is not None and ff12.bit_depth == 12 and ff12.pix_fmt == "yuv444p12le"
+        assert FFV1_CODEC_KEYS == frozenset({"ffv1", "ffv1_12"})
+        assert _default_codec_opts("ffv1_12")["slicecrc"] == "1"
 
 
 @pytest.mark.integration
@@ -96,10 +146,28 @@ class TestCodecEncodes:
         assert out.stat().st_size > 0
 
     def test_hevc_10_encode(self, tmp_path: Path):
-        out = tmp_path / "hevc.mp4"
+        # MKV is more reliable than MP4 for tiny test frames with libx265.
+        out = tmp_path / "hevc.mkv"
         _encode(out, "libx265", "yuv420p10le", {"crf": "28", "preset": "ultrafast"}, 64, 36)
         probe = av.open(str(out))
         assert probe.streams.video[0].codec_context.name in ("hevc", "libx265", "h265")
+        assert probe.streams.video[0].codec_context.pix_fmt == "yuv420p10le"
+        probe.close()
+
+    def test_hevc_12_encode(self, tmp_path: Path):
+        out = tmp_path / "hevc12.mkv"
+        _encode(out, "libx265", "yuv420p12le", {"crf": "28", "preset": "ultrafast"}, 64, 36)
+        probe = av.open(str(out))
+        stream = probe.streams.video[0]
+        assert stream.codec_context.name in ("hevc", "libx265", "h265")
+        assert stream.codec_context.pix_fmt == "yuv420p12le"
+        probe.close()
+
+    def test_ffv1_12_encode(self, tmp_path: Path):
+        out = tmp_path / "ffv1_12.mkv"
+        _encode(out, "ffv1", "yuv444p12le", {"slicecrc": "1"}, 64, 36)
+        probe = av.open(str(out))
+        assert probe.streams.video[0].codec_context.pix_fmt == "yuv444p12le"
         probe.close()
 
     def test_dnxhr_lb_needs_hd(self, tmp_path: Path):
@@ -136,6 +204,140 @@ class TestCodecEncodes:
         probe.close()
 
 
+@pytest.mark.integration
+class TestBitDepthRoundtrip:
+    """Prove encode precision with solid-patch mid-bin tests."""
+
+    W, H = 128, 72
+    # 10-bit lattice point in full-range 16-bit (multiples of 64).
+    BASE = 16384  # exactly 10-bit aligned
+    MID = 32  # halfway to next 10-bit code (needs >10 bits)
+
+    def _mean_after_roundtrip(
+        self,
+        tmp_path: Path,
+        value: int,
+        codec: str,
+        pix_fmt: str,
+        options: dict[str, str],
+        *,
+        w: int | None = None,
+        h: int | None = None,
+    ) -> float:
+        w = w or self.W
+        h = h or self.H
+        path = tmp_path / f"{codec}_{pix_fmt}_{value}.mkv"
+        # Prefer container that accepts the codec.
+        if codec in ("prores_ks", "prores_videotoolbox", "cfhd", "dnxhd"):
+            path = path.with_suffix(".mov")
+        elif codec == "libx265":
+            path = path.with_suffix(".mkv")
+        rgb = np.full((h, w, 3), value, dtype=np.uint16)
+        _encode(path, codec, pix_fmt, options, w, h, rgb=rgb, n_frames=4)
+        probe = av.open(str(path))
+        frames = list(probe.decode(video=0))
+        probe.close()
+        assert frames
+        out = (
+            frames[min(1, len(frames) - 1)].reformat(format="rgb48le").to_ndarray(format="rgb48le")
+        )
+        crop = out[h // 4 : 3 * h // 4, w // 4 : 3 * w // 4].astype(np.float64)
+        return float(crop.mean())
+
+    def test_prores_ks_4444_is_ten_bit_not_twelve(self, tmp_path: Path):
+        """prores_ks 4444 collapses B vs B+32 — 10-bit encode despite 12-bit probe labels."""
+        opts = {"profile": "4", "vendor": "apl0"}
+        m0 = self._mean_after_roundtrip(tmp_path, self.BASE, "prores_ks", "yuva444p10le", opts)
+        m1 = self._mean_after_roundtrip(
+            tmp_path, self.BASE + self.MID, "prores_ks", "yuva444p10le", opts
+        )
+        assert abs(m1 - m0) < 1.0, f"expected 10-bit collapse, got delta={m1 - m0}"
+
+    def test_prores_ks_xq_is_ten_bit(self, tmp_path: Path):
+        opts = {"profile": "5", "vendor": "apl0"}
+        m0 = self._mean_after_roundtrip(tmp_path, self.BASE, "prores_ks", "yuva444p10le", opts)
+        m1 = self._mean_after_roundtrip(
+            tmp_path, self.BASE + self.MID, "prores_ks", "yuva444p10le", opts
+        )
+        assert abs(m1 - m0) < 1.0, f"expected 10-bit collapse, got delta={m1 - m0}"
+
+    def test_prores_ks_rejects_twelve_bit_pix_fmt(self, tmp_path: Path):
+        """Encoder does not accept yuva444p12le — open fails or rewrites."""
+        path = tmp_path / "force12.mov"
+        with pytest.raises((av.error.FFmpegError, ValueError, Exception)):
+            _encode(
+                path,
+                "prores_ks",
+                "yuva444p12le",
+                {"profile": "4", "vendor": "apl0"},
+                64,
+                36,
+            )
+
+    def test_hevc_12_preserves_mid_bin(self, tmp_path: Path):
+        opts = {"crf": "0", "preset": "ultrafast", "x265-params": "lossless=1"}
+        m0 = self._mean_after_roundtrip(tmp_path, self.BASE, "libx265", "yuv420p12le", opts)
+        m1 = self._mean_after_roundtrip(
+            tmp_path, self.BASE + self.MID, "libx265", "yuv420p12le", opts
+        )
+        # 12-bit step in 16-bit is 16; mid-bin +32 must remain clearly non-zero.
+        assert (m1 - m0) > 16, f"expected 12-bit mid-bin keep, delta={m1 - m0}"
+
+    def test_hevc_10_collapses_mid_bin(self, tmp_path: Path):
+        opts = {"crf": "0", "preset": "ultrafast", "x265-params": "lossless=1"}
+        m0 = self._mean_after_roundtrip(tmp_path, self.BASE, "libx265", "yuv420p10le", opts)
+        m1 = self._mean_after_roundtrip(
+            tmp_path, self.BASE + self.MID, "libx265", "yuv420p10le", opts
+        )
+        assert abs(m1 - m0) < 1.0, f"expected 10-bit collapse, delta={m1 - m0}"
+
+    def test_ffv1_12_preserves_mid_bin(self, tmp_path: Path):
+        m0 = self._mean_after_roundtrip(
+            tmp_path, self.BASE, "ffv1", "yuv444p12le", {"slicecrc": "1"}
+        )
+        m1 = self._mean_after_roundtrip(
+            tmp_path, self.BASE + self.MID, "ffv1", "yuv444p12le", {"slicecrc": "1"}
+        )
+        assert (m1 - m0) > 16, f"expected 12-bit mid-bin keep, delta={m1 - m0}"
+
+    def test_cineform_rgb_preserves_mid_bin(self, tmp_path: Path):
+        m0 = self._mean_after_roundtrip(
+            tmp_path, self.BASE, "cfhd", "gbrp12le", {"quality": "film3+"}
+        )
+        m1 = self._mean_after_roundtrip(
+            tmp_path, self.BASE + self.MID, "cfhd", "gbrp12le", {"quality": "film3+"}
+        )
+        assert abs((m1 - m0) - 32.0) < 2.0, f"expected ~32 mid-bin, delta={m1 - m0}"
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="VideoToolbox is macOS-only")
+    def test_prores_vt_4444_keeps_beyond_ten_bit(self, tmp_path: Path):
+        """Apple VT 4444 preserves mid-bin (unlike prores_ks)."""
+        opts = {"profile": "4"}
+        try:
+            m0 = self._mean_after_roundtrip(
+                tmp_path,
+                self.BASE,
+                "prores_videotoolbox",
+                "ayuv64le",
+                opts,
+                w=192,
+                h=108,
+            )
+            m1 = self._mean_after_roundtrip(
+                tmp_path,
+                self.BASE + self.MID,
+                "prores_videotoolbox",
+                "ayuv64le",
+                opts,
+                w=192,
+                h=108,
+            )
+        except av.error.FFmpegError as e:
+            pytest.skip(f"prores_videotoolbox unavailable: {e}")
+        # Lossy HW: not exact 32, but clearly not collapsed to 0.
+        assert (m1 - m0) > 12, f"expected VT 12-bit-class keep, delta={m1 - m0}"
+
+
 def _encode(
     path: Path,
     codec: str,
@@ -143,6 +345,9 @@ def _encode(
     options: dict[str, str],
     w: int,
     h: int,
+    *,
+    rgb: np.ndarray | None = None,
+    n_frames: int = 1,
 ) -> None:
     container = av.open(str(path), mode="w")
     stream = container.add_stream(codec, rate=24)
@@ -150,10 +355,12 @@ def _encode(
     stream.height = h
     stream.pix_fmt = pix_fmt
     stream.options = options
-    rgb = np.full((h, w, 3), 22000, dtype=np.uint16)
-    vf = av.VideoFrame.from_ndarray(rgb, format="rgb48le").reformat(format=pix_fmt)
-    for packet in stream.encode(vf):
-        container.mux(packet)
+    if rgb is None:
+        rgb = np.full((h, w, 3), 22000, dtype=np.uint16)
+    for _ in range(n_frames):
+        vf = av.VideoFrame.from_ndarray(rgb, format="rgb48le").reformat(format=pix_fmt)
+        for packet in stream.encode(vf):
+            container.mux(packet)
     for packet in stream.encode():
         container.mux(packet)
     container.close()

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

- **Honest bit depths:** software `prores_ks` 4444/XQ labeled **10-bit** (FFmpeg encode reality; mid-bin roundtrips). VideoToolbox 4444/XQ remain ~12-bit on macOS.
- **New presets:** `hevc_12` (Main 12), `ffv1_12` (lossless 12-bit 4:4:4).
- **Tests:** solid-patch mid-bin proofs in `tests/test_codecs.py`.
- **Docs:** `docs/releasing.md` (Makefile + `gh` CLI), `docs/plan-12bit-prores-oxideav.md` (future cross-platform 12-bit ProRes plan).
- **CI:** untap noisy Homebrew third-party taps before `create-dmg` on macOS Intel.

## Version

- Bumps **0.3.0 → 0.4.0** (`release: 0.4.0` commit + local tag `v0.4.0`).
- After merge to `main`, push tag `v0.4.0` to trigger the Release workflow.

## Test plan

- [x] `ruff check` / `ruff format`
- [x] `pytest tests/test_codecs.py` (24 passed)
- [ ] CI green on this PR
- [ ] After merge: `git push origin v0.4.0` → Release workflow → assets on GitHub Release