### PR TITLE
fix(windows): restore OpenColorIO_2_4.dll for OIIO Nuitka loads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,14 @@ jobs:
           else
             uv run python scripts/fix_bundle_ocio.py dist/main.dist
           fi
+          # Windows: OIIO needs OpenColorIO_2_4.dll on the DLL search path.
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            echo "--- OCIO / OIIO DLLs in dist ---"
+            find dist/main.dist -iname '*OpenColorIO*' -o -iname 'OpenImageIO*' 2>/dev/null | sort || true
+            test -f dist/main.dist/OpenColorIO_2_4.dll \
+              || find dist/main.dist -name 'OpenColorIO_2_4.dll' | grep -q . \
+              || { echo "ERROR: OpenColorIO_2_4.dll missing from Windows bundle" >&2; exit 1; }
+          fi
 
       - name: Slim macOS bundle
         if: runner.os == 'macOS'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ rolling the `[Unreleased]` section into a versioned heading.
   start other workflows. Auto-tag now **dispatches** the Release workflow
   (`workflow_dispatch` on the tag) after tagging, and re-dispatches if a tag
   exists but no GitHub Release was published yet.
+- **Windows Nuitka / OpenImageIO LoadLibrary:** reinstalling OpenColorIO 2.5
+  removed oiio-python’s `OpenColorIO_2_4.dll`, so `OpenImageIO.pyd` failed with
+  “The specified module could not be found.” `ensure_ocio` and
+  `fix_bundle_ocio` now preserve that 2.4 DLL next to OIIO while keeping app
+  OCIO on 2.5.
 
 ---
 

--- a/scripts/ensure_ocio.py
+++ b/scripts/ensure_ocio.py
@@ -1,28 +1,32 @@
 #!/usr/bin/env python3
 """Ensure the runtime OpenColorIO library is 2.5+ (matches the bundled config).
 
-``oiio-python`` sometimes rewrites ``PyOpenColorIO.so`` to link against the
-OpenColorIO 2.4.0 dylib it vendors under ``OpenImageIO/.dylibs/``.  That makes
-``PyOpenColorIO.GetVersion()`` report 2.4.0 even when the ``opencolorio``
-package metadata says 2.5.x, and the bundled ACES Studio v4 config
-(``ocio_profile_version: 2.5``) then fails to load.
+``oiio-python`` sometimes rewrites ``PyOpenColorIO`` to link against its
+vendored OpenColorIO **2.4** (macOS: ``OpenImageIO/.dylibs/libOpenColorIO.2.4``;
+Windows: ``PyOpenColorIO/OpenColorIO_2_4.dll`` bundled inside the oiio wheel).
+That makes ``PyOpenColorIO.GetVersion()`` report 2.4.0 and the bundled ACES
+Studio v4 config (profile 2.5) fails to load.
 
-This script detects that mismatch and reinstalls ``opencolorio`` so the
-extension links its own ``@loader_path/libOpenColorIO.dylib`` again.
+This script reinstalls ``opencolorio`` so PyOpenColorIO is 2.5+ again.
 
-Version checks after reinstall run in a **fresh subprocess** so a previously
-loaded 2.4 extension module cannot mask a successful repair.
+**Windows caveat:** reinstalling opencolorio overwrites the oiio-shipped
+``PyOpenColorIO/`` tree and **deletes** ``OpenColorIO_2_4.dll``. OpenImageIO's
+native DLL still depends on that 2.4 library, so we preserve/restore it next
+to ``OpenImageIO.pyd`` for packaging and runtime.
 """
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 REQUIRED = (2, 5, 0)
 PACKAGE = "opencolorio>=2.5.1"
+OIIO_OCIO24_DLL = "OpenColorIO_2_4.dll"
 
 
 def _parse_version(text: str) -> tuple[int, ...]:
@@ -37,7 +41,6 @@ def _runtime_version_fresh() -> str:
         "print('\\n' + o.__file__, end='')"
     )
     out = subprocess.check_output([sys.executable, "-c", code], text=True)
-    # First line: version; second: path (optional)
     return out.splitlines()[0].strip()
 
 
@@ -51,8 +54,103 @@ def _is_broken() -> tuple[bool, str]:
     return False, ver
 
 
+def _oiio_dir() -> Path | None:
+    try:
+        import OpenImageIO as oiio
+
+        return Path(oiio.__file__).resolve().parent
+    except Exception:
+        return None
+
+
+def _find_oiio_wheel() -> Path | None:
+    """Locate a cached oiio_python wheel (uv/pip) containing the 2.4 OCIO DLL."""
+    roots: list[Path] = []
+    for key in ("UV_CACHE_DIR", "PIP_CACHE_DIR"):
+        v = os.environ.get(key)
+        if v:
+            roots.append(Path(v))
+    roots.extend(
+        [
+            Path.home() / ".cache" / "uv",
+            Path.home() / ".cache" / "pip",
+            Path(os.environ.get("LOCALAPPDATA", "")) / "uv" / "cache",
+            Path(os.environ.get("LOCALAPPDATA", "")) / "pip" / "Cache",
+        ]
+    )
+    hits: list[Path] = []
+    for root in roots:
+        if not root or not root.is_dir():
+            continue
+        try:
+            hits.extend(root.rglob("oiio_python-*.whl"))
+            hits.extend(root.rglob("oiio-python-*.whl"))
+        except OSError:
+            continue
+    if not hits:
+        return None
+    hits.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return hits[0]
+
+
+def _read_ocio24_dll_bytes() -> bytes | None:
+    """Return OpenColorIO_2_4.dll bytes from disk or the oiio wheel cache."""
+    # Any remaining copy under the env
+    for base in {Path(sys.prefix), Path(sys.base_prefix)}:
+        try:
+            for p in base.rglob(OIIO_OCIO24_DLL):
+                if p.is_file():
+                    return p.read_bytes()
+        except OSError:
+            continue
+
+    whl = _find_oiio_wheel()
+    if whl is None:
+        return None
+    try:
+        with zipfile.ZipFile(whl) as zf:
+            for name in zf.namelist():
+                if name.endswith(OIIO_OCIO24_DLL) or name.endswith("/" + OIIO_OCIO24_DLL):
+                    print(f"ensure_ocio: extracting {name} from {whl.name}")
+                    return zf.read(name)
+    except (OSError, zipfile.BadZipFile) as e:
+        print(f"ensure_ocio: could not read {whl}: {e}", file=sys.stderr)
+    return None
+
+
+def _preserve_oiio_ocio24_dll() -> None:
+    """Keep OpenColorIO_2_4.dll next to OpenImageIO for Windows LoadLibrary.
+
+    Safe no-op on platforms / installs that do not need it.
+    """
+    oiio = _oiio_dir()
+    if oiio is None:
+        return
+
+    dest = oiio / OIIO_OCIO24_DLL
+    if dest.is_file():
+        print(f"ensure_ocio: OIIO OCIO 2.4 present at {dest}")
+        return
+
+    data = _read_ocio24_dll_bytes()
+    if not data:
+        # Non-Windows oiio wheels often vendor OCIO under .dylibs instead.
+        if sys.platform == "win32":
+            print(
+                "ensure_ocio: WARNING — could not restore OpenColorIO_2_4.dll; "
+                "Windows OpenImageIO.pyd may fail LoadLibrary in the Nuitka bundle.",
+                file=sys.stderr,
+            )
+        return
+
+    dest.write_bytes(data)
+    print(f"ensure_ocio: wrote {dest} ({len(data)} bytes) for OIIO")
+
+
 def _reinstall() -> int:
-    # Target *this* interpreter's environment (uv run / CI venv).
+    # Snapshot 2.4 DLL before opencolorio clobbers oiio's PyOpenColorIO tree.
+    saved = _read_ocio24_dll_bytes()
+
     cmds = [
         [
             "uv",
@@ -78,6 +176,11 @@ def _reinstall() -> int:
         try:
             print(f"ensure_ocio: running {' '.join(cmd)}")
             subprocess.check_call(cmd)
+            if saved:
+                oiio = _oiio_dir()
+                if oiio is not None:
+                    (oiio / OIIO_OCIO24_DLL).write_bytes(saved)
+                    print(f"ensure_ocio: restored {OIIO_OCIO24_DLL} under {oiio}")
             return 0
         except FileNotFoundError:
             continue
@@ -95,11 +198,12 @@ def main() -> int:
     broken, ver = _is_broken()
     if not broken:
         print(f"ensure_ocio: OK — OpenColorIO {ver}")
+        _preserve_oiio_ocio24_dll()
         return 0
 
     print(
         f"ensure_ocio: OpenColorIO runtime is {ver!r}, need >= {'.'.join(map(str, REQUIRED))}.\n"
-        "  (oiio-python often rewires PyOpenColorIO to its vendored 2.4 dylib.)\n"
+        "  (oiio-python often rewires PyOpenColorIO to its vendored 2.4 library.)\n"
         f"  Reinstalling {PACKAGE} …",
         file=sys.stderr,
     )
@@ -113,7 +217,8 @@ def main() -> int:
         return 2
 
     print(f"ensure_ocio: repaired — OpenColorIO {ver}")
-    # Spot-check the macOS install name when otool is available.
+    _preserve_oiio_ocio24_dll()
+
     try:
         code = "import PyOpenColorIO as o; print(o.__file__)"
         mod = subprocess.check_output([sys.executable, "-c", code], text=True).strip()

--- a/scripts/fix_bundle_ocio.py
+++ b/scripts/fix_bundle_ocio.py
@@ -196,28 +196,93 @@ def _linux_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
     print(f"fix_bundle_ocio: Linux — ensured {plain}")
 
 
-def _windows_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
-    ext = _replace_extension(ext, src_ext)
-    # Windows loads DLLs from the pyd directory and the executable directory.
-    targets = [
-        ext.parent / src_lib.name,
-        ext.parent.parent / src_lib.name,
-    ]
-    for root in (ext.parent, *ext.parents[:3]):
-        if (root / "exr_converter.exe").is_file():
-            targets.append(root / src_lib.name)
-        if root.name.endswith(".dist") or root.name == "main.dist":
-            targets.append(root / src_lib.name)
-
+def _windows_copy_dll(src: Path, dests: list[Path]) -> None:
     written: set[Path] = set()
-    for dest in targets:
+    for dest in dests:
         dest = dest.resolve()
         if dest in written:
             continue
         dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src_lib, dest)
+        shutil.copy2(src, dest)
         written.add(dest)
         print(f"fix_bundle_ocio: Windows — copied {dest}")
+
+
+def _windows_oiio_ocio24_source() -> Path | None:
+    """Find OpenColorIO_2_4.dll (required by OpenImageIO on Windows)."""
+    name = "OpenColorIO_2_4.dll"
+    try:
+        import OpenImageIO as oiio
+
+        p = Path(oiio.__file__).resolve().parent / name
+        if p.is_file():
+            return p
+    except Exception:
+        pass
+    for base in {Path(sys.prefix), Path(sys.base_prefix)}:
+        try:
+            hits = list(base.rglob(name))
+            if hits:
+                return hits[0]
+        except OSError:
+            continue
+    return None
+
+
+def _windows_dist_root(ext: Path) -> Path:
+    """Best-effort Nuitka dist root (folder with exr_converter.exe or *.dist)."""
+    cur = ext.parent
+    for _ in range(8):
+        if (cur / "exr_converter.exe").is_file() or cur.name.endswith(".dist"):
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    return ext.parent.parent
+
+
+def _windows_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
+    """Restore PyOpenColorIO 2.5 *and* keep OIIO's OpenColorIO 2.4 DLL.
+
+    oiio-python's Windows wheel ships ``OpenColorIO_2_4.dll`` under
+    ``PyOpenColorIO/``. Reinstalling opencolorio 2.5 for the app removes that
+    file; OpenImageIO.pyd then fails with LoadLibraryExW "module not found".
+    """
+    ext = _replace_extension(ext, src_ext)
+    dist_root = _windows_dist_root(ext)
+
+    # App OCIO 2.5 — next to PyOpenColorIO.pyd and dist root.
+    _windows_copy_dll(
+        src_lib,
+        [
+            ext.parent / src_lib.name,
+            dist_root / src_lib.name,
+        ],
+    )
+
+    # OIIO OCIO 2.4 — next to OpenImageIO.pyd and dist root (DLL search path).
+    ocio24 = _windows_oiio_ocio24_source()
+    if ocio24 is None:
+        print(
+            "fix_bundle_ocio: WARNING — OpenColorIO_2_4.dll not found in env; "
+            "OpenImageIO.pyd may fail LoadLibrary on Windows",
+            file=sys.stderr,
+        )
+        return
+
+    dests_24 = [dist_root / ocio24.name]
+    for oiio_pyd in dist_root.rglob("OpenImageIO*.pyd"):
+        dests_24.append(oiio_pyd.parent / ocio24.name)
+    _windows_copy_dll(ocio24, dests_24)
+
+    # Hard fail if OIIO is present but still missing its OCIO DLL.
+    for oiio_pyd in dist_root.rglob("OpenImageIO*.pyd"):
+        need = oiio_pyd.parent / ocio24.name
+        if not need.is_file() and not (dist_root / ocio24.name).is_file():
+            raise SystemExit(
+                f"fix_bundle_ocio: {ocio24.name} missing next to {oiio_pyd} "
+                f"and under {dist_root} — Windows OIIO will not load"
+            )
 
 
 def fix_bundle(root: Path) -> None:


### PR DESCRIPTION
## Problem

Windows Release integration tests failed:

```
LoadLibraryExW '...OpenImageIO.pyd' failed: The specified module could not be found.
```

**Cause:** `ensure_ocio` reinstalls OpenColorIO **2.5** and overwrites oiio-python’s `PyOpenColorIO/` tree, deleting **`OpenColorIO_2_4.dll`**. OpenImageIO’s native DLL still depends on that 2.4 library, so the Nuitka `.exe` cannot load `OpenImageIO.pyd`.

macOS/Linux were fine (OIIO vendors 2.4 under `.dylibs/` separately).

## Fix

- `ensure_ocio`: snapshot/restore `OpenColorIO_2_4.dll` next to `OpenImageIO` (from env or oiio wheel cache)
- `fix_bundle_ocio` (Windows): copy **2.5** for PyOpenColorIO **and** **2.4** next to OpenImageIO.pyd / dist root; fail if 2.4 missing
- Release workflow: assert 2.4 DLL is present in the Windows bundle

## Test plan

- [ ] Merge → Auto-tag may re-dispatch Release for v0.5.1 if still unpublished
- [ ] Windows build job: integration tests green
- [ ] macOS/Linux still green