### PR TITLE
release: 0.5.2

### DIFF
--- a/.github/workflows/debug-windows-ocio.yml
+++ b/.github/workflows/debug-windows-ocio.yml
@@ -1,0 +1,89 @@
+# One-shot Windows diagnosis for OIIO / OCIO DLL packaging.
+# Run: gh workflow run "Debug Windows OCIO" --ref main
+name: Debug Windows OCIO
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install bundle deps
+        run: uv sync --group bundle
+
+      - name: Before ensure_ocio
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "=== PyOpenColorIO version ==="
+          uv run python -c "import PyOpenColorIO as o; print(o.GetVersion()); print(o.__file__)"
+          echo "=== OpenColorIO DLLs under site-packages ==="
+          find .venv -iname '*opencolorio*' -type f 2>/dev/null | head -50 || true
+          echo "=== OpenImageIO dir ==="
+          uv run python -c "import OpenImageIO as i, pathlib; print(pathlib.Path(i.__file__).parent); import os; print(os.listdir(pathlib.Path(i.__file__).parent)[:30])"
+
+      - name: ensure_ocio
+        run: uv run python scripts/ensure_ocio.py
+
+      - name: After ensure_ocio
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "=== PyOpenColorIO version ==="
+          uv run python -c "import PyOpenColorIO as o; print(o.GetVersion())"
+          echo "=== OpenColorIO_2_4 search ==="
+          find .venv -iname 'OpenColorIO_2_4.dll' -o -iname 'opencolorio_2_4.dll' 2>/dev/null || true
+          echo "=== materialize via oiio_ocio24 ==="
+          uv run python -c "
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, 'scripts')
+          from oiio_ocio24 import materialize_ocio24_dll, read_ocio24_dll_bytes, OIIO_OCIO24_DLL
+          b = read_ocio24_dll_bytes()
+          print('bytes', None if b is None else len(b))
+          p = materialize_ocio24_dll(Path('D:/a/exr-converter/exr-converter/.venv/Lib/site-packages/OpenImageIO'))
+          print('materialized', p)
+          "
+
+      - name: Import OpenImageIO after 2.4 restore
+        run: |
+          uv run python -c "import OpenImageIO as oiio; print('OIIO OK', oiio.VERSION_STRING)"
+
+      - name: Mini fake dist + fix_bundle_ocio
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Simulate Nuitka layout without full build
+          DIST=dist/main.dist
+          mkdir -p "$DIST/OpenImageIO" "$DIST/PyOpenColorIO"
+          # Copy pyds/dlls from venv as Nuitka roughly would
+          SITE=$(uv run python -c "import site; print(site.getsitepackages()[0])")
+          echo "SITE=$SITE"
+          cp -r "$SITE/OpenImageIO/"* "$DIST/OpenImageIO/" || true
+          cp -r "$SITE/PyOpenColorIO/"* "$DIST/PyOpenColorIO/" || true
+          # Flatten like Nuitka sometimes does
+          find "$DIST" -iname '*.dll' -exec cp -n {} "$DIST/" \; 2>/dev/null || true
+          echo "=== before fix_bundle ==="
+          find "$DIST" -iname '*ocio*' -o -iname '*openimage*' 2>/dev/null | sort
+          uv run python scripts/ensure_ocio.py
+          uv run python scripts/fix_bundle_ocio.py "$DIST"
+          echo "=== after fix_bundle ==="
+          find "$DIST" -iname '*ocio*' -o -iname '*openimage*' 2>/dev/null | sort
+          test -f "$DIST/OpenColorIO_2_4.dll" \
+            || find "$DIST" -iname 'OpenColorIO_2_4.dll' | grep -q . \
+            || { echo "FAIL: no 2_4 dll"; exit 1; }
+          echo "PASS: OpenColorIO_2_4.dll present"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,20 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-    # Prefer: gh workflow run Release --ref main -f tag=v0.5.1
-    # (runs workflow file from main; builds the given tag commit)
+    # Prefer: gh workflow run Release --ref main -f tag=v0.5.2
+    # Workflow *file* comes from --ref (use main). Source *code* is checked out
+    # from source_ref (default = tag). Re-dispatching an old tag without a new
+    # tag will NOT pick up packaging fixes that only exist on main.
     inputs:
       tag:
-        description: "Tag to release (e.g. v0.5.1). Required for manual / auto-tag dispatch."
+        description: "Release tag name (e.g. v0.5.2). Required for dispatch."
         required: true
         type: string
+      source_ref:
+        description: "Git ref to build (default: same as tag). Set to main only for emergency rebuilds."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -29,8 +36,10 @@ permissions:
 env:
   NUITKA_ASSUME_YES_FOR_DOWNLOADS: "1"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  # Tag push → github.ref_name; workflow_dispatch → inputs.tag
+  # Published version / GitHub Release name
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  # Code to build (must contain packaging scripts for that release)
+  RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && (inputs.source_ref != '' && inputs.source_ref || inputs.tag) || github.ref_name }}
 
 jobs:
   # ── Quality gate (must pass before build / sign / publish) ────────────────
@@ -39,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ env.RELEASE_REF }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -68,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ env.RELEASE_REF }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -139,7 +148,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ env.RELEASE_REF }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -170,7 +179,7 @@ jobs:
         shell: bash
         run: |
           VERSION="${RELEASE_TAG#v}"
-          echo "Building version ${VERSION} (tag ${RELEASE_TAG})"
+          echo "Building version ${VERSION} (tag ${RELEASE_TAG}, source ${RELEASE_REF})"
           sed -i.bak "s/^APP_VERSION = \"[^\"]*\"/APP_VERSION = \"${VERSION}\"/" src/core/constants.py
           rm -f src/core/constants.py.bak
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,19 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+---
+
+## [0.5.2] — 2026-08-06
+
 ### Fixed
 
-- **CI/CD chain after merge:** tags created by Actions with `GITHUB_TOKEN` do not
-  start other workflows. Auto-tag now **dispatches** the Release workflow
-  (`workflow_dispatch` on the tag) after tagging, and re-dispatches if a tag
-  exists but no GitHub Release was published yet.
-- **Windows Nuitka / OpenImageIO LoadLibrary:** reinstalling OpenColorIO 2.5
-  removed oiio-python’s `OpenColorIO_2_4.dll`, so `OpenImageIO.pyd` failed with
-  “The specified module could not be found.” `ensure_ocio` /
-  `fix_bundle_ocio` now restore that DLL (from env, uv cache, or **PyPI
-  oiio-python wheel download**) next to OIIO while keeping app OCIO on 2.5.
+- **Windows Nuitka OpenImageIO LoadLibrary:** ship `OpenColorIO_2_4.dll` for OIIO
+  (from env/cache or PyPI oiio-python wheel) while app OCIO stays on **2.5**.
+  Re-running Release for `v0.5.1` kept failing because that tag predates the fix;
+  packaging scripts live on the **tag commit** that is built.
+- **CI/CD chain after merge:** Auto-tag dispatches Release via `workflow_dispatch`
+  (`GITHUB_TOKEN` tag pushes do not start other workflows).
+- Release dispatch documents `source_ref` for emergency rebuilds from another ref.
 
 ---
 
@@ -41,6 +43,7 @@ rolling the `[Unreleased]` section into a versioned heading.
   the combo but are **greyed out** with a tooltip explaining why.
 - Bundled ACES Studio no longer silently falls back to a library config on version
   mismatch (status matched convert failures).
+- Note: Windows OIIO DLL packaging for this release was incomplete; use **0.5.2+**.
 
 ---
 
@@ -213,7 +216,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/derek-rein/exr-converter/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/derek-rein/exr-converter/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/derek-rein/exr-converter/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/derek-rein/exr-converter/compare/v0.3.0...v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.5.1"
+version = "0.5.2"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.5.1"
+APP_VERSION = "0.5.2"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.5.1"
+version = "0.5.2"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Why 0.5.2 (not another v0.5.1 re-run)

Release checks out **the tag commit**. Re-dispatching `tag=v0.5.1` always builds
the old tree without the PyPI `OpenColorIO_2_4.dll` fetch — which is why Windows
kept failing with the same log.

## This release

- Windows: restore/fetch `OpenColorIO_2_4.dll` for OIIO; app OCIO stays 2.5
- Release: `source_ref` input + clearer docs
- Debug workflow for Windows OCIO (optional)

## After merge

Auto-tag → `v0.5.2` → Release with **this** commit as source.