### PR TITLE
ci: auto-tag release on merge to main

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,62 @@
+# After a PR merges to main, if pyproject.toml version X.Y.Z has no matching
+# git tag vX.Y.Z yet, create and push that tag. The existing Release workflow
+# (on: push tags: v*) then builds, signs, and publishes the GitHub Release.
+#
+# Why this exists: protected main means tags are not pushed during
+# `make release PUSH=0`. Merging the release PR alone never fired Release
+# until someone remembered `git push origin vX.Y.Z`.
+
+name: Auto-tag release
+
+on:
+  push:
+    branches: [main]
+
+# Do not cancel in-flight Release builds if several merges land quickly.
+concurrency:
+  group: auto-tag-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag-if-needed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Need full history / ability to push tags from GITHUB_TOKEN.
+          fetch-depth: 0
+
+      - name: Read version and tag if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to tag non-semver version: $VERSION"
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          echo "version=${VERSION} tag=${TAG}"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists locally — nothing to do."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin — nothing to do."
+            exit 0
+          fi
+
+          # Point the tag at the commit that just landed on main (this push).
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "release: ${VERSION}"
+          git push origin "refs/tags/${TAG}"
+          echo "Pushed ${TAG} → triggers Release workflow."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,11 +149,12 @@ feature commits (PR → main)
         │  1. scripts/bump_app_version.py → pyproject + APP_VERSION
         │  2. uv lock
         │  3. commit: "release: X.Y.Z"  (only version files)
-        │  4. tag: vX.Y.Z  (local)
+        │  4. optional local tag vX.Y.Z  (not required for publish)
         ▼
  PR → main → merge
         │
- git push origin vX.Y.Z
+ Auto-tag release workflow (on push to main)
+        │  if pyproject version X.Y.Z has no tag vX.Y.Z → create + push tag
         ▼
  GitHub Actions “Release” on tag v*
         │  lint → test (3 OS) → gate → Nuitka → Cosign → GitHub Release
@@ -164,6 +165,12 @@ feature commits (PR → main)
 
 Tags are plain semver: **`v1.2.3`**. The tag is the published app version
 (workflow also injects `APP_VERSION` from the tag during the Nuitka build).
+
+**Important:** the **Release** workflow only runs on **tag push** (`v*`), not on
+merge alone. Historically the tag was left local (`PUSH=0`) and someone had to
+`git push origin vX.Y.Z` after merge — that is what missed 0.5.0 until fixed by
+hand. **`.github/workflows/auto-tag-release.yml`** now tags automatically when
+`main` advances and the version in `pyproject.toml` has no matching tag yet.
 
 ### Prerequisites
 
@@ -192,16 +199,18 @@ gh pr checks
 gh pr merge --merge          # or --squash per preference
 
 git checkout main && git pull origin main
-# If tag still points at pre-merge SHA, retag the release commit on main when needed:
-git tag -d vX.Y.Z 2>/dev/null || true
-git tag vX.Y.Z
-git push origin vX.Y.Z       # triggers Release workflow
+# Auto-tag release workflow pushes vX.Y.Z if missing → Release workflow runs.
+# Manual fallback if auto-tag is disabled or failed:
+#   git tag vX.Y.Z && git push origin vX.Y.Z
 
+gh run list --workflow="Auto-tag release" --limit 3
+gh run list --workflow=Release --limit 3
 gh run watch
 gh release view vX.Y.Z
 ```
 
-Historical: `release/0.3.0` → PR #1; `release/0.4.0` → PR #2.
+Historical: `release/0.3.0` → PR #1; `release/0.4.0` → PR #2; `release/0.5.0` → PR #3
+(tag was pushed manually after merge; auto-tag added afterward).
 
 ### Make variables
 
@@ -253,8 +262,9 @@ Local package only: `make bundle` (no GitHub Release).
 - [ ] **[CHANGELOG.md](./CHANGELOG.md)** updated: `[Unreleased]` rolled into `[X.Y.Z]`
 - [ ] On branch `release/X.Y.Z` (not direct push to `main`)
 - [ ] Working tree free of unrelated unstaged work
-- [ ] Correct `PART`; `make release … PUSH=0` → PR → merge → `git push origin vX.Y.Z`
-- [ ] `gh run watch` green; `gh release view vX.Y.Z` has artifacts + signatures
+- [ ] Correct `PART`; `make release … PUSH=0` → PR → merge
+- [ ] Auto-tag (or manual `git push origin vX.Y.Z`) fires Release; `gh run watch` green
+- [ ] `gh release view vX.Y.Z` has artifacts + signatures
 
 ### Troubleshooting
 
@@ -286,6 +296,7 @@ xattr -cr "/Applications/EXR Converter.app"
 | Workflow | Trigger | Gate |
 |----------|---------|------|
 | [CI](.github/workflows/ci.yml) | push / PR to `main` | Ruff + full pytest on 3 OS; job **`ci-ok`** requires all green |
+| [Auto-tag release](.github/workflows/auto-tag-release.yml) | push to `main` | If `pyproject` version has no `vX.Y.Z` tag → push tag |
 | [Release](.github/workflows/release.yml) | tag `v*` | Same lint + tests via **`gate`** before Nuitka / publish |
 
 Branch protection on `main` should require `ci-ok`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auto-tag on merge:** after a version bump lands on `main`, a workflow creates
+  and pushes `vX.Y.Z` if the tag is missing so the Release pipeline runs without
+  a manual `git push origin v…` step (the gap that delayed the 0.5.0 publish).
+
 ---
 
 ## [0.5.0] — 2026-08-06

--- a/README.md
+++ b/README.md
@@ -145,12 +145,10 @@ Tags use plain semver: `v1.2.3`. Pushing a tag runs [`.github/workflows/release.
 ```bash
 git checkout -b release/X.Y.Z
 # Roll CHANGELOG [Unreleased] → [X.Y.Z] first
-make release PART=minor PUSH=0   # bump + commit + local tag (main is PR-only)
+make release PART=minor PUSH=0   # bump + commit (+ optional local tag; main is PR-only)
 git push -u origin HEAD
 gh pr create --base main --title "release: X.Y.Z"
-# after merge:
-git checkout main && git pull
-git push origin vX.Y.Z           # triggers Release workflow (Nuitka + GitHub Release)
+# after merge: Auto-tag release pushes vX.Y.Z if missing → Release workflow runs
 gh run watch
 gh release list --limit 5
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,5 +9,9 @@ User-facing history (required on every release):
 
 **[CHANGELOG.md](../CHANGELOG.md)**
 
+**Short path:** merge a release PR that bumps `pyproject.toml` → **Auto-tag
+release** pushes `vX.Y.Z` if missing → **Release** builds and publishes. You do
+not need a manual tag push after merge (that was what skipped 0.5.0 until fixed).
+
 Related design notes (not release machinery):
 [plan-12bit-prores-oxideav.md](./plan-12bit-prores-oxideav.md).


### PR DESCRIPTION
## Summary

- Add **Auto-tag release** workflow: on push to `main`, if `pyproject.toml` version `X.Y.Z` has no `vX.Y.Z` tag, create and push it.
- That tag push triggers the existing **Release** workflow (Nuitka + Cosign + GitHub Release).
- Docs updated (AGENTS / README / releasing stub / changelog).

Fixes the 0.5.0 footgun: merge alone never published because the tag was local-only (`PUSH=0`).

## Test plan

- [ ] PR CI green
- [ ] After merge: Auto-tag no-ops (v0.5.0 already exists)
- [ ] Next real version bump: merge → auto tag → Release run