### PR TITLE
release: 0.5.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,8 +308,11 @@ Branch protection on `main` should require `ci-ok`.
 | [AGENTS.md](./AGENTS.md) | This file — agent/process context, release & deploy |
 | [CHANGELOG.md](./CHANGELOG.md) | User-facing history (**must update**) |
 | [README.md](./README.md) | Product overview, install, CLI |
+| [docs/cli.md](./docs/cli.md) | CLI + GUI launch flags |
+| [docs/nuke.md](./docs/nuke.md) | Nuke menu integration |
 | [docs/plan-12bit-prores-oxideav.md](./docs/plan-12bit-prores-oxideav.md) | Future 12-bit ProRes plan (not implemented) |
 | [docs/releasing.md](./docs/releasing.md) | Stub pointing here (release process lives in AGENTS.md) |
+| [integrations/nuke/](./integrations/nuke/) | Nuke `menu.py` + helpers |
 
 ## What not to do
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.5.3] — 2026-08-06
+
+### Added
+
+- **CLI / GUI launch docs:** richer `-h` epilog; [docs/cli.md](docs/cli.md);
+  README links.
+- **GUI launch flags:** `--open`, `--gui-ocio`, `--mode` pre-fill media and OCIO
+  when starting the app (no convert subcommand).
+- **Nuke integration:** [integrations/nuke/](integrations/nuke/) menu script to
+  open the selected Read with session OCIO; [docs/nuke.md](docs/nuke.md).
+- **Slate thumbnail frame** preference (first / middle / last), integer in
+  QSettings, editable under File → Preferences.
+
+### Fixed
+
+- **Slate thumbnail extraction (EXR → video only):** pick first/mid/last from the
+  known EXR frame list (no video seek). OCIO ``src → slate authoring (sRGB)`` when
+  a config is available; QImage buffer ownership / JPEG encode fixed. Video → EXR
+  never uses slate/burn-in/watermark.
+- **GUI `--open` / Nuke launch:** no longer overwritten by deferred QSettings
+  input restore.
+- **CLI `--workers`:** works before or after the subcommand.
+
+---
+
 ## [0.5.2] — 2026-08-06
 
 ### Fixed
@@ -216,7 +241,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/derek-rein/exr-converter/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/derek-rein/exr-converter/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/derek-rein/exr-converter/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/derek-rein/exr-converter/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ Enable the **Prepend slate** checkbox to add a 1-frame slate image before the co
 
 ## CLI
 
-Use the `video2exr` or `exr2video` subcommand.
+**Full reference:** [docs/cli.md](docs/cli.md)  
+**Nuke menu (open Read + session OCIO):** [docs/nuke.md](docs/nuke.md)
+
+Use the `video2exr` or `exr2video` subcommand to convert, or run with **no**
+subcommand to open the GUI (optionally with `--open` / `--gui-ocio`).
 
 **Video → EXR**
 
@@ -68,21 +72,33 @@ uv run python main.py video2exr -i clip.mov -o ./exr_out/
 **EXR → video**
 
 ```bash
-uv run python main.py exr2video -i "./plate.####.exr" -o review.mov --fps 24
+uv run python main.py exr2video -i ./plate -o review.mov --fps 24
+# or any frame file from the sequence:
+uv run python main.py exr2video -i ./plate/plate.1001.exr -o review.mov --fps 24
 ```
 
-Common options:
+**GUI with path pre-loaded** (also used by the Nuke integration)
+
+```bash
+uv run python main.py --open ./plate --gui-ocio "$OCIO" --mode exr2video
+```
+
+Common convert options:
 
 | Option | Applies to | Notes |
 |--------|------------|--------|
-| `--ocio PATH` | both | OCIO config file (overrides `$OCIO`) |
-| `--src` / `--dst` | both | OCIO display / scene color space names |
+| `--ocio PATH` | both convert commands | OCIO config file (overrides `$OCIO`) |
+| `--src` / `--dst` | both | OCIO color space names |
 | `--workers N` | both | `0` = auto, `1` = single-threaded |
 | `--scale FACTOR` | both | e.g. `0.5` for half resolution |
 | `--exr-compression NAME` | `video2exr` | e.g. `dwaa`, `zip`, `none` (see `--help`) |
-| `--codec KEY` | `exr2video` | Full ladder with honest bit depths: ProRes Proxy…XQ (software = 10-bit encode), DNxHR LB…444, CineForm 10/12-bit, HEVC 8/10/12-bit, H.264, FFV1 10/12-bit. **VideoToolbox ProRes** (`prores_vt_*`) is **macOS-only**; VT 4444/XQ are ~12-bit. |
+| `--codec KEY` | `exr2video` | ProRes / DNxHR / CineForm / HEVC / H.264 / FFV1 — see [docs/cli.md](docs/cli.md) for bit-depth notes |
 
-Run `uv run python main.py video2exr --help` or `exr2video --help` for the full list.
+```bash
+uv run python main.py --help
+uv run python main.py video2exr --help
+uv run python main.py exr2video --help
+```
 
 ## Requirements (running from source)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,163 @@
+# EXR Converter — CLI reference
+
+Command-line interface for **video ↔ OpenEXR** conversion with **OpenColorIO**.
+The same entry point launches the **GUI** when no convert subcommand is given.
+
+```bash
+# From a source checkout
+uv run python main.py --help
+uv run python main.py video2exr --help
+uv run python main.py exr2video --help
+
+# Packaged binary (examples)
+exr_converter --help
+"/Applications/EXR Converter.app/Contents/MacOS/exr_converter" --help
+```
+
+Related: [Nuke integration](./nuke.md) · [README](../README.md)
+
+---
+
+## Modes
+
+| Invocation | What it does |
+|------------|----------------|
+| `main.py` *(no subcommand)* | Open the GUI |
+| `main.py video2exr …` | CLI: video → OCIO → EXR sequence |
+| `main.py exr2video …` | CLI: EXR sequence → OCIO → video |
+
+Global flags (before the subcommand):
+
+| Flag | Meaning |
+|------|---------|
+| `--workers N` | CLI convert parallelism (`0` = auto, `1` = serial). May appear **before** the subcommand or **after** it. |
+| `--smoke-test` | CI: launch GUI briefly and exit |
+| `--open PATH` | **GUI only:** open this media on launch |
+| `--gui-ocio PATH` | **GUI only:** load this OCIO config on launch |
+| `--mode auto\|video2exr\|exr2video` | **GUI only:** which tab (`auto` from `--open`) |
+
+---
+
+## GUI launch (for shells & Nuke)
+
+```bash
+# Open GUI with an EXR sequence already loaded (EXR → Video tab)
+uv run python main.py --open "/show/shot/plate.####.exr"
+
+# Force Video → EXR tab + custom OCIO
+uv run python main.py --open /path/clip.mov --mode video2exr \
+  --gui-ocio /path/to/config.ocio
+
+# Packaged app
+open -a "EXR Converter" --args --open "/path/to/seq" --gui-ocio "$OCIO"
+# or call the binary directly:
+"/Applications/EXR Converter.app/Contents/MacOS/exr_converter" \
+  --open "/path/to/seq" --gui-ocio "/path/to/config.ocio" --mode exr2video
+```
+
+OCIO resolution for the GUI when `--gui-ocio` is set: **custom file** source
+(same as picking a config in the UI). Otherwise the app uses its saved preference
+/ bundled ACES Studio / `$OCIO` as usual.
+
+For a one-click Nuke menu that fills these in from a **Read** node, see
+[nuke.md](./nuke.md).
+
+---
+
+## `video2exr` — video → EXR
+
+```bash
+uv run python main.py video2exr -i plate.mov
+uv run python main.py video2exr -i plate.mov -o /tmp/exr_out --exr-compression zip
+uv run python main.py video2exr -i plate.mov --frame-range 1-100 --workers 4
+```
+
+| Option | Default | Notes |
+|--------|---------|--------|
+| `-i` / `--input` | *(required)* | Input video file |
+| `-o` / `--output-dir` | `<input_dir>/<stem>/` | Directory for EXR frames |
+| `--ocio` | bundled / `$OCIO` | Config file path |
+| `--src` | auto | Source color space (probe + aliases) |
+| `--dst` | ACEScg / scene_linear | Destination scene space |
+| `--exr-compression` | `dwaa` | `none`, `rle`, `zip`, `zips`, `piz`, `pxr24`, `b44`, `b44a`, `dwaa`, `dwab` |
+| `--dwa-level` | library | DWA level for `dwaa`/`dwab` (`0` = lossless) |
+| `--zip-level` | library | ZIP level 1–9 for `zip`/`zips` |
+| `--scale` | `1.0` | e.g. `0.5` half-res |
+| `--padding` | `4` | Frame zero-pad width |
+| `--start-frame` | `1001` | First output frame number |
+| `--frame-range` | all | Nuke-style, e.g. `1-100`, `1-50x2` |
+| `--deinterlace` | `auto` | `auto` / `on` / `off` |
+
+**Output naming:** `stem.####.exr` inside the output directory (pad width from
+`--padding`).
+
+---
+
+## `exr2video` — EXR → video
+
+```bash
+uv run python main.py exr2video -i ./plate
+uv run python main.py exr2video -i ./plate -o review.mov --fps 24
+uv run python main.py exr2video -i ./plate/plate.1001.exr -o review.mov --fps 24
+uv run python main.py exr2video -i ./plate --codec h264 --crf 18
+```
+
+| Option | Default | Notes |
+|--------|---------|--------|
+| `-i` / `--input` | *(required)* | Sequence **directory** or any **existing frame** from the sequence (not a literal `####` string) |
+| `-o` / `--output` | next to sequence | Video path; extension follows codec if omitted |
+| `--fps` | `24` | Frame rate |
+| `--ocio` | bundled / `$OCIO` | Config file path |
+| `--src` | EXR meta / scene_linear | Scene-linear source space |
+| `--dst` | display Rec.709 | Display / delivery space |
+| `--scale` | `1.0` | Output scale |
+| `--codec` | platform default | See codec ladder below |
+| `--crf` | codec default | H.264 / HEVC quality |
+| `--preset` | codec default | x264 / x265 preset |
+| `--frame-range` | all | e.g. `1001-1100` |
+
+### Codecs (honest bit depths)
+
+| Key pattern | Notes |
+|-------------|--------|
+| `prores_*` (software) | FFmpeg `prores_ks` — **10-bit** encode (not true 12-bit) |
+| `prores_vt_*` | **macOS only** VideoToolbox; 4444/XQ ~12-bit |
+| `dnxhr_*` | DNxHR LB…444 |
+| CineForm keys | 10 / 12-bit variants |
+| `h264`, `hevc`, `hevc_8`, `hevc_12` | Delivery; CRF/preset apply |
+| `ffv1`, `ffv1_12` | Archival FFV1 |
+
+List available keys on your build:
+
+```bash
+uv run python main.py exr2video --help
+```
+
+---
+
+## Color management notes
+
+- **Transforms** are applied with **PyOpenColorIO** (not OIIO’s colorconvert).
+- Omitted `--src` / `--dst` use probing + role fallbacks and
+  `find_equivalent_space` so names still resolve across configs.
+- Packaged app needs **OpenColorIO 2.5+** for the bundled ACES Studio v4 config.
+  From source: `make ensure-ocio` if OIIO rewired you to 2.4.
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Convert / argument / codec error |
+| `2` | Smoke test: OCIO runtime &lt; 2.5 |
+| `3` | Smoke test: bundled config failed to load |
+
+---
+
+## See also
+
+- `main.py --help`, `video2exr --help`, `exr2video --help` (always current)
+- [Nuke integration](./nuke.md)
+- [Releasing](../AGENTS.md#releasing-and-deployment)

--- a/docs/nuke.md
+++ b/docs/nuke.md
@@ -1,0 +1,113 @@
+# EXR Converter — Nuke integration
+
+Launch **EXR Converter** from Nuke with:
+
+- the selected **Read** node’s file path (or the node under the cursor), and  
+- this Nuke session’s **OCIO config** path when available.
+
+Scripts live under [`integrations/nuke/`](../integrations/nuke/).
+
+---
+
+## Install
+
+### 1. Point at the app (optional but recommended)
+
+Set an environment variable to the **binary** (not only the `.app` wrapper):
+
+```bash
+# macOS app bundle binary
+export EXR_CONVERTER="/Applications/EXR Converter.app/Contents/MacOS/exr_converter"
+
+# or a source checkout
+export EXR_CONVERTER="/path/to/exr-converter/.venv/bin/python"
+export EXR_CONVERTER_ARGS="/path/to/exr-converter/main.py"   # optional second token
+```
+
+If `EXR_CONVERTER` is unset, the script probes common install locations
+(`/Applications/EXR Converter.app/…`, `exr_converter` on `PATH`, etc.).
+
+### 2. Load the menu
+
+**Option A — drop into `~/.nuke`**
+
+```bash
+cp integrations/nuke/exr_converter_nuke.py ~/.nuke/
+cp integrations/nuke/menu.py ~/.nuke/exr_converter_menu.py
+```
+
+Ensure `~/.nuke/menu.py` imports it (create or append):
+
+```python
+try:
+    import exr_converter_menu  # noqa: F401
+except ImportError:
+    pass
+```
+
+**Option B — `NUKE_PATH` plugin folder**
+
+```text
+$NUKE_PATH/
+  exr_converter_nuke.py
+  menu.py          # contents of integrations/nuke/menu.py
+```
+
+Restart Nuke. You should see:
+
+**Nuke menu → EXR Converter → Open selected Read…**
+
+Also under **Nodes → EXR Converter** for discoverability.
+
+---
+
+## Usage
+
+1. Select a **Read** (or leave nothing selected and run the command with a
+   single Read selected in the DAG).
+2. **EXR Converter → Open selected Read…**
+3. The GUI opens on **EXR → Video** with that path and Nuke’s OCIO config
+   pre-selected (when a real `.ocio` path can be resolved).
+
+Video Reads open the **Video → EXR** tab instead.
+
+---
+
+## What gets passed
+
+```text
+exr_converter --open <read file> --gui-ocio <config.ocio> --mode exr2video|video2exr
+```
+
+| Source | Knob / logic |
+|--------|----------------|
+| Media path | Read `file` knob (evaluated), sequence-friendly |
+| OCIO | Root `customOCIOConfigPath` when set and on disk; else `$OCIO`; else omit (app default) |
+| Mode | `.exr` / sequence → `exr2video`; common video extensions → `video2exr` |
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Menu missing | Confirm `menu.py` is loaded; check Script Editor for import errors |
+| “Could not find EXR Converter” | Set `EXR_CONVERTER` to the binary path |
+| Wrong OCIO | Set a custom OCIO path on the Nuke root, or `export OCIO=/path/config.ocio` before Nuke |
+| App opens but empty input | Path may not expand (relative/missing frames); use an absolute evaluated path on the Read |
+
+---
+
+## API (for custom tools)
+
+```python
+import exr_converter_nuke as ecn
+
+# Selected node(s)
+ecn.open_selected_read()
+
+# Explicit path
+ecn.launch(open_path="/show/shot/plate.%04d.exr", ocio_path="/configs/studio.ocio")
+```
+
+See module docstrings in `exr_converter_nuke.py`.

--- a/integrations/nuke/exr_converter_nuke.py
+++ b/integrations/nuke/exr_converter_nuke.py
@@ -1,0 +1,235 @@
+"""Nuke helpers: open EXR Converter with a Read path + session OCIO.
+
+Install
+-------
+Copy this file (and ``menu.py``) onto ``NUKE_PATH`` or into ``~/.nuke``, then
+restart Nuke. See ``docs/nuke.md``.
+
+Environment
+-----------
+``EXR_CONVERTER``
+    Path to the ``exr_converter`` binary, or to ``python`` if launching from source.
+``EXR_CONVERTER_ARGS``
+    Optional extra argument inserted after the binary (e.g. path to ``main.py``
+    when ``EXR_CONVERTER`` is a Python interpreter).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import nuke
+except ImportError:  # allow import outside Nuke for tooling
+    nuke = None  # type: ignore[assignment]
+
+_VIDEO_EXTS = {
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".avi",
+    ".mxf",
+    ".webm",
+    ".m4v",
+    ".ts",
+    ".mpg",
+    ".mpeg",
+}
+
+
+def _message(msg: str) -> None:
+    if nuke is not None:
+        nuke.message(msg)
+    else:
+        print(msg, file=sys.stderr)
+
+
+def find_exr_converter_command() -> list[str]:
+    """Return argv prefix to launch EXR Converter, or raise FileNotFoundError."""
+    env = os.environ.get("EXR_CONVERTER", "").strip()
+    extra = os.environ.get("EXR_CONVERTER_ARGS", "").strip()
+    candidates: list[str] = []
+    if env:
+        candidates.append(env)
+
+    # Common install locations
+    candidates.extend(
+        [
+            "/Applications/EXR Converter.app/Contents/MacOS/exr_converter",
+            str(Path.home() / "Applications/EXR Converter.app/Contents/MacOS/exr_converter"),
+            "exr_converter",
+        ]
+    )
+    # Windows-style
+    pf = os.environ.get("ProgramFiles", r"C:\Program Files")
+    candidates.append(str(Path(pf) / "EXR Converter" / "exr_converter.exe"))
+
+    for c in candidates:
+        p = Path(c).expanduser()
+        if p.is_file() or (c == "exr_converter"):  # allow PATH lookup
+            cmd = [str(p) if p.is_file() else c]
+            if extra:
+                # Support a single path (main.py) or shell-split later if needed
+                cmd.append(extra)
+            # PATH name: verify with which-like check only for bare name
+            if p.is_file():
+                return cmd
+            # bare command on PATH
+            from shutil import which
+
+            hit = which(c)
+            if hit:
+                out = [hit]
+                if extra:
+                    out.append(extra)
+                return out
+
+    raise FileNotFoundError(
+        "Could not find EXR Converter.\n\n"
+        "Set EXR_CONVERTER to the binary, e.g.\n"
+        '  export EXR_CONVERTER="/Applications/EXR Converter.app/Contents/MacOS/exr_converter"'
+    )
+
+
+def get_nuke_ocio_path() -> str:
+    """Best-effort path to this Nuke session's OCIO config file."""
+    if nuke is None:
+        return os.environ.get("OCIO", "") or ""
+
+    root = nuke.root()
+    # Prefer an explicit custom file on the root.
+    for knob_name in (
+        "customOCIOConfigPath",
+        "OCIO_config",
+        "ocioConfigPath",
+    ):
+        try:
+            kn = root[knob_name]
+        except (NameError, KeyError, ValueError):
+            continue
+        try:
+            val = kn.value()
+        except Exception:
+            continue
+        if not val:
+            continue
+        path = Path(str(val)).expanduser()
+        if path.is_file():
+            return str(path)
+
+    env = os.environ.get("OCIO", "")
+    if env and Path(env).expanduser().is_file():
+        return str(Path(env).expanduser())
+    return ""
+
+
+def _evaluate_read_file(node) -> str:
+    """Return the evaluated file path from a Read (or similar) node."""
+    try:
+        kn = node["file"]
+    except Exception as e:
+        raise RuntimeError(f"Node has no 'file' knob: {node.name()}") from e
+    # Prefer evaluate() so frame tokens expand where possible.
+    try:
+        path = kn.evaluate()
+    except Exception:
+        path = kn.value()
+    return str(path or "").strip()
+
+
+def guess_mode(path: str) -> str:
+    """Return ``exr2video`` or ``video2exr`` from *path*."""
+    p = Path(path.split()[0] if path else "")
+    # Sequence patterns: plate.%04d.exr / plate.####.exr
+    name = p.name.lower()
+    if ".exr" in name or p.suffix.lower() == ".exr":
+        return "exr2video"
+    if p.suffix.lower() in _VIDEO_EXTS:
+        return "video2exr"
+    if p.is_dir():
+        return "exr2video"
+    return "exr2video"
+
+
+def launch(
+    open_path: str | None = None,
+    ocio_path: str | None = None,
+    mode: str | None = None,
+) -> None:
+    """Spawn EXR Converter (non-blocking)."""
+    cmd = find_exr_converter_command()
+    if open_path:
+        cmd.extend(["--open", open_path])
+    if ocio_path:
+        cmd.extend(["--gui-ocio", ocio_path])
+    if mode and mode != "auto":
+        cmd.extend(["--mode", mode])
+
+    try:
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError as e:
+        _message(f"Failed to launch EXR Converter:\n{e}\n\nCommand:\n{' '.join(cmd)}")
+        return
+
+    # Soft log in Nuke's script editor
+    try:
+        nuke.tprint("EXR Converter: " + " ".join(cmd))
+    except Exception:
+        pass
+
+
+def open_selected_read() -> None:
+    """Open the selected Read (or sole selected node with a file knob) in EXR Converter."""
+    if nuke is None:
+        _message("This command must be run inside Nuke.")
+        return
+
+    nodes = [n for n in nuke.selectedNodes() if n.Class() in ("Read", "ReadGeo", "DeepRead")]
+    if not nodes:
+        # Any selected node with a file knob
+        nodes = [n for n in nuke.selectedNodes() if "file" in n.knobs()]
+    if not nodes:
+        _message("Select a Read node (or a node with a file path) first.")
+        return
+    if len(nodes) > 1:
+        # Use the first; still useful in multi-select
+        pass
+
+    node = nodes[0]
+    try:
+        path = _evaluate_read_file(node)
+    except RuntimeError as e:
+        _message(str(e))
+        return
+    if not path:
+        _message(f"{node.name()}: empty file path.")
+        return
+
+    ocio = get_nuke_ocio_path()
+    mode = guess_mode(path)
+    launch(open_path=path, ocio_path=ocio or None, mode=mode)
+
+
+def open_this_read() -> None:
+    """Callback for a knob on a Read — uses ``nuke.thisNode()``."""
+    if nuke is None:
+        return
+    node = nuke.thisNode()
+    try:
+        path = _evaluate_read_file(node)
+    except RuntimeError as e:
+        _message(str(e))
+        return
+    if not path:
+        _message(f"{node.name()}: empty file path.")
+        return
+    ocio = get_nuke_ocio_path()
+    launch(open_path=path, ocio_path=ocio or None, mode=guess_mode(path))

--- a/integrations/nuke/menu.py
+++ b/integrations/nuke/menu.py
@@ -1,0 +1,52 @@
+"""Nuke menu registration for EXR Converter.
+
+Copy to ~/.nuke/exr_converter_menu.py (and import from ~/.nuke/menu.py),
+or place on NUKE_PATH as menu.py next to exr_converter_nuke.py.
+
+See docs/nuke.md.
+"""
+
+from __future__ import annotations
+
+import nuke
+
+try:
+    import exr_converter_nuke as exr_converter_nuke
+except ImportError:
+    # Same folder load when this file is named menu.py on NUKE_PATH
+    import os
+    import sys
+
+    _here = os.path.dirname(os.path.abspath(__file__))
+    if _here not in sys.path:
+        sys.path.insert(0, _here)
+    import exr_converter_nuke as exr_converter_nuke  # type: ignore
+
+# Keep module bound so Nuke menu callbacks resolve the name.
+assert exr_converter_nuke is not None
+
+
+def _register() -> None:
+    menubar = nuke.menu("Nuke")
+    m = menubar.addMenu("EXR Converter")
+    m.addCommand(
+        "Open selected Read…",
+        "exr_converter_nuke.open_selected_read()",
+        shortcut="",
+    )
+    m.addCommand(
+        "Open EXR Converter only…",
+        "exr_converter_nuke.launch()",
+    )
+
+    # Nodes menu (discoverability next to other tools)
+    try:
+        nuke.menu("Nodes").addCommand(
+            "EXR Converter/Open selected Read…",
+            "exr_converter_nuke.open_selected_read()",
+        )
+    except Exception:
+        pass
+
+
+_register()

--- a/main.py
+++ b/main.py
@@ -33,6 +33,12 @@ def main() -> int:
     app.setWindowIcon(QIcon(":/icon.png"))
 
     win = MainWindow()
+    # Nuke / shell launch: pre-fill media + OCIO before the event loop runs.
+    open_path = getattr(args, "open", None)
+    gui_ocio = getattr(args, "gui_ocio", None)
+    mode = getattr(args, "mode", None)
+    if open_path or gui_ocio or (mode and mode != "auto"):
+        win.apply_startup(open_path=open_path, ocio_path=gui_ocio, mode=mode)
     win.show()
 
     if args.smoke_test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.5.2"
+version = "0.5.3"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/cli.py
+++ b/src/cli.py
@@ -37,19 +37,58 @@ from .core.ocio_utils import find_equivalent_space, resolve_ocio_for_cli
 _CODEC_KEYS = [spec.key for spec in available_video_codecs()]
 
 _EPILOG = """\
-examples:
+usage modes
+  (no subcommand)     Launch the GUI
+  video2exr           Video → OCIO → EXR sequence (CLI convert)
+  exr2video           EXR sequence → OCIO → video (CLI convert)
+
+GUI launch (no subcommand)
+  %(prog)s
+  %(prog)s --open /path/to/plate.####.exr
+  %(prog)s --open /path/to/clip.mov --mode video2exr
+  %(prog)s --open /path/to/exrs --gui-ocio /path/to/config.ocio
+
+CLI convert examples
   %(prog)s video2exr -i plate.mov
       → ./plate/plate.####.exr  (Rec.709-ish → ACEScg, DWAA EXR)
 
   %(prog)s exr2video -i ./plate
-      → ./plate.mov  (scene-linear → Rec.709 display, ProRes)
+      → ./plate.mov  (scene-linear → Rec.709 display, default codec)
 
   %(prog)s video2exr -i plate.mov -o /tmp/out --frame-range 1-100
-  %(prog)s exr2video -i ./plate -o review.mp4 --codec h264
+  %(prog)s exr2video -i ./plate -o review.mp4 --codec h264 --fps 24
 
-Color spaces default to auto (probe + OCIO-aware equivalents). Pass --src / --dst
-only when you need an override. OCIO defaults to the bundled ACES Studio config
-(or $OCIO if set).
+Color / OCIO
+  Defaults: probe + OCIO-aware equivalents for --src/--dst when omitted.
+  Config:   --ocio PATH  (CLI) or --gui-ocio PATH (GUI), else $OCIO, else
+            bundled ACES Studio Config v4.
+
+Full docs: docs/cli.md
+Nuke menu: integrations/nuke/  (see docs/nuke.md)
+"""
+
+_V2E_EPILOG = """\
+examples:
+  %(prog)s -i plate.mov
+  %(prog)s -i plate.mov -o /tmp/exr_out --exr-compression zip
+  %(prog)s -i plate.mov --src "sRGB Encoded Rec.709 (sRGB)" --dst ACEScg
+  %(prog)s -i plate.mov --frame-range 1-100 --deinterlace auto
+  %(prog)s -i plate.mov --ocio /path/to/config.ocio --workers 4
+
+Omit -o to write <input_parent>/<stem>/<stem>.####.exr
+See docs/cli.md for the full option list.
+"""
+
+_E2V_EPILOG = """\
+examples:
+  %(prog)s -i ./plate
+  %(prog)s -i "./plate.####.exr" -o review.mov --fps 24
+  %(prog)s -i ./plate --codec prores --src ACEScg --dst "Output - Rec.709"
+  %(prog)s -i ./plate --codec h264 --crf 18 --preset medium
+  %(prog)s -i ./plate --frame-range 1001-1100 --ocio /path/to/config.ocio
+
+Omit -o to write <parent>/<dirname>.mov (extension follows codec).
+See docs/cli.md for codecs and bit-depth notes.
 """
 
 
@@ -81,7 +120,10 @@ def _resolve_config_source(ocio_arg: str | None) -> tuple[str, str]:
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        description=("Convert between video and EXR with OCIO — simpler happy-path than ffmpeg."),
+        description=(
+            "EXR Converter — GUI and CLI for video ↔ OpenEXR with OpenColorIO.\n"
+            "Run with no subcommand to open the GUI; use video2exr / exr2video to convert."
+        ),
         epilog=_EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -89,13 +131,34 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--smoke-test",
         action="store_true",
-        help="Launch the GUI, verify it initializes, then exit.",
+        help="Launch the GUI, verify it initializes, then exit (CI).",
     )
     p.add_argument(
         "--workers",
+        dest="workers_global",
         type=int,
         default=0,
-        help="Parallel workers (0=auto, 1=serial). Default: auto.",
+        help="CLI convert: parallel workers (0=auto, 1=serial). Default: auto. "
+        "May also be passed after the subcommand.",
+    )
+    # GUI-only launch helpers (ignored when a convert subcommand is used).
+    p.add_argument(
+        "--open",
+        metavar="PATH",
+        default=None,
+        help="GUI: open this video / EXR sequence / folder on launch.",
+    )
+    p.add_argument(
+        "--gui-ocio",
+        metavar="PATH",
+        default=None,
+        help="GUI: load this OCIO config file on launch (overrides saved preference).",
+    )
+    p.add_argument(
+        "--mode",
+        choices=["auto", "video2exr", "exr2video"],
+        default="auto",
+        help="GUI: which tab to show (default: auto from --open).",
     )
     sub = p.add_subparsers(dest="command")
 
@@ -104,7 +167,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Video → OCIO → EXR sequence.",
         description="Decode video, apply OCIO, write an EXR sequence.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="Omit -o to write <input_parent>/<stem>/<stem>.####.exr",
+        epilog=_V2E_EPILOG,
     )
     v2e.add_argument("-i", "--input", required=True, help="Input video file")
     v2e.add_argument(
@@ -171,19 +234,26 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["auto", "on", "off"],
         help="Deinterlace (default: auto)",
     )
+    v2e.add_argument(
+        "--workers",
+        dest="workers_local",
+        type=int,
+        default=None,
+        help="Parallel workers (0=auto, 1=serial). Overrides global --workers.",
+    )
 
     e2v = sub.add_parser(
         "exr2video",
         help="EXR sequence → OCIO → video.",
         description="Read an EXR sequence, apply OCIO, encode a video file.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="Omit -o to write <parent>/<dirname>.mov next to the sequence.",
+        epilog=_E2V_EPILOG,
     )
     e2v.add_argument(
         "-i",
         "--input",
         required=True,
-        help="EXR sequence directory, frame, or pattern",
+        help="EXR sequence directory or any existing frame file from the sequence",
     )
     e2v.add_argument(
         "-o",
@@ -235,6 +305,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--frame-range",
         default="",
         help="Nuke-style range (e.g. 1001-1100). Default: all frames",
+    )
+    e2v.add_argument(
+        "--workers",
+        dest="workers_local",
+        type=int,
+        default=None,
+        help="Parallel workers (0=auto, 1=serial). Overrides global --workers.",
     )
 
     return p
@@ -440,6 +517,14 @@ def run_cli(args: argparse.Namespace) -> int:
     def _log(msg: str) -> None:
         print(msg, file=sys.stderr)
 
+    # Subcommand --workers overrides parent global.
+    workers_local = getattr(args, "workers_local", None)
+    workers = (
+        int(workers_local)
+        if workers_local is not None
+        else int(getattr(args, "workers_global", 0) or 0)
+    )
+
     try:
         cfg = resolve_ocio_for_cli(args.ocio)
         cs, cp = _resolve_config_source(args.ocio)
@@ -475,7 +560,7 @@ def run_cli(args: argparse.Namespace) -> int:
                 progress=_progress,
                 log=_log,
                 compression=args.exr_compression,
-                workers=args.workers,
+                workers=workers,
                 config_source=cs,
                 config_path=cp,
                 scale=args.scale,
@@ -518,7 +603,7 @@ def run_cli(args: argparse.Namespace) -> int:
                 args.fps,
                 progress=_progress,
                 log=_log,
-                workers=args.workers,
+                workers=workers,
                 config_source=cs,
                 config_path=cp,
                 scale=args.scale,

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.5.2"
+APP_VERSION = "0.5.3"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/gui/preferences.py
+++ b/src/gui/preferences.py
@@ -11,9 +11,11 @@ from PySide6.QtCore import QSettings, Qt, QUrl
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QButtonGroup,
+    QComboBox,
     QDialog,
     QDialogButtonBox,
     QFileDialog,
+    QFormLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
@@ -28,9 +30,20 @@ from PySide6.QtWidgets import (
 # QSettings keys
 PLAYER_MODE_KEY = "player/mode"
 PLAYER_PATH_KEY = "player/path"
+THUMBNAIL_FRAME_KEY = "slate/thumbnail_frame"
 
 PLAYER_MODE_SYSTEM = "system"
 PLAYER_MODE_CUSTOM = "custom"
+
+# Integer prefs for which source frame becomes the slate thumbnail.
+THUMBNAIL_FRAME_FIRST = 0
+THUMBNAIL_FRAME_MID = 1
+THUMBNAIL_FRAME_LAST = 2
+THUMBNAIL_FRAME_CHOICES: tuple[tuple[int, str], ...] = (
+    (THUMBNAIL_FRAME_FIRST, "First frame"),
+    (THUMBNAIL_FRAME_MID, "Middle frame"),
+    (THUMBNAIL_FRAME_LAST, "Last frame"),
+)
 
 
 def player_mode(settings: QSettings) -> str:
@@ -47,6 +60,50 @@ def player_path(settings: QSettings) -> str:
 def set_player_prefs(settings: QSettings, mode: str, path: str) -> None:
     settings.setValue(PLAYER_MODE_KEY, mode)
     settings.setValue(PLAYER_PATH_KEY, path.strip())
+
+
+def thumbnail_frame_choice(settings: QSettings) -> int:
+    """Return which frame to use for the slate thumbnail (0=first, 1=mid, 2=last)."""
+    # Prefer typed read; fall back for stringy platforms / older values.
+    try:
+        raw = settings.value(THUMBNAIL_FRAME_KEY, THUMBNAIL_FRAME_MID, type=int)
+    except (TypeError, ValueError):
+        raw = settings.value(THUMBNAIL_FRAME_KEY, THUMBNAIL_FRAME_MID)
+    try:
+        val = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return THUMBNAIL_FRAME_MID
+    if val not in (
+        THUMBNAIL_FRAME_FIRST,
+        THUMBNAIL_FRAME_MID,
+        THUMBNAIL_FRAME_LAST,
+    ):
+        return THUMBNAIL_FRAME_MID
+    return val
+
+
+def set_thumbnail_frame_choice(settings: QSettings, which: int) -> None:
+    which_i = int(which)
+    if which_i not in (
+        THUMBNAIL_FRAME_FIRST,
+        THUMBNAIL_FRAME_MID,
+        THUMBNAIL_FRAME_LAST,
+    ):
+        which_i = THUMBNAIL_FRAME_MID
+    settings.setValue(THUMBNAIL_FRAME_KEY, which_i)
+
+
+def pick_thumbnail_index(count: int, which: int) -> int:
+    """Map a thumbnail preference to an index in ``[0, count)``."""
+    n = int(count)
+    if n <= 0:
+        return 0
+    w = int(which)
+    if w == THUMBNAIL_FRAME_FIRST:
+        return 0
+    if w == THUMBNAIL_FRAME_LAST:
+        return n - 1
+    return n // 2
 
 
 def _is_macos_app_bundle(path: Path) -> bool:
@@ -293,6 +350,21 @@ class PreferencesDialog(QDialog):
 
         root.addWidget(player_box)
 
+        # --- Slate thumbnail frame ---
+        slate_box = QGroupBox("Slate")
+        slate_form = QFormLayout(slate_box)
+        self._thumb_combo = QComboBox()
+        for value, label in THUMBNAIL_FRAME_CHOICES:
+            self._thumb_combo.addItem(label, int(value))
+        self._thumb_combo.setToolTip(
+            "Which frame of the EXR sequence is used for the slate thumbnail "
+            "(EXR → video only). Picked by index from the known frame list — "
+            "first, middle, or last. Converted to the slate authoring space "
+            "(sRGB-like) so colour management matches the rest of the slate."
+        )
+        slate_form.addRow("Thumbnail frame:", self._thumb_combo)
+        root.addWidget(slate_box)
+
         # Load current values
         mode = player_mode(settings)
         if mode == PLAYER_MODE_CUSTOM:
@@ -303,6 +375,12 @@ class PreferencesDialog(QDialog):
         self._sync_custom_enabled()
         self._system_radio.toggled.connect(self._sync_custom_enabled)
         self._custom_radio.toggled.connect(self._sync_custom_enabled)
+
+        which = thumbnail_frame_choice(settings)
+        for i in range(self._thumb_combo.count()):
+            if int(self._thumb_combo.itemData(i)) == which:
+                self._thumb_combo.setCurrentIndex(i)
+                break
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -377,4 +455,9 @@ class PreferencesDialog(QDialog):
                     )
                     return
         set_player_prefs(self._settings, mode, path)
+        thumb_data = self._thumb_combo.currentData()
+        set_thumbnail_frame_choice(
+            self._settings,
+            int(thumb_data) if thumb_data is not None else THUMBNAIL_FRAME_MID,
+        )
         self.accept()

--- a/src/gui/slate_widgets.py
+++ b/src/gui/slate_widgets.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import (
     QEvent,
@@ -69,6 +70,9 @@ from ..services.frame_cache import FrameCache
 from .size_grip import SizeGrip
 from .timeline_slider import TimelineSlider
 from .token_line_edit import TokenLineEdit
+
+if TYPE_CHECKING:
+    import numpy as np
 
 log = logging.getLogger(__name__)
 
@@ -322,78 +326,62 @@ class NukeSlider(QWidget):
         self.valueChanged.emit(self._value)
 
 
-def extract_thumbnail_b64(input_path: str, mode: str) -> str:
-    """Extract a JPEG thumbnail from the midpoint of the input as raw base64.
+def extract_thumbnail_b64(
+    input_path: str,
+    mode: str = "exr2video",
+    *,
+    which: int | None = None,
+    ocio_cfg: object | None = None,
+    src_space: str = "",
+) -> str:
+    """Extract a JPEG thumbnail as raw base64 for the slate (sRGB authoring).
 
-    Returns a plain base64 string (no data-URI prefix), or '' on failure.
+    Slate / burn-in only apply to **EXR → video**. The thumbnail is one EXR
+    frame from the known sequence (first / middle / last by frame index — no
+    video seek). Scene-linear pixels are OCIO-transformed
+    ``src → slate authoring (sRGB-like)`` when a config is available so the
+    still matches slate colour management at convert time.
+
+    *which* is ``0`` first / ``1`` middle / ``2`` last
+    (:func:`preferences.thumbnail_frame_choice`). Defaults to middle.
+
+    Returns a plain base64 string (no data-URI prefix), or ``''`` on failure.
+    ``mode`` is accepted for call-site compatibility; non-EXR modes return ``''``.
     """
     import base64
 
+    import numpy as np
+    from PySide6.QtCore import QBuffer, QIODevice
+    from PySide6.QtGui import QImage
+
+    from .preferences import THUMBNAIL_FRAME_MID
+
+    if mode and mode != "exr2video":
+        return ""
+
+    if which is None:
+        which = THUMBNAIL_FRAME_MID
+
     try:
-        if mode == "video2exr":
-            import av
+        arr = _thumbnail_rgb_from_exr(
+            input_path,
+            which,
+            ocio_cfg=ocio_cfg,
+            src_space=src_space,
+        )
+        if arr is None or getattr(arr, "size", 0) == 0:
+            return ""
 
-            container = av.open(input_path)
-            stream = container.streams.video[0]
-            total = stream.frames
-            if not total and stream.duration and stream.time_base:
-                fps = float(stream.average_rate) if stream.average_rate else 24.0
-                total = max(1, int(float(stream.duration * stream.time_base) * fps + 0.5))
-            mid = max(0, (total or 1) // 2)
-            fps = float(stream.average_rate) if stream.average_rate else 24.0
-            tb = stream.time_base
-            if tb is not None and float(tb) != 0.0:
-                target_ts = int(mid / fps / float(tb))
-                container.seek(target_ts, stream=stream)
-            frame = None
-            for f in container.decode(video=0):
-                frame = f
-                break
-            container.close()
-            if frame is None:
-                return ""
-            import numpy as np
-
-            arr = frame.to_ndarray(format="rgb24")
-        else:
-            from ..core.sequence import find_exr_sequence_info
-
-            _paths, _name, frames, _pad, seq = find_exr_sequence_info(input_path)
-            if not frames:
-                return ""
-            mid_idx = len(frames) // 2
-            mid_frame = sorted(frames)[mid_idx]
-            mid_path = seq.frame(mid_frame)
-
-            import numpy as np
-            import OpenImageIO as oiio
-
-            img_buf = oiio.ImageBuf(mid_path)
-            if img_buf.has_error:
-                return ""
-            spec = img_buf.spec()
-            if spec.full_width > 0 and spec.full_height > 0:
-                dx, dy = spec.full_x, spec.full_y
-                dw, dh = spec.full_width, spec.full_height
-            else:
-                dx, dy = 0, 0
-                dw, dh = spec.width, spec.height
-            roi = oiio.ROI(dx, dx + dw, dy, dy + dh, 0, 1, 0, min(spec.nchannels, 3))
-            pixels = np.ascontiguousarray(img_buf.get_pixels(oiio.FLOAT, roi), dtype=np.float32)
-            rgb = pixels[..., :3] if pixels.shape[2] >= 3 else np.repeat(pixels, 3, axis=2)
-            rgb = np.clip(rgb, 0, None)
-            srgb = np.where(
-                rgb <= 0.0031308,
-                rgb * 12.92,
-                1.055 * np.power(rgb, 1.0 / 2.4) - 0.055,
-            )
-            arr = np.clip(srgb * 255, 0, 255).astype(np.uint8)
-
-        from PySide6.QtCore import QBuffer, QIODevice
-        from PySide6.QtGui import QImage
-
+        arr = np.ascontiguousarray(arr, dtype=np.uint8)
+        if arr.ndim != 3 or arr.shape[2] < 3:
+            return ""
         h, w = arr.shape[:2]
-        qimg = QImage(arr.data, w, h, 3 * w, QImage.Format.Format_RGB888)
+        if h < 1 or w < 1:
+            return ""
+        # .copy() so QImage owns the buffer (arr can be freed after this).
+        qimg = QImage(arr.data, w, h, 3 * w, QImage.Format.Format_RGB888).copy()
+        if qimg.isNull():
+            return ""
 
         max_w = 640
         if w > max_w:
@@ -401,11 +389,153 @@ def extract_thumbnail_b64(input_path: str, mode: str) -> str:
 
         qbuf = QBuffer()
         qbuf.open(QIODevice.OpenModeFlag.WriteOnly)
-        # PySide6 stubs type ``format`` as bytes-like; pass a real QByteArray name.
-        qimg.save(qbuf, b"JPEG", 85)
-        return base64.b64encode(bytes(qbuf.data().data())).decode("ascii")
+        if not qimg.save(qbuf, "JPEG", 85):
+            log.warning("thumbnail JPEG encode failed for %s", input_path)
+            return ""
+        data = bytes(qbuf.data())
+        if not data:
+            return ""
+        return base64.b64encode(data).decode("ascii")
+    except (FileNotFoundError, NotADirectoryError, OSError) as e:
+        log.debug("thumbnail extract: path error for %s: %s", input_path, e)
+        return ""
     except Exception:
-        log.debug("thumbnail extract failed for %s", input_path, exc_info=True)
+        log.warning("thumbnail extract failed for %s", input_path, exc_info=True)
+        return ""
+
+
+def _thumbnail_rgb_from_exr(
+    input_path: str,
+    which: int,
+    *,
+    ocio_cfg: object | None = None,
+    src_space: str = "",
+) -> object | None:
+    """Return uint8 RGB for one EXR frame in slate authoring (sRGB-like) space.
+
+    Frame list is known from the sequence (no seeking): pick first/mid/last index.
+    """
+    import numpy as np
+    import OpenImageIO as oiio
+
+    from ..core.sequence import find_exr_sequence_info
+    from .preferences import pick_thumbnail_index
+
+    try:
+        _paths, _name, frames, _pad, seq = find_exr_sequence_info(input_path)
+    except (RuntimeError, OSError, ValueError) as e:
+        log.debug("thumbnail EXR resolve failed for %s: %s", input_path, e)
+        return None
+    if not frames:
+        return None
+    ordered = sorted(frames)
+    idx = pick_thumbnail_index(len(ordered), which)
+    frame_no = ordered[idx]
+    frame_path = seq.frame(frame_no)
+
+    img_buf = oiio.ImageBuf(frame_path)
+    if img_buf.has_error:
+        return None
+    spec = img_buf.spec()
+    if spec.full_width > 0 and spec.full_height > 0:
+        dx, dy = spec.full_x, spec.full_y
+        dw, dh = spec.full_width, spec.full_height
+    else:
+        dx, dy = 0, 0
+        dw, dh = spec.width, spec.height
+    roi = oiio.ROI(dx, dx + dw, dy, dy + dh, 0, 1, 0, min(spec.nchannels, 3))
+    pixels = np.ascontiguousarray(img_buf.get_pixels(oiio.FLOAT, roi), dtype=np.float32)
+    if pixels is None or pixels.size == 0:
+        return None
+    rgb = (
+        pixels[..., :3]
+        if pixels.ndim == 3 and pixels.shape[2] >= 3
+        else np.repeat(pixels.reshape(pixels.shape[0], pixels.shape[1], 1), 3, axis=2)
+    )
+    rgb = np.ascontiguousarray(rgb, dtype=np.float32)
+
+    # Prefer OCIO src → slate authoring (display-encoded sRGB), matching how
+    # the slate itself is colour-managed at convert time.
+    display_rgb = _exr_rgb_to_slate_authoring(rgb, ocio_cfg, src_space, frame_path)
+    return np.clip(display_rgb * 255.0, 0, 255).astype(np.uint8)
+
+
+def _exr_rgb_to_slate_authoring(
+    rgb: np.ndarray,
+    ocio_cfg: object | None,
+    src_space: str,
+    frame_path: str,
+) -> np.ndarray:
+    """Convert scene-linear EXR RGB to display-encoded slate authoring space."""
+    import numpy as np
+
+    arr = np.ascontiguousarray(rgb, dtype=np.float32)
+
+    if ocio_cfg is not None:
+        try:
+            import PyOpenColorIO as OCIO
+
+            from ..core.ocio_utils import (
+                find_equivalent_space,
+                get_overlay_authoring_space,
+                get_working_space,
+                make_cpu_processor,
+            )
+
+            # Resolve source: explicit UI space, EXR metadata, then working.
+            src = (src_space or "").strip()
+            if not src:
+                try:
+                    meta = oiio_colorspace_attr(frame_path)
+                    if meta:
+                        src = find_equivalent_space(ocio_cfg, meta) or meta
+                except Exception:
+                    pass
+            if not src:
+                try:
+                    src = get_working_space(ocio_cfg)
+                except Exception:
+                    src = ""
+            if src:
+                # Map aliases so "ACEScg" etc. resolve on ACES Studio configs.
+                resolved = find_equivalent_space(ocio_cfg, src) or src
+                auth = get_overlay_authoring_space(ocio_cfg)
+                if auth and resolved:
+                    cpu = make_cpu_processor(ocio_cfg, resolved, auth)
+                    h, w = arr.shape[:2]
+                    buf = np.ascontiguousarray(arr.copy(), dtype=np.float32)
+                    cpu.apply(OCIO.PackedImageDesc(buf, w, h, 3))
+                    return np.clip(buf, 0.0, 1.0)
+        except Exception:
+            log.warning(
+                "OCIO thumbnail transform failed; using transfer fallback",
+                exc_info=True,
+            )
+
+    # Fallback: assume linear light, apply Rec.709/sRGB OETF (display-ish).
+    lin = np.clip(arr, 0.0, None)
+    srgb = np.where(
+        lin <= 0.0031308,
+        lin * 12.92,
+        1.055 * np.power(lin, 1.0 / 2.4) - 0.055,
+    )
+    return np.clip(srgb, 0.0, 1.0)
+
+
+def oiio_colorspace_attr(path: str) -> str:
+    """Return ``oiio:ColorSpace`` from an EXR if present."""
+    try:
+        import OpenImageIO as oiio
+
+        inp = oiio.ImageInput.open(path)
+        if inp is None:
+            return ""
+        try:
+            cs = inp.spec().getattribute("oiio:ColorSpace")
+            return str(cs) if cs else ""
+        finally:
+            inp.close()
+    except Exception:
         return ""
 
 
@@ -1344,9 +1474,25 @@ class SlateDialog(QDialog):
         self._form = SlateFormPanel(model, input_path=input_path, embed_overlays=False)
 
         if input_path:
-            thumb = extract_thumbnail_b64(input_path, mode)
+            from .preferences import thumbnail_frame_choice
+
+            which = thumbnail_frame_choice(self._model.settings)
+            thumb = extract_thumbnail_b64(
+                input_path,
+                mode,
+                which=which,
+                ocio_cfg=self._ocio_cfg,
+                src_space=self._src_colorspace or "",
+            )
             if thumb:
                 self._form.set_thumbnail_b64(thumb)
+            else:
+                log.warning(
+                    "No slate thumbnail extracted from %s (mode=%s, which=%s)",
+                    input_path,
+                    mode,
+                    which,
+                )
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -560,6 +560,28 @@ class OcioConfigPanel(QGroupBox):
     def current_source_key(self) -> str:
         return self._source_combo.currentData() or ""
 
+    def set_custom_config_file(self, path: str) -> bool:
+        """Force the custom OCIO file source to *path* (used by GUI launch args / Nuke).
+
+        Returns True if the path exists and was selected.
+        """
+        p = Path(path).expanduser()
+        if not p.is_file():
+            return False
+        self._file_path = str(p)
+        self._settings.setValue("ocio/file_path", str(p))
+        self._settings.setValue("ocio/source", OCIO_SOURCE_FILE)
+        self._update_custom_label()
+        for i in range(self._source_combo.count()):
+            if self._source_combo.itemData(i) == OCIO_SOURCE_FILE:
+                self._source_combo.blockSignals(True)
+                self._source_combo.setCurrentIndex(i)
+                self._source_combo.blockSignals(False)
+                self._prev_index = i
+                break
+        self.config_changed.emit()
+        return True
+
     def load_config(self):  # -> OCIO.Config | None
         source = self.current_source_key()
         file_path = self._file_path
@@ -2584,10 +2606,23 @@ class ConvertTab(QWidget):
         self.src_btn.space_changed.connect(lambda _: self._emit_readiness())
         self.dst_btn.space_changed.connect(lambda _: self._emit_readiness())
 
-        # Validate any saved input path once the event loop starts.
+        # Validate any saved input path once the event loop starts — unless a
+        # GUI launch path (--open / Nuke) already applied input on this tab.
+        self._skip_saved_input_restore = False
         saved = self.input_path.text().strip()
         if saved:
-            QTimer.singleShot(0, self, lambda: self.set_input_async(saved))
+            QTimer.singleShot(0, self, self._restore_saved_input_if_needed)
+
+    def _restore_saved_input_if_needed(self) -> None:
+        if getattr(self, "_skip_saved_input_restore", False):
+            return
+        saved = self.input_path.text().strip()
+        if saved:
+            self.set_input_async(saved)
+
+    def suppress_saved_input_restore(self) -> None:
+        """Cancel deferred QSettings input restore (used by ``--open`` / Nuke)."""
+        self._skip_saved_input_restore = True
 
     def _on_input_text_changed(self, text: str) -> None:
         """React to manual edits (typing / paste) in the input field.

--- a/src/gui/window.py
+++ b/src/gui/window.py
@@ -298,6 +298,52 @@ class MainWindow(QMainWindow):
         if geom:
             self.restoreGeometry(geom)
 
+    def apply_startup(
+        self,
+        open_path: str | None = None,
+        ocio_path: str | None = None,
+        mode: str | None = None,
+    ) -> None:
+        """Apply GUI launch options (CLI ``--open`` / ``--gui-ocio`` / ``--mode``).
+
+        Used by the bare ``main.py`` entry and by the Nuke menu integration.
+        """
+        if ocio_path:
+            ok = self._ocio_panel.set_custom_config_file(ocio_path)
+            if ok:
+                self._append_log(f"OCIO config (launch): {ocio_path}")
+                self._reload_ocio()
+            else:
+                self._append_log(f"OCIO config not found (launch ignored): {ocio_path}")
+
+        open_path = (open_path or "").strip()
+        mode_norm = (mode or "auto").strip().lower()
+        if mode_norm in ("video2exr", "v2e", "video"):
+            self._tabs.setCurrentIndex(0)
+        elif mode_norm in ("exr2video", "e2v", "exr"):
+            self._tabs.setCurrentIndex(1)
+        elif open_path:
+            # Prefer extension over filesystem existence (Nuke may pass paths
+            # that are not yet fully visible, or sequence tokens).
+            p = Path(open_path.split()[0] if open_path else "")
+            name = p.name.lower()
+            if p.suffix.lower() in self._VIDEO_EXTS or any(
+                name.endswith(ext) for ext in self._VIDEO_EXTS
+            ):
+                self._tabs.setCurrentIndex(0)
+            else:
+                # Directory, EXR frame, or sequence pattern → EXR tab
+                self._tabs.setCurrentIndex(1)
+
+        if open_path:
+            # Prevent deferred QSettings restore from overwriting --open / Nuke.
+            self._v2e_tab.suppress_saved_input_restore()
+            self._e2v_tab.suppress_saved_input_restore()
+            tab = self._active_tab()
+            # Async probe so large MXFs / sequences don't freeze launch.
+            tab.set_input_async(open_path)
+            self._append_log(f"Opened (launch): {open_path}")
+
     # -- Menu bar --
 
     def _build_menu_bar(self) -> None:
@@ -715,19 +761,43 @@ class MainWindow(QMainWindow):
             if not frame_set:
                 frame_set = None
 
-        # -- Slate (raw sRGB float32 RGBA -- convert.py does the OCIO transit) --
+        # -- Slate / burn-in / watermark: EXR → video only (never video → EXR) --
         slate_np = None
-        if tab.slate_enabled():
+        overlay_np = None
+        slate_overlay_np = None
+        overlay_provider = None
+        if mode == "exr2video" and tab.slate_enabled():
             slate_data = tab.get_slate_data()
             if slate_data is not None:
                 from ..render.slate import render_slate_frame
 
                 sw, sh = self._detect_slate_resolution(mode, inp)
                 thumb_b64 = tab.get_slate_thumbnail_b64()
+                # If the slate dialog was never opened, still extract a thumb
+                # from the known EXR frame list (first / mid / last).
+                if not thumb_b64 and inp:
+                    try:
+                        from .preferences import thumbnail_frame_choice
+                        from .slate_widgets import extract_thumbnail_b64
+
+                        thumb_b64 = extract_thumbnail_b64(
+                            inp,
+                            "exr2video",
+                            which=thumbnail_frame_choice(self._settings),
+                            ocio_cfg=self._ocio_cfg,
+                            src_space=tab.src_btn.current_space() or "",
+                        )
+                        if thumb_b64 and tab._slate_model is not None:
+                            tab._slate_model.set_thumbnail_b64(thumb_b64)
+                    except Exception as e:
+                        self._append_log(f"Slate thumbnail extract skipped: {e}")
                 self._append_log(f"Rendering slate frame ({sw}\u00d7{sh})\u2026")
                 try:
                     slate_np = render_slate_frame(slate_data, sw, sh, thumbnail_b64=thumb_b64)
-                    self._append_log("Slate frame rendered successfully")
+                    if thumb_b64:
+                        self._append_log("Slate frame rendered (with thumbnail)")
+                    else:
+                        self._append_log("Slate frame rendered (no thumbnail)")
                 except Exception as e:
                     QMessageBox.warning(self, "Slate Error", f"Failed to render slate: {e}")
                     return
@@ -739,27 +809,15 @@ class MainWindow(QMainWindow):
         self._progress.setValue(0)
         self._progress.setFormat("%p%")
 
-        # -- Burn-in + watermark overlays (EXR→Video only) --
         # Burn-in and watermark are stamped on shot frames only; the slate is
-        # left clean (matching the live preview).  The overlay stays as an sRGB
-        # uint8 RGBA buffer — convert.py linearises it once and keeps the linear
-        # copy for compositing in working space.
-        overlay_np = None
-        slate_overlay_np = None
-        overlay_provider = None
+        # left clean (matching the live preview). Overlay is sRGB uint8 RGBA —
+        # convert.py linearises once and composites in working space.
         if mode == "exr2video":
             overlay_np, slate_overlay_np, overlay_provider = self._build_overlays(
                 tab, inp, frame_range_str, frame_set
             )
 
         if mode == "video2exr":
-            # v2e still pre-transforms the slate to dst space (no overlays
-            # here) — slate becomes one EXR frame on disk in dst colorspace.
-            v2e_slate = slate_np
-            if v2e_slate is not None:
-                from ..render.slate import SLATE_COLORSPACE
-
-                v2e_slate = self._ocio_transform_slate(v2e_slate, SLATE_COLORSPACE, dst)
             # ocio_cfg intentionally omitted — worker rebuilds from config_source/path.
             kwargs = dict(
                 video_path=inp,
@@ -773,7 +831,6 @@ class MainWindow(QMainWindow):
                 padding=tab.get_padding(),
                 start_frame=tab.get_start_frame(),
                 frame_set=frame_set,
-                slate_frame=v2e_slate,
                 exr_opts=tab.get_exr_opts() or None,
             )
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,31 @@ class TestParserDefaults:
         assert b.output is None
         assert b.src is None and b.dst is None
 
+    def test_gui_launch_flags(self):
+        p = build_parser()
+        a = p.parse_args(
+            [
+                "--open",
+                "/show/plate.####.exr",
+                "--gui-ocio",
+                "/cfg/studio.ocio",
+                "--mode",
+                "exr2video",
+            ]
+        )
+        assert a.command is None
+        assert a.open == "/show/plate.####.exr"
+        assert a.gui_ocio == "/cfg/studio.ocio"
+        assert a.mode == "exr2video"
+
+    def test_workers_before_or_after_subcommand(self):
+        p = build_parser()
+        a = p.parse_args(["--workers", "1", "video2exr", "-i", "a.mov"])
+        assert a.workers_global == 1
+        assert a.workers_local is None
+        b = p.parse_args(["video2exr", "-i", "a.mov", "--workers", "4"])
+        assert b.workers_local == 4
+
     def test_explicit_overrides(self):
         p = build_parser()
         a = p.parse_args(

--- a/tests/test_thumbnail_prefs.py
+++ b/tests/test_thumbnail_prefs.py
@@ -1,0 +1,32 @@
+"""Slate thumbnail frame preference helpers."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QSettings
+
+from src.gui.preferences import (
+    THUMBNAIL_FRAME_FIRST,
+    THUMBNAIL_FRAME_LAST,
+    THUMBNAIL_FRAME_MID,
+    pick_thumbnail_index,
+    set_thumbnail_frame_choice,
+    thumbnail_frame_choice,
+)
+
+
+def test_pick_thumbnail_index():
+    assert pick_thumbnail_index(10, THUMBNAIL_FRAME_FIRST) == 0
+    assert pick_thumbnail_index(10, THUMBNAIL_FRAME_MID) == 5
+    assert pick_thumbnail_index(10, THUMBNAIL_FRAME_LAST) == 9
+    assert pick_thumbnail_index(1, THUMBNAIL_FRAME_LAST) == 0
+    assert pick_thumbnail_index(0, THUMBNAIL_FRAME_MID) == 0
+
+
+def test_thumbnail_frame_choice_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    s = QSettings(str(tmp_path / "t.ini"), QSettings.Format.IniFormat)
+    assert thumbnail_frame_choice(s) == THUMBNAIL_FRAME_MID
+    set_thumbnail_frame_choice(s, THUMBNAIL_FRAME_LAST)
+    assert thumbnail_frame_choice(s) == THUMBNAIL_FRAME_LAST
+    set_thumbnail_frame_choice(s, 99)  # invalid → mid
+    assert thumbnail_frame_choice(s) == THUMBNAIL_FRAME_MID

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.5.2"
+version = "0.5.3"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

**Patch 0.5.3** — CLI/Nuke launch, slate thumbnail preferences, and polish.

### Added
- GUI launch: `--open`, `--gui-ocio`, `--mode`
- Docs: `docs/cli.md`, `docs/nuke.md`; Nuke menu under `integrations/nuke/`
- Preferences: slate thumbnail frame (first / middle / last)

### Fixed
- Slate thumbnail extraction for EXR→video (known frame list; OCIO to sRGB authoring)
- `--open` / Nuke no longer overwritten by saved input restore
- `--workers` works before or after the subcommand

## After merge
Auto-tag → `v0.5.3` → Release workflow.