### PR TITLE
fix(windows): download OpenColorIO_2_4.dll from PyPI for OIIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ rolling the `[Unreleased]` section into a versioned heading.
   exists but no GitHub Release was published yet.
 - **Windows Nuitka / OpenImageIO LoadLibrary:** reinstalling OpenColorIO 2.5
   removed oiio-python’s `OpenColorIO_2_4.dll`, so `OpenImageIO.pyd` failed with
-  “The specified module could not be found.” `ensure_ocio` and
-  `fix_bundle_ocio` now preserve that 2.4 DLL next to OIIO while keeping app
-  OCIO on 2.5.
+  “The specified module could not be found.” `ensure_ocio` /
+  `fix_bundle_ocio` now restore that DLL (from env, uv cache, or **PyPI
+  oiio-python wheel download**) next to OIIO while keeping app OCIO on 2.5.
 
 ---
 

--- a/scripts/ensure_ocio.py
+++ b/scripts/ensure_ocio.py
@@ -1,32 +1,30 @@
 #!/usr/bin/env python3
 """Ensure the runtime OpenColorIO library is 2.5+ (matches the bundled config).
 
-``oiio-python`` sometimes rewrites ``PyOpenColorIO`` to link against its
-vendored OpenColorIO **2.4** (macOS: ``OpenImageIO/.dylibs/libOpenColorIO.2.4``;
-Windows: ``PyOpenColorIO/OpenColorIO_2_4.dll`` bundled inside the oiio wheel).
-That makes ``PyOpenColorIO.GetVersion()`` report 2.4.0 and the bundled ACES
-Studio v4 config (profile 2.5) fails to load.
+``oiio-python`` sometimes rewires ``PyOpenColorIO`` to its vendored OpenColorIO
+**2.4**. This script reinstalls ``opencolorio`` so PyOpenColorIO is 2.5+ again.
 
-This script reinstalls ``opencolorio`` so PyOpenColorIO is 2.5+ again.
-
-**Windows caveat:** reinstalling opencolorio overwrites the oiio-shipped
-``PyOpenColorIO/`` tree and **deletes** ``OpenColorIO_2_4.dll``. OpenImageIO's
-native DLL still depends on that 2.4 library, so we preserve/restore it next
-to ``OpenImageIO.pyd`` for packaging and runtime.
+**Windows:** reinstalling opencolorio overwrites oiio's ``PyOpenColorIO/`` tree
+and drops ``OpenColorIO_2_4.dll``, which OpenImageIO still needs. We restore
+that DLL next to the OpenImageIO package for Nuitka packaging / LoadLibrary.
 """
 
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 import sys
-import zipfile
 from pathlib import Path
 
 REQUIRED = (2, 5, 0)
 PACKAGE = "opencolorio>=2.5.1"
-OIIO_OCIO24_DLL = "OpenColorIO_2_4.dll"
+
+# Shared helper lives next to this script.
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from oiio_ocio24 import materialize_ocio24_dll, oiio_package_dir  # noqa: E402
 
 
 def _parse_version(text: str) -> tuple[int, ...]:
@@ -54,103 +52,26 @@ def _is_broken() -> tuple[bool, str]:
     return False, ver
 
 
-def _oiio_dir() -> Path | None:
-    try:
-        import OpenImageIO as oiio
-
-        return Path(oiio.__file__).resolve().parent
-    except Exception:
-        return None
-
-
-def _find_oiio_wheel() -> Path | None:
-    """Locate a cached oiio_python wheel (uv/pip) containing the 2.4 OCIO DLL."""
-    roots: list[Path] = []
-    for key in ("UV_CACHE_DIR", "PIP_CACHE_DIR"):
-        v = os.environ.get(key)
-        if v:
-            roots.append(Path(v))
-    roots.extend(
-        [
-            Path.home() / ".cache" / "uv",
-            Path.home() / ".cache" / "pip",
-            Path(os.environ.get("LOCALAPPDATA", "")) / "uv" / "cache",
-            Path(os.environ.get("LOCALAPPDATA", "")) / "pip" / "Cache",
-        ]
-    )
-    hits: list[Path] = []
-    for root in roots:
-        if not root or not root.is_dir():
-            continue
-        try:
-            hits.extend(root.rglob("oiio_python-*.whl"))
-            hits.extend(root.rglob("oiio-python-*.whl"))
-        except OSError:
-            continue
-    if not hits:
-        return None
-    hits.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    return hits[0]
-
-
-def _read_ocio24_dll_bytes() -> bytes | None:
-    """Return OpenColorIO_2_4.dll bytes from disk or the oiio wheel cache."""
-    # Any remaining copy under the env
-    for base in {Path(sys.prefix), Path(sys.base_prefix)}:
-        try:
-            for p in base.rglob(OIIO_OCIO24_DLL):
-                if p.is_file():
-                    return p.read_bytes()
-        except OSError:
-            continue
-
-    whl = _find_oiio_wheel()
-    if whl is None:
-        return None
-    try:
-        with zipfile.ZipFile(whl) as zf:
-            for name in zf.namelist():
-                if name.endswith(OIIO_OCIO24_DLL) or name.endswith("/" + OIIO_OCIO24_DLL):
-                    print(f"ensure_ocio: extracting {name} from {whl.name}")
-                    return zf.read(name)
-    except (OSError, zipfile.BadZipFile) as e:
-        print(f"ensure_ocio: could not read {whl}: {e}", file=sys.stderr)
-    return None
-
-
 def _preserve_oiio_ocio24_dll() -> None:
-    """Keep OpenColorIO_2_4.dll next to OpenImageIO for Windows LoadLibrary.
-
-    Safe no-op on platforms / installs that do not need it.
-    """
-    oiio = _oiio_dir()
+    """Keep OpenColorIO_2_4.dll next to OpenImageIO for Windows LoadLibrary."""
+    oiio = oiio_package_dir()
     if oiio is None:
         return
-
-    dest = oiio / OIIO_OCIO24_DLL
-    if dest.is_file():
-        print(f"ensure_ocio: OIIO OCIO 2.4 present at {dest}")
-        return
-
-    data = _read_ocio24_dll_bytes()
-    if not data:
-        # Non-Windows oiio wheels often vendor OCIO under .dylibs instead.
-        if sys.platform == "win32":
-            print(
-                "ensure_ocio: WARNING — could not restore OpenColorIO_2_4.dll; "
-                "Windows OpenImageIO.pyd may fail LoadLibrary in the Nuitka bundle.",
-                file=sys.stderr,
-            )
-        return
-
-    dest.write_bytes(data)
-    print(f"ensure_ocio: wrote {dest} ({len(data)} bytes) for OIIO")
+    if sys.platform != "win32":
+        # Still useful if a Windows wheel was inspected cross-platform; no-op OK.
+        pass
+    path = materialize_ocio24_dll(oiio)
+    if path is None and sys.platform == "win32":
+        print(
+            "ensure_ocio: WARNING — could not restore OpenColorIO_2_4.dll; "
+            "Windows OpenImageIO.pyd may fail LoadLibrary in the Nuitka bundle.",
+            file=sys.stderr,
+        )
+    elif path is not None:
+        print(f"ensure_ocio: OIIO OCIO 2.4 ready at {path}")
 
 
 def _reinstall() -> int:
-    # Snapshot 2.4 DLL before opencolorio clobbers oiio's PyOpenColorIO tree.
-    saved = _read_ocio24_dll_bytes()
-
     cmds = [
         [
             "uv",
@@ -176,11 +97,6 @@ def _reinstall() -> int:
         try:
             print(f"ensure_ocio: running {' '.join(cmd)}")
             subprocess.check_call(cmd)
-            if saved:
-                oiio = _oiio_dir()
-                if oiio is not None:
-                    (oiio / OIIO_OCIO24_DLL).write_bytes(saved)
-                    print(f"ensure_ocio: restored {OIIO_OCIO24_DLL} under {oiio}")
             return 0
         except FileNotFoundError:
             continue

--- a/scripts/fix_bundle_ocio.py
+++ b/scripts/fix_bundle_ocio.py
@@ -34,6 +34,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from oiio_ocio24 import OIIO_OCIO24_DLL, materialize_ocio24_dll, read_ocio24_dll_bytes  # noqa: E402
+
 REQUIRED = (2, 5, 0)
 
 
@@ -208,25 +214,23 @@ def _windows_copy_dll(src: Path, dests: list[Path]) -> None:
         print(f"fix_bundle_ocio: Windows — copied {dest}")
 
 
-def _windows_oiio_ocio24_source() -> Path | None:
-    """Find OpenColorIO_2_4.dll (required by OpenImageIO on Windows)."""
-    name = "OpenColorIO_2_4.dll"
-    try:
-        import OpenImageIO as oiio
-
-        p = Path(oiio.__file__).resolve().parent / name
-        if p.is_file():
-            return p
-    except Exception:
-        pass
-    for base in {Path(sys.prefix), Path(sys.base_prefix)}:
-        try:
-            hits = list(base.rglob(name))
-            if hits:
-                return hits[0]
-        except OSError:
-            continue
-    return None
+def _windows_materialize_ocio24(work_dir: Path) -> Path:
+    """Ensure OpenColorIO_2_4.dll exists on disk; download from PyPI if needed."""
+    path = materialize_ocio24_dll(work_dir)
+    if path is not None and path.is_file():
+        return path
+    # Last resort: write into a temp file under work_dir via raw bytes
+    data = read_ocio24_dll_bytes()
+    if not data:
+        raise SystemExit(
+            "fix_bundle_ocio: cannot obtain OpenColorIO_2_4.dll "
+            "(not in env, uv cache, or PyPI oiio-python wheel). "
+            "Windows OpenImageIO.pyd will fail LoadLibrary."
+        )
+    dest = work_dir / OIIO_OCIO24_DLL
+    dest.write_bytes(data)
+    print(f"fix_bundle_ocio: wrote {dest} ({len(data)} bytes)")
+    return dest
 
 
 def _windows_dist_root(ext: Path) -> Path:
@@ -252,6 +256,7 @@ def _windows_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
     dist_root = _windows_dist_root(ext)
 
     # App OCIO 2.5 — next to PyOpenColorIO.pyd and dist root.
+    # Keep the exact filename from the opencolorio wheel (OpenColorIO_2_5.dll).
     _windows_copy_dll(
         src_lib,
         [
@@ -260,29 +265,41 @@ def _windows_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
         ],
     )
 
-    # OIIO OCIO 2.4 — next to OpenImageIO.pyd and dist root (DLL search path).
-    ocio24 = _windows_oiio_ocio24_source()
-    if ocio24 is None:
-        print(
-            "fix_bundle_ocio: WARNING — OpenColorIO_2_4.dll not found in env; "
-            "OpenImageIO.pyd may fail LoadLibrary on Windows",
-            file=sys.stderr,
-        )
-        return
+    # OIIO OCIO 2.4 — required for OpenImageIO.pyd LoadLibrary on Windows.
+    # Fetch from env / uv cache / PyPI if ensure_ocio did not already place it.
+    staging = dist_root / "_ocio24_staging"
+    ocio24 = _windows_materialize_ocio24(staging)
 
-    dests_24 = [dist_root / ocio24.name]
+    dests_24 = [
+        dist_root / OIIO_OCIO24_DLL,
+        dist_root / "OpenImageIO" / OIIO_OCIO24_DLL,
+    ]
     for oiio_pyd in dist_root.rglob("OpenImageIO*.pyd"):
-        dests_24.append(oiio_pyd.parent / ocio24.name)
+        dests_24.append(oiio_pyd.parent / OIIO_OCIO24_DLL)
+    # Also next to flattened openimageio.dll (Nuitka lowercases some names)
+    for dll in dist_root.glob("[Oo]pen[Ii]mage[Ii][Oo]*.dll"):
+        dests_24.append(dll.parent / OIIO_OCIO24_DLL)
+
     _windows_copy_dll(ocio24, dests_24)
 
-    # Hard fail if OIIO is present but still missing its OCIO DLL.
-    for oiio_pyd in dist_root.rglob("OpenImageIO*.pyd"):
-        need = oiio_pyd.parent / ocio24.name
-        if not need.is_file() and not (dist_root / ocio24.name).is_file():
-            raise SystemExit(
-                f"fix_bundle_ocio: {ocio24.name} missing next to {oiio_pyd} "
-                f"and under {dist_root} — Windows OIIO will not load"
-            )
+    # Hard fail if still missing (case-insensitive check on Windows).
+    found = any(
+        p.is_file()
+        for p in dist_root.rglob("*")
+        if p.is_file() and p.name.lower() == OIIO_OCIO24_DLL.lower()
+    )
+    if not found:
+        raise SystemExit(f"fix_bundle_ocio: {OIIO_OCIO24_DLL} still missing under {dist_root}")
+    print(f"fix_bundle_ocio: verified {OIIO_OCIO24_DLL} present in Windows bundle")
+
+    # Cleanup staging dir if empty of other files
+    try:
+        if staging.is_dir():
+            for p in staging.iterdir():
+                p.unlink(missing_ok=True)
+            staging.rmdir()
+    except OSError:
+        pass
 
 
 def fix_bundle(root: Path) -> None:

--- a/scripts/oiio_ocio24.py
+++ b/scripts/oiio_ocio24.py
@@ -1,0 +1,164 @@
+"""Locate / fetch oiio-python's OpenColorIO_2_4.dll (Windows OIIO dependency).
+
+oiio-python's Windows wheel vendors ``PyOpenColorIO/OpenColorIO_2_4.dll``.
+Reinstalling the standalone ``opencolorio`` 2.5 package overwrites that tree and
+drops the DLL, so Nuitka builds then fail to LoadLibrary OpenImageIO.pyd.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+OIIO_OCIO24_DLL = "OpenColorIO_2_4.dll"
+
+
+def oiio_package_dir() -> Path | None:
+    try:
+        import OpenImageIO as oiio
+
+        return Path(oiio.__file__).resolve().parent
+    except Exception:
+        return None
+
+
+def _find_cached_oiio_wheel() -> Path | None:
+    roots: list[Path] = []
+    for key in ("UV_CACHE_DIR", "PIP_CACHE_DIR"):
+        v = os.environ.get(key)
+        if v:
+            roots.append(Path(v))
+    roots.extend(
+        [
+            Path.home() / ".cache" / "uv",
+            Path.home() / ".cache" / "pip",
+            Path(os.environ.get("LOCALAPPDATA", "")) / "uv" / "cache",
+            Path(os.environ.get("LOCALAPPDATA", "")) / "pip" / "Cache",
+        ]
+    )
+    hits: list[Path] = []
+    for root in roots:
+        if not root or not root.is_dir():
+            continue
+        try:
+            hits.extend(root.rglob("oiio_python-*.whl"))
+            hits.extend(root.rglob("oiio-python-*.whl"))
+        except OSError:
+            continue
+    if not hits:
+        return None
+    hits.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return hits[0]
+
+
+def _dll_from_zip(zf: zipfile.ZipFile) -> bytes | None:
+    for name in zf.namelist():
+        base = name.rsplit("/", 1)[-1]
+        if base.lower() == OIIO_OCIO24_DLL.lower():
+            return zf.read(name)
+    return None
+
+
+def _download_oiio_win_wheel_dll() -> bytes | None:
+    """Download the matching oiio-python Windows wheel from PyPI and extract the DLL."""
+    try:
+        import importlib.metadata as md
+
+        ver = md.version("oiio-python")
+    except Exception:
+        ver = "3.0.10.0.1"
+
+    try:
+        with urlopen(f"https://pypi.org/pypi/oiio-python/{ver}/json", timeout=60) as resp:
+            meta = json.load(resp)
+    except (URLError, OSError, json.JSONDecodeError) as e:
+        print(f"oiio_ocio24: PyPI metadata failed: {e}", file=sys.stderr)
+        return None
+
+    # Prefer cp313 win_amd64; fall back to any win_amd64 wheel for this version.
+    urls = meta.get("urls") or []
+    chosen = None
+    for u in urls:
+        fn = u.get("filename", "")
+        if "win_amd64" in fn and "cp313" in fn and fn.endswith(".whl"):
+            chosen = u
+            break
+    if chosen is None:
+        for u in urls:
+            fn = u.get("filename", "")
+            if "win_amd64" in fn and fn.endswith(".whl"):
+                chosen = u
+                break
+    if chosen is None:
+        print(f"oiio_ocio24: no win_amd64 wheel for oiio-python {ver}", file=sys.stderr)
+        return None
+
+    url = chosen["url"]
+    print(f"oiio_ocio24: downloading {chosen['filename']}")
+    try:
+        with urlopen(url, timeout=120) as resp:
+            data = resp.read()
+    except (URLError, OSError) as e:
+        print(f"oiio_ocio24: download failed: {e}", file=sys.stderr)
+        return None
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            dll = _dll_from_zip(zf)
+            if dll is None:
+                print("oiio_ocio24: DLL not inside wheel", file=sys.stderr)
+            return dll
+    except zipfile.BadZipFile as e:
+        print(f"oiio_ocio24: bad wheel: {e}", file=sys.stderr)
+        return None
+
+
+def read_ocio24_dll_bytes() -> bytes | None:
+    """Return OpenColorIO_2_4.dll contents, or None if unavailable."""
+    # 1) Already on disk under the env
+    for base in {Path(sys.prefix), Path(sys.base_prefix)}:
+        try:
+            for p in base.rglob(OIIO_OCIO24_DLL):
+                if p.is_file():
+                    return p.read_bytes()
+            # Case-insensitive fallback (Windows FS may store different casing)
+            for p in base.rglob("*"):
+                if p.is_file() and p.name.lower() == OIIO_OCIO24_DLL.lower():
+                    return p.read_bytes()
+        except OSError:
+            continue
+
+    # 2) uv/pip wheel cache
+    whl = _find_cached_oiio_wheel()
+    if whl is not None:
+        try:
+            with zipfile.ZipFile(whl) as zf:
+                dll = _dll_from_zip(zf)
+                if dll is not None:
+                    print(f"oiio_ocio24: extracted from cache {whl.name}")
+                    return dll
+        except (OSError, zipfile.BadZipFile) as e:
+            print(f"oiio_ocio24: cache wheel unreadable ({whl}): {e}", file=sys.stderr)
+
+    # 3) Download Windows wheel from PyPI (works on any host OS during CI)
+    return _download_oiio_win_wheel_dll()
+
+
+def materialize_ocio24_dll(dest_dir: Path) -> Path | None:
+    """Write OpenColorIO_2_4.dll into *dest_dir*; return the path or None."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / OIIO_OCIO24_DLL
+    if dest.is_file() and dest.stat().st_size > 0:
+        return dest
+    data = read_ocio24_dll_bytes()
+    if not data:
+        return None
+    dest.write_bytes(data)
+    print(f"oiio_ocio24: wrote {dest} ({len(data)} bytes)")
+    return dest


### PR DESCRIPTION
## Problem

Windows Release still failed after the previous fix:

```
ERROR: OpenColorIO_2_4.dll missing from Windows bundle
```

`fix_bundle_ocio` only found OpenColorIO **2.5** and never obtained the **2.4** DLL (gone from env after `ensure_ocio`, not in uv cache on the runner).

## Fix

- New `scripts/oiio_ocio24.py`: resolve DLL from env → uv/pip cache → **download oiio-python win_amd64 wheel from PyPI**
- `ensure_ocio` + `fix_bundle_ocio` use that helper
- Hard-fail if still missing after materialize
- Copy next to `OpenImageIO*.pyd`, `OpenImageIO/`, and dist root

## Test plan

- [ ] Windows Release: fix_bundle logs “verified OpenColorIO_2_4.dll present”
- [ ] Integration tests green on Windows