### PR TITLE
release: 0.5.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,10 @@ jobs:
       - name: Install dependencies
         run: uv sync --group bundle
 
+      # oiio-python may rewire PyOpenColorIO.so → OCIO 2.4; reinstall 2.5 first.
+      - name: Ensure OpenColorIO 2.5+ linkage
+        run: uv run python scripts/ensure_ocio.py
+
       - name: Inject version from tag
         shell: bash
         run: |
@@ -208,6 +212,18 @@ jobs:
       - name: Rename macOS app bundle
         if: runner.os == 'macOS'
         run: mv dist/main.app "dist/EXR Converter.app"
+
+      # Nuitka often links PyOpenColorIO.so to OIIO’s libOpenColorIO.2.4.0.dylib
+      # and drops the 2.5 dylib. Re-copy 2.5 and rewrite the install name so the
+      # bundled ACES Studio v4 config (profile 2.5) can load.
+      - name: Fix OpenColorIO 2.5 linkage in bundle
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            uv run python scripts/fix_bundle_ocio.py "dist/EXR Converter.app"
+          else
+            uv run python scripts/fix_bundle_ocio.py dist/main.dist
+          fi
 
       - name: Slim macOS bundle
         if: runner.os == 'macOS'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,22 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+---
+
+## [0.5.1] — 2026-08-06
+
 ### Fixed
 
-- **Auto-tag on merge:** after a version bump lands on `main`, a workflow creates
-  and pushes `vX.Y.Z` if the tag is missing so the Release pipeline runs without
-  a manual `git push origin v…` step (the gap that delayed the 0.5.0 publish).
+- **Packaged app OpenColorIO 2.4 bug:** Nuitka was linking `PyOpenColorIO` to
+  oiio-python’s vendored OCIO **2.4** (and could ship a 2.4-ABI extension), so the
+  bundled ACES Studio v4 config (profile **2.5**) failed at convert while the UI
+  could still look green. Release/local bundle now runs
+  `scripts/fix_bundle_ocio.py` (restore 2.5 `.so` + dylib), `ensure_ocio` before
+  Nuitka, and the smoke test loads the bundled config.
+- **Nuke OCIO configs** that the linked OpenColorIO cannot load stay visible in
+  the combo but are **greyed out** with a tooltip explaining why.
+- Bundled ACES Studio no longer silently falls back to a library config on version
+  mismatch (status matched convert failures).
 
 ---
 
@@ -190,7 +201,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/derek-rein/exr-converter/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/derek-rein/exr-converter/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/derek-rein/exr-converter/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/derek-rein/exr-converter/compare/v0.2.2...v0.3.0

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,8 @@ bundle: resources
 		--noinclude-dlls='libssl*' \
 		$(ENTRY)
 	mv dist/main.app "dist/$(MACOS_BUNDLE_NAME).app"
+	# Nuitka rewires PyOpenColorIO → OIIO’s OCIO 2.4; put 2.5 back.
+	$(PYTHON) scripts/fix_bundle_ocio.py "dist/$(MACOS_BUNDLE_NAME).app"
 
 clean:
 	rm -rf dist build *.build *.dist *.onefile-build __pycache__

--- a/main.py
+++ b/main.py
@@ -36,7 +36,27 @@ def main() -> int:
     win.show()
 
     if args.smoke_test:
+        # Fail the build if the frozen app linked OCIO 2.4 (Nuitka/oiio trap).
+        import PyOpenColorIO as _OCIO
         from PySide6.QtCore import QTimer
+
+        from src.core.ocio_utils import get_bundled_aces_studio_path
+
+        ver = _OCIO.GetVersion()
+        nums = tuple(int(x) for x in ver.split(".")[:3] if x.isdigit())
+        if nums < (2, 5, 0):
+            print(f"SMOKE FAIL: OpenColorIO {ver} (need >= 2.5.0)", file=sys.stderr)
+            return 2
+        cfg_path = get_bundled_aces_studio_path()
+        if cfg_path is not None and cfg_path.is_file():
+            try:
+                _OCIO.Config.CreateFromFile(str(cfg_path))
+            except Exception as e:
+                print(f"SMOKE FAIL: cannot load bundled OCIO config: {e}", file=sys.stderr)
+                return 3
+            print(f"smoke: OpenColorIO {ver} + bundled config OK")
+        else:
+            print(f"smoke: OpenColorIO {ver} OK (no bundled config path)")
 
         QTimer.singleShot(3000, app.quit)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.5.0"
+version = "0.5.1"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/scripts/fix_bundle_ocio.py
+++ b/scripts/fix_bundle_ocio.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Repair OpenColorIO linkage inside a Nuitka standalone / app bundle.
+
+Nuitka often collides the two OCIO shared libraries we ship:
+
+* ``PyOpenColorIO`` (opencolorio wheel) → **2.5.x**  — required for the
+  bundled ACES Studio v4 config (profile 2.5) and modern Foundry Nuke configs.
+* ``OpenImageIO/.dylibs/libOpenColorIO.2.4.0`` (oiio-python) → **2.4** —
+  used only by OIIO.
+
+Nuitka rewrites ``PyOpenColorIO.so`` to load the 2.4 dylib at
+``@executable_path`` and drops the 2.5 library. The GUI can still show a green
+status (builtin fallback) while convert fails on the real 2.5 config.
+
+This script:
+
+1. Requires a build-env ``PyOpenColorIO`` whose runtime is >= 2.5.
+2. Copies the correct OCIO shared lib next to ``PyOpenColorIO.so`` / ``.pyd``.
+3. Relinks the extension to that library (``@loader_path`` / ``$ORIGIN``).
+4. Leaves OIIO on 2.4 — it does not need profile-2.5 configs.
+
+Usage::
+
+    uv run python scripts/fix_bundle_ocio.py "dist/EXR Converter.app"
+    uv run python scripts/fix_bundle_ocio.py dist/main.dist
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REQUIRED = (2, 5, 0)
+
+
+def _parse_version(text: str) -> tuple[int, ...]:
+    import re
+
+    nums = re.findall(r"\d+", text)
+    return tuple(int(n) for n in nums[:3]) if nums else (0,)
+
+
+def _site_pyocio_dir() -> Path:
+    import PyOpenColorIO as ocio
+
+    ver = ocio.GetVersion()
+    if _parse_version(ver) < REQUIRED:
+        raise SystemExit(
+            f"Build-env OpenColorIO is {ver!r}; need >= 2.5.0 before fixing a "
+            f"bundle. Run: make ensure-ocio"
+        )
+    return Path(ocio.__file__).resolve().parent
+
+
+def _find_extension(root: Path) -> Path:
+    for name in ("PyOpenColorIO.so", "PyOpenColorIO.pyd"):
+        hits = list(root.rglob(name))
+        if hits:
+            # Prefer the one under a PyOpenColorIO package dir.
+            hits.sort(key=lambda p: (0 if p.parent.name == "PyOpenColorIO" else 1, str(p)))
+            return hits[0]
+    raise SystemExit(f"No PyOpenColorIO.so/.pyd under {root}")
+
+
+def _source_lib(site_dir: Path) -> Path:
+    system = platform.system()
+    candidates: list[Path] = []
+    if system == "Darwin":
+        candidates = [site_dir / "libOpenColorIO.dylib"]
+    elif system == "Windows":
+        candidates = [
+            site_dir / "bin" / "OpenColorIO_2_5.dll",
+            site_dir / "OpenColorIO_2_5.dll",
+            site_dir / "bin" / "OpenColorIO.dll",
+            site_dir / "OpenColorIO.dll",
+        ]
+    else:
+        candidates = [
+            site_dir / "libOpenColorIO.so",
+            *sorted(site_dir.glob("libOpenColorIO.so.*")),
+        ]
+    for c in candidates:
+        if c.is_file():
+            return c
+    raise SystemExit(
+        f"Could not find OCIO 2.5 shared library next to {site_dir}. "
+        f"Tried: {', '.join(str(c) for c in candidates)}"
+    )
+
+
+def _source_extension(site_dir: Path) -> Path:
+    """Healthy build-env PyOpenColorIO extension (2.5 ABI)."""
+    for name in ("PyOpenColorIO.so", "PyOpenColorIO.pyd"):
+        p = site_dir / name
+        if p.is_file():
+            return p
+    raise SystemExit(f"No PyOpenColorIO extension in {site_dir}")
+
+
+def _replace_extension(dest_ext: Path, src_ext: Path) -> Path:
+    """Overwrite the bundled extension with the build-env 2.5 module.
+
+    Nuitka has been observed to ship a *different, smaller* ``.so`` that
+    references the OpenColorIO **v2_4** C++ ABI and links oiio’s 2.4 dylib.
+    Only swapping the dylib then fails with missing symbols; the extension
+    itself must be restored too.
+    """
+    shutil.copy2(src_ext, dest_ext)
+    print(
+        f"fix_bundle_ocio: restored {dest_ext.name} from build-env ({src_ext.stat().st_size} bytes)"
+    )
+    return dest_ext
+
+
+def _macos_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
+    ext = _replace_extension(ext, src_ext)
+    dest_lib = ext.parent / "libOpenColorIO.dylib"
+    shutil.copy2(src_lib, dest_lib)
+    # Stable install name relative to the extension module.
+    subprocess.check_call(
+        ["install_name_tool", "-id", "@loader_path/libOpenColorIO.dylib", str(dest_lib)]
+    )
+    # Ensure the extension loads the dylib sitting next to it (Nuitka may have
+    # rewritten the original to @executable_path/libOpenColorIO.2.4.0.dylib).
+    out = subprocess.check_output(["otool", "-L", str(ext)], text=True)
+    for line in out.splitlines()[1:]:
+        dep = line.strip().split(" ", 1)[0]
+        if "OpenColorIO" in dep or "libOpenColorIO" in dep:
+            if dep == "@loader_path/libOpenColorIO.dylib":
+                continue
+            subprocess.check_call(
+                [
+                    "install_name_tool",
+                    "-change",
+                    dep,
+                    "@loader_path/libOpenColorIO.dylib",
+                    str(ext),
+                ]
+            )
+    out2 = subprocess.check_output(["otool", "-L", str(ext)], text=True)
+    if "libOpenColorIO.2.4" in out2:
+        raise SystemExit(
+            f"Still linked to 2.4 after rewrite:\n{out2}\n"
+            "install_name_tool failed to retarget PyOpenColorIO.so"
+        )
+    if "@loader_path/libOpenColorIO.dylib" not in out2:
+        raise SystemExit(f"Expected @loader_path/libOpenColorIO.dylib on {ext}:\n{out2}")
+    # ABI sanity: restored module must reference v2_5 symbols, not v2_4.
+    undef = subprocess.check_output(["nm", "-u", str(ext)], text=True, stderr=subprocess.DEVNULL)
+    if "OpenColorIO_v2_4" in undef and "OpenColorIO_v2_5" not in undef:
+        raise SystemExit(
+            f"{ext} still has only OpenColorIO_v2_4 undefined symbols — "
+            f"build-env extension was not restored correctly"
+        )
+    print(f"fix_bundle_ocio: macOS — {ext.name} → @loader_path/libOpenColorIO.dylib")
+    print(f"fix_bundle_ocio: copied {dest_lib} ({dest_lib.stat().st_size} bytes)")
+
+
+def _linux_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
+    ext = _replace_extension(ext, src_ext)
+    plain = ext.parent / "libOpenColorIO.so"
+    shutil.copy2(src_lib, plain)
+    if src_lib.name != plain.name:
+        # Keep versioned soname copy too when present
+        shutil.copy2(src_lib, ext.parent / src_lib.name)
+
+    try:
+        subprocess.check_call(
+            ["patchelf", "--set-rpath", "$ORIGIN", str(ext)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        print(
+            "fix_bundle_ocio: warning — patchelf not found; "
+            "relying on Nuitka rpath / LD_LIBRARY_PATH",
+            file=sys.stderr,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"fix_bundle_ocio: patchelf failed ({e.returncode})", file=sys.stderr)
+
+    try:
+        needed = subprocess.check_output(["patchelf", "--print-needed", str(ext)], text=True)
+        for line in needed.splitlines():
+            if "OpenColorIO" in line and line.strip() != "libOpenColorIO.so":
+                subprocess.check_call(
+                    ["patchelf", "--replace-needed", line.strip(), "libOpenColorIO.so", str(ext)]
+                )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+
+    print(f"fix_bundle_ocio: Linux — ensured {plain}")
+
+
+def _windows_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
+    ext = _replace_extension(ext, src_ext)
+    # Windows loads DLLs from the pyd directory and the executable directory.
+    targets = [
+        ext.parent / src_lib.name,
+        ext.parent.parent / src_lib.name,
+    ]
+    for root in (ext.parent, *ext.parents[:3]):
+        if (root / "exr_converter.exe").is_file():
+            targets.append(root / src_lib.name)
+        if root.name.endswith(".dist") or root.name == "main.dist":
+            targets.append(root / src_lib.name)
+
+    written: set[Path] = set()
+    for dest in targets:
+        dest = dest.resolve()
+        if dest in written:
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src_lib, dest)
+        written.add(dest)
+        print(f"fix_bundle_ocio: Windows — copied {dest}")
+
+
+def fix_bundle(root: Path) -> None:
+    root = root.resolve()
+    if not root.exists():
+        raise SystemExit(f"Bundle path does not exist: {root}")
+
+    # Accept .app bundle or standalone dist dir
+    search_root = root
+    if root.suffix == ".app" or root.name.endswith(".app"):
+        macos = root / "Contents" / "MacOS"
+        if macos.is_dir():
+            search_root = macos
+
+    site = _site_pyocio_dir()
+    src_lib = _source_lib(site)
+    src_ext = _source_extension(site)
+    ext = _find_extension(search_root)
+    print(f"fix_bundle_ocio: extension {ext}")
+    print(f"fix_bundle_ocio: source ext {src_ext} ({src_ext.stat().st_size} bytes)")
+    print(f"fix_bundle_ocio: source lib {src_lib} (from build-env PyOpenColorIO)")
+
+    system = platform.system()
+    if system == "Darwin":
+        _macos_fix(ext, src_ext, src_lib)
+    elif system == "Windows":
+        _windows_fix(ext, src_ext, src_lib)
+    else:
+        _linux_fix(ext, src_ext, src_lib)
+
+    print("fix_bundle_ocio: done")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "bundle",
+        type=Path,
+        help='Path to "EXR Converter.app" or Nuitka dist/main.dist',
+    )
+    args = ap.parse_args()
+    fix_bundle(args.bundle)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.5.0"
+APP_VERSION = "0.5.1"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/core/ocio_utils.py
+++ b/src/core/ocio_utils.py
@@ -130,21 +130,84 @@ def list_app_configs() -> list[tuple[str, str, bool]]:
     return []
 
 
-def list_nuke_configs() -> list[tuple[str, str, bool]]:
+def is_ocio_config_loadable(path: str | Path) -> tuple[bool, str]:
+    """Return ``(ok, error_message)`` for whether *path* loads with this OCIO.
+
+    Uses the process-linked :mod:`PyOpenColorIO` (normally 2.5+ after
+    ``make ensure-ocio``). Configs that need builtins or profile versions this
+    library lacks — e.g. some Foundry Nuke Studio ACES 2.0 configs when OCIO
+    was rewired to 2.4 — return ``(False, …)``.
+    """
+    p = Path(path)
+    if not p.is_file():
+        return False, f"config file not found: {p}"
+    try:
+        OCIO.Config.CreateFromFile(str(p))
+        return True, ""
+    except Exception as e:
+        return False, str(e).strip() or type(e).__name__
+
+
+def list_nuke_configs() -> list[tuple[str, str, bool, bool, str]]:
     """Local Nuke install configs (path references only — never bundled).
 
-    Returns ``[(key, label, recommended), ...]``.  *recommended* is True for
-    the newest install's Studio ACES 2.0 config when present.
+    Returns ``[(key, label, recommended, compatible, detail), ...]``.
+
+    *recommended* is True for the first **compatible** Studio-kind entry
+    (newest Nuke × preferred kind). *compatible* is False when the current
+    OpenColorIO cannot load the file; the UI should still list those entries
+    greyed-out. *detail* is the load error (or empty when compatible).
     """
     configs = find_nuke_ocio_configs()
     if not configs:
         return []
-    # Mark the first entry (newest Nuke × preferred kind) as recommended.
-    out: list[tuple[str, str, bool]] = []
-    for i, cfg in enumerate(configs):
+
+    # Probe once per unique path (cheap enough for a handful of Nuke configs).
+    loadable: dict[str, tuple[bool, str]] = {}
+    for cfg in configs:
+        key = str(cfg.path)
+        if key not in loadable:
+            loadable[key] = is_ocio_config_loadable(cfg.path)
+
+    out: list[tuple[str, str, bool, bool, str]] = []
+    recommended_set = False
+    for cfg in configs:
+        ok, err = loadable[str(cfg.path)]
         label = f"{cfg.label}  (local)"
-        out.append((cfg.key, label, i == 0 and cfg.kind.startswith("studio")))
+        if not ok:
+            label = f"{cfg.label}  (incompatible)"
+        recommend = False
+        if ok and not recommended_set and cfg.kind.startswith("studio"):
+            recommend = True
+            recommended_set = True
+        out.append((cfg.key, label, recommend, ok, err))
     return out
+
+
+def _is_frozen_app() -> bool:
+    """True when running inside a Nuitka / frozen binary (not a source venv)."""
+    if getattr(sys, "frozen", False):
+        return True
+    # Nuitka sets __compiled__ on compiled modules.
+    return globals().get("__compiled__") is not None
+
+
+def _ocio_version_mismatch_hint(runtime: str) -> str:
+    if _is_frozen_app():
+        return (
+            f"Runtime OpenColorIO is {runtime}; this app build needs 2.5+ to load "
+            f"the bundled ACES Studio config.\n"
+            f"This is a packaging bug (OpenImageIO’s OCIO 2.4 dylib was linked "
+            f"instead of OpenColorIO 2.5). Install a newer EXR Converter release, "
+            f"or run from source with: make ensure-ocio && make run"
+        )
+    return (
+        f"Runtime OpenColorIO is {runtime}; the bundled ACES Studio config "
+        f"needs 2.5+.  oiio-python sometimes rewires PyOpenColorIO to its "
+        f"vendored 2.4 dylib.  Fix with:\n"
+        f"  make ensure-ocio\n"
+        f"  # or: uv pip install --reinstall-package opencolorio 'opencolorio>=2.5.1'"
+    )
 
 
 def _create_from_file(path: str | Path) -> OCIO.Config:
@@ -156,14 +219,7 @@ def _create_from_file(path: str | Path) -> OCIO.Config:
         msg = str(e)
         if "not able to load that config version" in msg or "Maximum minor version" in msg:
             runtime = OCIO.GetVersion()
-            raise RuntimeError(
-                f"{msg}\n\n"
-                f"Runtime OpenColorIO is {runtime}; the bundled ACES Studio config "
-                f"needs 2.5+.  oiio-python sometimes rewires PyOpenColorIO to its "
-                f"vendored 2.4 dylib.  Fix with:\n"
-                f"  make ensure-ocio\n"
-                f"  # or: uv pip install --reinstall-package opencolorio 'opencolorio>=2.5.1'"
-            ) from e
+            raise RuntimeError(f"{msg}\n\n{_ocio_version_mismatch_hint(runtime)}") from e
         raise
 
 
@@ -185,11 +241,11 @@ def resolve_ocio_config(source: str, builtin_name: str = "", file_path: str = ""
     if source == OCIO_SOURCE_BUNDLED or source == BUNDLED_ACES_STUDIO_KEY:
         p = get_bundled_aces_studio_path()
         if p and p.is_file():
-            try:
-                return _create_from_file(p)
-            except Exception:
-                pass  # version too old or corrupt; fall through to library fallback
-        # Graceful fallback to the best available library studio config (the "awesome cameras" one)
+            # Do not silently fall back on version errors — that left the UI green
+            # while convert failed with OCIO 2.4. Only fall back if the file is
+            # missing entirely.
+            return _create_from_file(p)
+        # File missing from the bundle: try library studio configs.
         for candidate in (
             "studio-config-v2.2.0_aces-v1.3_ocio-v2.4",
             "studio-config-v2.1.0_aces-v1.3_ocio-v2.3",
@@ -201,7 +257,8 @@ def resolve_ocio_config(source: str, builtin_name: str = "", file_path: str = ""
                 continue
         raise RuntimeError(
             "Bundled ACES Studio config not found (requires OCIO 2.5+ at runtime) "
-            "and no library fallback available. Run: make ensure-ocio"
+            "and no library fallback available. "
+            + ("Reinstall EXR Converter." if _is_frozen_app() else "Run: make ensure-ocio")
         )
     if is_nuke_source_key(source):
         p = resolve_nuke_config_path(source)

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -436,22 +436,39 @@ class OcioConfigPanel(QGroupBox):
             self._source_combo.insertSeparator(self._source_combo.count())
 
         # Local Nuke installs — path references only (never redistributed).
-        for name, label, recommended in self._nuke_configs:
+        # Incompatible with the linked OpenColorIO are listed but greyed out.
+        from ..core.nuke_discover import resolve_nuke_config_path
+
+        for name, label, recommended, compatible, detail in self._nuke_configs:
             short = label
             if recommended:
                 short += "  \u2605"
             self._source_combo.addItem(short, name)
-            # Tooltip shows full on-disk path so users know it's their Nuke install.
-            from ..core.nuke_discover import resolve_nuke_config_path
-
+            idx = self._source_combo.count() - 1
             p = resolve_nuke_config_path(name)
+            tip_lines = [
+                "Uses OCIO from your Nuke install (not redistributed).",
+            ]
             if p is not None:
-                idx = self._source_combo.count() - 1
-                self._source_combo.setItemData(
-                    idx,
-                    f"Uses OCIO from your Nuke install (not redistributed):\n{p}",
-                    Qt.ItemDataRole.ToolTipRole,
+                tip_lines.append(str(p))
+            if not compatible:
+                tip_lines.append("")
+                tip_lines.append(
+                    "Unavailable with this app’s OpenColorIO "
+                    f"({__import__('PyOpenColorIO').GetVersion()})."
                 )
+                if detail:
+                    tip_lines.append(detail)
+                tip_lines.append(
+                    "Use the bundled ACES Studio config, or run make ensure-ocio "
+                    "if OpenColorIO was downgraded by oiio-python."
+                )
+                self._set_combo_item_enabled(idx, False)
+            self._source_combo.setItemData(
+                idx,
+                "\n".join(tip_lines),
+                Qt.ItemDataRole.ToolTipRole,
+            )
         if self._nuke_configs:
             self._source_combo.insertSeparator(self._source_combo.count())
 
@@ -479,6 +496,37 @@ class OcioConfigPanel(QGroupBox):
         else:
             self._source_combo.addItem(label, OCIO_SOURCE_FILE)
 
+    def _set_combo_item_enabled(self, index: int, enabled: bool) -> None:
+        """Grey out a combo row (still visible) when *enabled* is False."""
+        from PySide6.QtGui import QColor, QStandardItemModel
+
+        model = self._source_combo.model()
+        if not isinstance(model, QStandardItemModel):
+            return
+        item = model.item(index)
+        if item is None:
+            return
+        flags = item.flags()
+        if enabled:
+            item.setFlags(flags | Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            item.setForeground(
+                self._source_combo.palette().color(self._source_combo.foregroundRole())
+            )
+        else:
+            item.setFlags(flags & ~Qt.ItemFlag.ItemIsEnabled)
+            item.setForeground(QColor("#666666"))
+
+    def _combo_item_is_enabled(self, index: int) -> bool:
+        from PySide6.QtGui import QStandardItemModel
+
+        model = self._source_combo.model()
+        if not isinstance(model, QStandardItemModel):
+            return True
+        item = model.item(index)
+        if item is None:
+            return True
+        return bool(item.flags() & Qt.ItemFlag.ItemIsEnabled)
+
     def _select_saved_source(self) -> None:
         saved = self._settings.value("ocio/source", "")
         if not saved:
@@ -494,6 +542,17 @@ class OcioConfigPanel(QGroupBox):
                     saved = recommended[0][0] if recommended else self._builtin_configs[-1][0]
         for i in range(self._source_combo.count()):
             if self._source_combo.itemData(i) == saved:
+                if self._combo_item_is_enabled(i):
+                    self._source_combo.setCurrentIndex(i)
+                    return
+                # Saved Nuke config is no longer loadable — fall through.
+                break
+        # Prefer first enabled non-env item if saved was incompatible.
+        for i in range(self._source_combo.count()):
+            data = self._source_combo.itemData(i)
+            if data is None:
+                continue
+            if self._combo_item_is_enabled(i) and data != OCIO_SOURCE_ENV:
                 self._source_combo.setCurrentIndex(i)
                 return
         self._source_combo.setCurrentIndex(0)
@@ -532,6 +591,14 @@ class OcioConfigPanel(QGroupBox):
         return cfg
 
     def _on_source_changed(self, _idx: int) -> None:
+        # Disabled (incompatible) rows should not be selectable; if Qt still
+        # delivers the change, bounce back to the previous enabled index.
+        if not self._combo_item_is_enabled(_idx):
+            self._source_combo.blockSignals(True)
+            self._source_combo.setCurrentIndex(self._prev_index)
+            self._source_combo.blockSignals(False)
+            return
+
         source = self.current_source_key()
         if source == OCIO_SOURCE_FILE:
             path, _ = QFileDialog.getOpenFileName(

--- a/tests/test_nuke_discover.py
+++ b/tests/test_nuke_discover.py
@@ -52,6 +52,46 @@ def test_list_nuke_configs_empty_without_install(monkeypatch):
     assert list_nuke_configs() == []
 
 
+def test_list_nuke_configs_marks_incompatible(tmp_path, monkeypatch):
+    """Incompatible configs stay listed but are flagged for greying-out in the UI."""
+    from src.core import ocio_utils
+
+    install = _fake_nuke_tree(tmp_path)
+    monkeypatch.setattr(nuke_discover, "_iter_install_roots", lambda: [install])
+
+    def _probe(path):
+        path = Path(path)
+        # Pretend Studio ACES 2.0 is unloadable (real-world BuiltinTransform case).
+        if "studio" in path.name.lower() and "aces-v2" in path.name.lower():
+            return (
+                False,
+                "invalid built-in transform style 'DISPLAY - CIE-XYZ-D65_to_DisplayP3-HDR'",
+            )
+        # Fake tree files are not real OCIO — treat others as loadable for the test.
+        return True, ""
+
+    monkeypatch.setattr(ocio_utils, "is_ocio_config_loadable", _probe)
+
+    listed = list_nuke_configs()
+    assert listed
+    # (key, label, recommended, compatible, detail)
+    studio = [c for c in listed if "studio" in c[0].lower() or "Studio" in c[1]]
+    assert studio, listed
+    assert studio[0][3] is False
+    assert "incompatible" in studio[0][1].lower()
+    assert "DisplayP3-HDR" in studio[0][4]
+    # Recommended star only on a compatible studio entry — none here
+    assert all(not c[2] for c in studio)
+
+
+def test_is_ocio_config_loadable_missing(tmp_path):
+    from src.core.ocio_utils import is_ocio_config_loadable
+
+    ok, err = is_ocio_config_loadable(tmp_path / "nope.ocio")
+    assert ok is False
+    assert "not found" in err.lower()
+
+
 def test_resolve_nuke_source_key(tmp_path, monkeypatch):
     install = _fake_nuke_tree(tmp_path, "16.0v5")
     monkeypatch.setattr(nuke_discover, "_iter_install_roots", lambda: [install])

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.5.0"
+version = "0.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

**Patch 0.5.1** — fixes the packaged-app OpenColorIO 2.4 failure on the bundled ACES Studio config.

- `scripts/fix_bundle_ocio.py` restores build-env OCIO **2.5** extension + dylib after Nuitka
- `ensure_ocio` before Nuitka in Release CI; smoke test loads bundled config
- Nuke OCIO configs that cannot load are greyed out (not hard-fail only after select)
- No silent fallback for bundled ACES Studio on version mismatch

## Changelog

See `[0.5.1]` in CHANGELOG.md.

## Test plan

- [ ] PR CI green
- [ ] After merge: Auto-tag pushes `v0.5.1` → Release workflow
- [ ] Smoke on macOS DMG: bundled ACES Studio loads; convert succeeds