### PR TITLE
ci: fix merge → auto-tag → Release chain

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,10 +1,13 @@
-# After a PR merges to main, if pyproject.toml version X.Y.Z has no matching
-# git tag vX.Y.Z yet, create and push that tag. The existing Release workflow
-# (on: push tags: v*) then builds, signs, and publishes the GitHub Release.
+# After a PR merges to main: if pyproject version X.Y.Z has no tag vX.Y.Z yet,
+# create and push the tag, then *explicitly* start the Release workflow.
 #
-# Why this exists: protected main means tags are not pushed during
-# `make release PUSH=0`. Merging the release PR alone never fired Release
-# until someone remembered `git push origin vX.Y.Z`.
+# Why workflow_dispatch (not “tag push alone”):
+#   Tags created with the default GITHUB_TOKEN do **not** start other workflows
+#   (GitHub recursion guard). So auto-tag must call `gh workflow run Release`
+#   after pushing the tag. That *does* work with GITHUB_TOKEN.
+#
+# Also recovers: if the tag exists but no GitHub Release was published yet,
+# re-trigger Release (e.g. after a failed publish or the 0.5.1 gap).
 
 name: Auto-tag release
 
@@ -12,25 +15,24 @@ on:
   push:
     branches: [main]
 
-# Do not cancel in-flight Release builds if several merges land quickly.
 concurrency:
   group: auto-tag-release
   cancel-in-progress: false
 
 permissions:
   contents: write
+  actions: write # required to `gh workflow run` Release
 
 jobs:
-  tag-if-needed:
+  tag-and-dispatch:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Need full history / ability to push tags from GITHUB_TOKEN.
           fetch-depth: 0
 
-      - name: Read version and tag if missing
+      - name: Tag if needed and trigger Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -44,19 +46,36 @@ jobs:
           TAG="v${VERSION}"
           echo "version=${VERSION} tag=${TAG}"
 
+          TAG_EXISTS=false
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists locally — nothing to do."
+            TAG_EXISTS=true
+          elif git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            TAG_EXISTS=true
+          fi
+
+          if [ "$TAG_EXISTS" = false ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "${TAG}" -m "release: ${VERSION}"
+            git push origin "refs/tags/${TAG}"
+            echo "Created and pushed ${TAG}"
+          else
+            echo "Tag ${TAG} already exists"
+          fi
+
+          # Publish if there is no GitHub Release yet (new tag or previous miss).
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "GitHub Release ${TAG} already exists — nothing to dispatch."
             exit 0
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists on origin — nothing to do."
-            exit 0
-          fi
-
-          # Point the tag at the commit that just landed on main (this push).
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG}" -m "release: ${VERSION}"
-          git push origin "refs/tags/${TAG}"
-          echo "Pushed ${TAG} → triggers Release workflow."
+          echo "No GitHub Release for ${TAG} — dispatching Release workflow (workflow file from main)"
+          # workflow_dispatch IS allowed to start new runs with GITHUB_TOKEN
+          # (unlike events from a GITHUB_TOKEN tag push).
+          # Use --ref main so we get the latest Release.yml (with workflow_dispatch
+          # + RELEASE_TAG input). The build checks out the tag via inputs.tag.
+          gh workflow run Release \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f "tag=${TAG}"
+          echo "Dispatched Release for ${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 # Tag format: v1.2.3
-# Push: git tag v1.2.3 && git push origin v1.2.3
+#
+# Triggers:
+#   1. push of tag v* (human / PAT push — GITHUB_TOKEN tag pushes do NOT fire this)
+#   2. workflow_dispatch on a tag ref (used by Auto-tag release after merge to main)
 #
 # Gate: lint + full pytest suite (unit + integration) must pass on all
 # platforms before any Nuitka build or GitHub Release is published.
@@ -10,6 +13,14 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    # Prefer: gh workflow run Release --ref main -f tag=v0.5.1
+    # (runs workflow file from main; builds the given tag commit)
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.5.1). Required for manual / auto-tag dispatch."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,6 +29,8 @@ permissions:
 env:
   NUITKA_ASSUME_YES_FOR_DOWNLOADS: "1"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  # Tag push → github.ref_name; workflow_dispatch → inputs.tag
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
   # ── Quality gate (must pass before build / sign / publish) ────────────────
@@ -25,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -52,6 +67,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -121,6 +138,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -150,7 +169,8 @@ jobs:
       - name: Inject version from tag
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
+          echo "Building version ${VERSION} (tag ${RELEASE_TAG})"
           sed -i.bak "s/^APP_VERSION = \"[^\"]*\"/APP_VERSION = \"${VERSION}\"/" src/core/constants.py
           rm -f src/core/constants.py.bak
 
@@ -392,7 +412,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           APPDIR="${{ matrix.artifact }}.AppDir"
           mkdir -p "${APPDIR}/usr/bin" "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
 
@@ -424,7 +444,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}".Replace("v","")
+          $version = "${{ env.RELEASE_TAG }}".Replace("v","")
           iscc "/DAppVersion=$version" installer.iss
 
       - name: Upload artifact
@@ -514,8 +534,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2.6.1
         with:
-          tag_name: ${{ github.ref_name }}
-          name: "EXR Converter ${{ github.ref_name }}"
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: "EXR Converter ${{ env.RELEASE_TAG }}"
           generate_release_notes: true
           files: artifacts/*
           body: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,9 +154,10 @@ feature commits (PR → main)
  PR → main → merge
         │
  Auto-tag release workflow (on push to main)
-        │  if pyproject version X.Y.Z has no tag vX.Y.Z → create + push tag
+        │  if pyproject version X.Y.Z has no tag → create + push tag
+        │  if no GitHub Release for that tag yet → `gh workflow run Release --ref vX.Y.Z`
         ▼
- GitHub Actions “Release” on tag v*
+ GitHub Actions “Release” (tag push **or** workflow_dispatch on the tag)
         │  lint → test (3 OS) → gate → Nuitka → Cosign → GitHub Release
         ▼
  Artifacts: Linux AppImage, macOS DMG (arm64 + x86_64), Windows installer
@@ -166,11 +167,10 @@ feature commits (PR → main)
 Tags are plain semver: **`v1.2.3`**. The tag is the published app version
 (workflow also injects `APP_VERSION` from the tag during the Nuitka build).
 
-**Important:** the **Release** workflow only runs on **tag push** (`v*`), not on
-merge alone. Historically the tag was left local (`PUSH=0`) and someone had to
-`git push origin vX.Y.Z` after merge — that is what missed 0.5.0 until fixed by
-hand. **`.github/workflows/auto-tag-release.yml`** now tags automatically when
-`main` advances and the version in `pyproject.toml` has no matching tag yet.
+**Critical GitHub quirk:** a tag created with the default **`GITHUB_TOKEN` does
+not start other workflows** (recursion guard). Auto-tag therefore **dispatches**
+Release via `workflow_dispatch` after pushing the tag. Human `git push origin v*`
+with a real user/PAT still triggers Release on `push: tags` as usual.
 
 ### Prerequisites
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI/CD chain after merge:** tags created by Actions with `GITHUB_TOKEN` do not
+  start other workflows. Auto-tag now **dispatches** the Release workflow
+  (`workflow_dispatch` on the tag) after tagging, and re-dispatches if a tag
+  exists but no GitHub Release was published yet.
+
 ---
 
 ## [0.5.1] — 2026-08-06


### PR DESCRIPTION
## Problem

`GITHUB_TOKEN` tag pushes **do not** trigger other workflows (GitHub recursion guard).  
Auto-tag successfully pushed `v0.5.1` but **Release never started**.

## Fix

1. **Release** accepts `workflow_dispatch` with required `tag` input; builds check out that tag.
2. **Auto-tag** after merge: create tag if needed, then  
   `gh workflow run Release --ref main -f tag=vX.Y.Z`  
   (also recovers when tag exists but no GitHub Release yet).

## After merge

Auto-tag on this merge will see `v0.5.1` already tagged and **no** GH Release → dispatch Release for 0.5.1 automatically.

## Test plan

- [ ] Merge this PR
- [ ] Auto-tag run dispatches Release for v0.5.1
- [ ] Release completes and publishes assets