### PR TITLE
release: 0.5.4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,63 @@
+# Build Hugo docs from docs/ + site/ and publish to GitHub Pages.
+# Repo Settings → Pages → Source must be "GitHub Actions" (one-time).
+
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "site/**"
+      - "resources/screenshots/**"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "site/**"
+      - "resources/screenshots/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.164.0"
+          extended: true
+
+      - name: Build
+        run: hugo --minify --gc -s site
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/public
+
+  deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,9 @@ jobs:
           if [ "$RUNNER_OS" == "macOS" ]; then
             EXTRA_FLAGS+=(--macos-create-app-bundle "--macos-app-name=EXR Converter" "--macos-app-icon=${{ steps.icon.outputs.path }}")
             EXTRA_FLAGS+=("--macos-target-arch=${{ runner.arch == 'ARM64' && 'arm64' || 'x86_64' }}")
-            EXTRA_FLAGS+=("--noinclude-dlls=libcrypto*" "--noinclude-dlls=libssl*")
+            # Do not --noinclude-dlls libssl/libcrypto: that breaks Python HTTPS
+            # in the frozen app (urlopen "unknown url type: https") and disables
+            # Help → Check for Updates against the GitHub API.
           elif [ "$RUNNER_OS" == "Windows" ]; then
             EXTRA_FLAGS+=("--windows-icon-from-ico=${{ steps.icon.outputs.path }}" --windows-console-mode=disable)
           else
@@ -234,6 +236,7 @@ jobs:
             --include-package-data=PyOpenColorIO \
             --include-package=fileseq \
             --include-data-dir=resources/ocio=resources/ocio \
+            --include-module=ssl \
             --quiet \
             "${EXTRA_FLAGS[@]}" \
             main.py

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ build/
 *.pywz
 *.pyzw
 *.pyzwz
+
+# Hugo docs site
+site/public/
+site/resources/
+site/.hugo_build.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,28 @@ VFX Reference Platform CY2026-ish stack: PySide6 6.8, OCIO 2.5, OIIO, NumPy 2.x,
 
 Agents: if you implement a feature or fix and forget the changelog, treat that as incomplete work and add the entry before finishing.
 
+## Documentation (required)
+
+**User-facing docs live in [`docs/`](./docs/)** (Markdown source of truth). Hugo
+builds them from [`site/`](./site/) and the **Docs** workflow publishes to
+GitHub Pages: https://derek-rein.github.io/exr-converter/
+
+| Rule | Detail |
+|------|--------|
+| When | Any change that affects how users run or integrate the app: CLI flags, GUI behavior, codecs, OCIO/defaults, install/packaging users notice, Nuke/helpers, post-convert prefs, launch flags |
+| Where | Update the matching file under `docs/` in the **same PR / commit set** as the code (and [CHANGELOG.md](./CHANGELOG.md) when user-visible) |
+| Map | [docs/cli.md](./docs/cli.md) CLI + GUI launch · [docs/gui.md](./docs/gui.md) GUI / prefs / overlays · [docs/nuke.md](./docs/nuke.md) Nuke menu · [docs/releasing.md](./docs/releasing.md) short release pointer · design notes only when the design changes |
+| Local | `make docs-serve` (preview) · `make docs-build` (static `site/public/`) |
+| Do not | Leave docs describing old flags/defaults/codecs. Do not hand-edit generated `site/public/`. Do not put the only copy of user docs solely in chat or PR text. |
+
+Agents: **before finishing work**, check whether `docs/` still matches the
+behavior you shipped. If you changed CLI/GUI/integration surface area and
+skipped docs, treat that as incomplete and update them.
+
+Release process for maintainers stays in this file
+([Releasing and deployment](#releasing-and-deployment)); keep `docs/releasing.md`
+as a short pointer, not a second full copy.
+
 ## Layout (where to edit)
 
 ```text
@@ -48,8 +70,9 @@ src/
 resources/              # icons, style.qss, OCIO config, screenshots
 scripts/                # bump_app_version.py, ensure_ocio.py
 tests/                  # pytest; integration + fixtures under tests/fixtures/
-docs/                   # design notes (e.g. oxideav plan); release process lives here in AGENTS.md
-.github/workflows/      # ci.yml (PR/main), release.yml (tag v*)
+docs/                   # user-facing Markdown (Hugo content source of truth)
+site/                   # Hugo config + theme; mounts docs/ → GitHub Pages
+.github/workflows/      # ci.yml, docs.yml, release.yml, auto-tag-release.yml
 ```
 
 ### Important modules
@@ -76,6 +99,8 @@ make typecheck     # basedpyright
 make test          # full pytest (needs QT_QPA_PLATFORM=offscreen — Makefile sets it)
 make test-unit     # skip @pytest.mark.integration
 make resources     # regenerate src/rc_resources.py after resources.qrc / icons change
+make docs-serve    # Hugo local preview of docs/ (http://127.0.0.1:1313/)
+make docs-build    # Hugo static build → site/public/
 make bundle        # local Nuitka standalone (does not publish a GitHub Release)
 make clean
 ```
@@ -119,6 +144,14 @@ config version 2.5 cannot load on library 2.4. Fix: `make ensure-ocio` or
 7. **Nuitka** — Release builds strip many Qt modules (WebEngine, Svg, Pdf, …).
    Prefer PySide6-Essentials APIs already used in the tree. Bundle includes
    `resources/ocio` and package data for `av`, OIIO, OCIO, fileseq.
+   **HTTPS / Check for Updates** uses stdlib `urllib` + Python `ssl` — do **not**
+   `--noinclude-dlls=libssl*` / `libcrypto*` (breaks HTTPS in the frozen app).
+   Do not pull `QtNetwork` solely for updates; keep `--include-module=ssl`.
+   Smoke test asserts `ssl.create_default_context()` works in the packaged binary.
+8. **macOS Dock icon** — Do **not** call `setWindowIcon` / set a runtime PNG on
+   Darwin. Dock must use the bundle `.icns` (`--macos-app-icon`). A Qt PNG
+   override becomes `applicationIconImage` and shows sharp square corners while
+   running. Windows/Linux still set `:/icon.png`.
 
 ## Coding conventions
 
@@ -296,6 +329,7 @@ xattr -cr "/Applications/EXR Converter.app"
 | Workflow | Trigger | Gate |
 |----------|---------|------|
 | [CI](.github/workflows/ci.yml) | push / PR to `main` | Ruff + full pytest on 3 OS; job **`ci-ok`** requires all green |
+| [Docs](.github/workflows/docs.yml) | push / PR paths under `docs/`, `site/` | Hugo build; deploy to Pages on `main` only |
 | [Auto-tag release](.github/workflows/auto-tag-release.yml) | push to `main` | If `pyproject` version has no `vX.Y.Z` tag → push tag |
 | [Release](.github/workflows/release.yml) | tag `v*` | Same lint + tests via **`gate`** before Nuitka / publish |
 
@@ -305,14 +339,20 @@ Branch protection on `main` should require `ci-ok`.
 
 | Doc | Purpose |
 |-----|---------|
-| [AGENTS.md](./AGENTS.md) | This file — agent/process context, release & deploy |
+| [AGENTS.md](./AGENTS.md) | This file — agent/process context, release & deploy, **docs rules** |
 | [CHANGELOG.md](./CHANGELOG.md) | User-facing history (**must update**) |
-| [README.md](./README.md) | Product overview, install, CLI |
+| [README.md](./README.md) | Product overview, install, short CLI |
+| [docs/](./docs/) | User-facing Markdown (**must update** when behavior changes) |
+| [site/](./site/) | Hugo config + theme; mounts `docs/` → GitHub Pages |
 | [docs/cli.md](./docs/cli.md) | CLI + GUI launch flags |
+| [docs/gui.md](./docs/gui.md) | GUI tabs, overlays, preferences, post-convert |
 | [docs/nuke.md](./docs/nuke.md) | Nuke menu integration |
 | [docs/plan-12bit-prores-oxideav.md](./docs/plan-12bit-prores-oxideav.md) | Future 12-bit ProRes plan (not implemented) |
-| [docs/releasing.md](./docs/releasing.md) | Stub pointing here (release process lives in AGENTS.md) |
+| [docs/releasing.md](./docs/releasing.md) | Short pointer here + docs-site note |
 | [integrations/nuke/](./integrations/nuke/) | Nuke `menu.py` + helpers |
+
+Public site: `make docs-serve` / `make docs-build`; workflow **Docs** deploys to
+`https://derek-rein.github.io/exr-converter/` (Pages source = GitHub Actions).
 
 ## What not to do
 
@@ -321,3 +361,4 @@ Branch protection on `main` should require `ci-ok`.
 - Do not reintroduce Qt WebEngine for slate.
 - Do not push version tags without a changelog section and green Release gate intent.
 - Do not hand-edit `src/rc_resources.py` or force-push published release tags without a deliberate recovery process.
+- Do not finish user-visible work without updating **CHANGELOG.md** and **`docs/`** when the surface area changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+### Added
+
+- **Docs site (GitHub Pages):** write Markdown under `docs/`; Hugo builds from
+  `site/` and the **Docs** workflow publishes to
+  `https://derek-rein.github.io/exr-converter/`. Local preview: `make docs-serve`.
+- **GUI docs:** [docs/gui.md](docs/gui.md) covers tabs, slate/burn-in/watermark,
+  preferences, and post-convert actions.
+
+### Changed
+
+- **Docs accuracy:** CLI codec ladder (default `prores`, honest bit depths,
+  default extensions), Nuke “Open EXR Converter only…”, and AGENTS.md now
+  require updating `docs/` with user-visible work (same rule as the changelog).
+
+### Fixed
+
+- **Check for Updates on macOS packages:** Nuitka no longer excludes OpenSSL
+  (`libssl` / `libcrypto`), which left Python without HTTPS and produced
+  `urlopen error unknown url type: https`. If SSL is still unavailable, the app
+  opens the GitHub releases page in the browser instead of only showing an error.
+- **macOS Dock icon corners while running:** stop overriding the Dock tile with
+  `setWindowIcon(:/icon.png)`. The running app now keeps the bundle `.icns` so
+  open and closed Dock tiles match (no sharp square PNG override).
+
 ---
 
 ## [0.5.3] — 2026-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+---
+
+## [0.5.4] — 2026-08-08
+
 ### Added
 
 - **Docs site (GitHub Pages):** write Markdown under `docs/`; Hugo builds from
@@ -265,7 +269,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/derek-rein/exr-converter/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/derek-rein/exr-converter/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/derek-rein/exr-converter/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/derek-rein/exr-converter/compare/v0.5.0...v0.5.1

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #   make release PUSH=0                   # … local only; push branch + tag yourself to trigger CI
 
 .PHONY: help run lint typecheck fmt test test-unit resources bundle clean bump release \
-	sync ensure-ocio
+	sync ensure-ocio docs-serve docs-build
 
 APP_NAME := exr_converter
 MACOS_BUNDLE_NAME := EXR Converter
@@ -40,14 +40,15 @@ help:
 	@echo "  make resources                         # regenerate Qt resources"
 	@echo "  make bundle                            # Nuitka standalone build"
 	@echo "  make clean                             # remove build artifacts"
+	@echo "  make docs-serve / docs-build           # Hugo site from docs/ (local / CI)"
 	@echo ""
 	@echo "  make bump PART=patch|minor|major       # bump version (no git)"
 	@echo "  make release PART=… PUSH=0             # preferred: bump+commit+tag on release/* branch"
 	@echo "  make release PART=…                    # also pushes (fails if main is protected)"
 	@echo ""
-	@echo "  Docs: AGENTS.md          (release/deploy + agent context; main is protected)"
+	@echo "  Docs: docs/*.md → Hugo site/ → GitHub Pages (workflow Docs)"
+	@echo "        AGENTS.md          (release/deploy + agent context; main is protected)"
 	@echo "        CHANGELOG.md       (user-facing history — update every release)"
-	@echo "        docs/plan-12bit-prores-oxideav.md"
 	@echo "Current tags: git tag -l 'v*' --sort=-v:refname | head"
 
 # ── Dependencies ─────────────────────────────────────────────────────────────
@@ -131,15 +132,23 @@ bundle: resources
 		--include-package-data=PyOpenColorIO \
 		--include-package=fileseq \
 		--include-data-dir=resources/ocio=resources/ocio \
-	--noinclude-dlls='libcrypto*' \
-		--noinclude-dlls='libssl*' \
+		--include-module=ssl \
 		$(ENTRY)
 	mv dist/main.app "dist/$(MACOS_BUNDLE_NAME).app"
 	# Nuitka rewires PyOpenColorIO → OIIO’s OCIO 2.4; put 2.5 back.
 	$(PYTHON) scripts/fix_bundle_ocio.py "dist/$(MACOS_BUNDLE_NAME).app"
 
+# ── Docs site (Hugo → GitHub Pages) ──────────────────────────────────────────
+# Source of truth: docs/*.md  ·  site config/theme: site/  ·  preview: http://127.0.0.1:1313/
+
+docs-serve:
+	hugo server -s site -D --disableFastRender
+
+docs-build:
+	hugo --minify --gc -s site
+
 clean:
-	rm -rf dist build *.build *.dist *.onefile-build __pycache__
+	rm -rf dist build *.build *.dist *.onefile-build __pycache__ site/public site/resources
 
 # ── Version bump (no git) ────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,27 @@ Common camera source names (when using the default ACES Studio config): "Apple L
 
 Enable the **Prepend slate** checkbox to add a 1-frame slate image before the converted output.
 
+## Documentation
+
+Guides live under [`docs/`](docs/) (Markdown source of truth). The public site is
+built with Hugo from [`site/`](site/) and published to GitHub Pages:
+
+**https://derek-rein.github.io/exr-converter/**
+
+| Guide | |
+|-------|--|
+| [CLI](docs/cli.md) | `video2exr` / `exr2video` / GUI launch flags |
+| [GUI](docs/gui.md) | Tabs, overlays, preferences, post-convert |
+| [Nuke](docs/nuke.md) | Menu: open selected Read + session OCIO |
+
+```bash
+make docs-serve   # local preview → http://127.0.0.1:1313/
+make docs-build   # write site/public/
+```
+
 ## CLI
 
-**Full reference:** [docs/cli.md](docs/cli.md)  
-**Nuke menu (open Read + session OCIO):** [docs/nuke.md](docs/nuke.md)
+**Full reference:** [docs/cli.md](docs/cli.md) · **GUI:** [docs/gui.md](docs/gui.md) · **Nuke:** [docs/nuke.md](docs/nuke.md)
 
 Use the `video2exr` or `exr2video` subcommand to convert, or run with **no**
 subcommand to open the GUI (optionally with `--open` / `--gui-ocio`).
@@ -183,3 +200,5 @@ Enable **branch protection** on `main` and require the `ci-ok` status check so m
 MIT — see [`LICENSE`](LICENSE).
 
 [derekvfx.ca](https://derekvfx.ca)
+
+![](https://umami.derekvfx.ca/p/c3Aaarpz7)

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,14 @@
+---
+title: Documentation
+---
+
+Guides for running and integrating **EXR Converter**. Edit these files under
+`docs/` in the repo — the site is generated with Hugo (`site/`) and published to
+[GitHub Pages](https://derek-rein.github.io/exr-converter/).
+
+When you change CLI flags, GUI behavior, codecs, OCIO defaults, packaging that
+users see, or integrations, update the matching guide here in the **same** PR
+as the code (and [CHANGELOG.md](../CHANGELOG.md)). See
+[AGENTS.md — Documentation](../AGENTS.md#documentation-required).
+
+## Guides

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,14 @@
-# EXR Converter — CLI reference
+---
+title: CLI reference
+weight: 10
+description: video2exr, exr2video, and GUI launch flags
+---
 
 Command-line interface for **video ↔ OpenEXR** conversion with **OpenColorIO**.
 The same entry point launches the **GUI** when no convert subcommand is given.
+
+Slate, burn-in, watermark, and post-convert toggles are **GUI-only** — see
+[GUI](./gui.md).
 
 ```bash
 # From a source checkout
@@ -14,7 +21,7 @@ exr_converter --help
 "/Applications/EXR Converter.app/Contents/MacOS/exr_converter" --help
 ```
 
-Related: [Nuke integration](./nuke.md) · [README](../README.md)
+Related: [GUI](./gui.md) · [Nuke integration](./nuke.md) · [README](../README.md)
 
 ---
 
@@ -26,12 +33,12 @@ Related: [Nuke integration](./nuke.md) · [README](../README.md)
 | `main.py video2exr …` | CLI: video → OCIO → EXR sequence |
 | `main.py exr2video …` | CLI: EXR sequence → OCIO → video |
 
-Global flags (before the subcommand):
+Global flags (before the subcommand; convert flags may also appear after it):
 
 | Flag | Meaning |
 |------|---------|
-| `--workers N` | CLI convert parallelism (`0` = auto, `1` = serial). May appear **before** the subcommand or **after** it. |
-| `--smoke-test` | CI: launch GUI briefly and exit |
+| `--workers N` | CLI convert parallelism (`0` = auto, `1` = serial). May appear **before** the subcommand or **after** it (subcommand value wins). |
+| `--smoke-test` | CI: launch GUI briefly, verify OCIO/ssl, exit |
 | `--open PATH` | **GUI only:** open this media on launch |
 | `--gui-ocio PATH` | **GUI only:** load this OCIO config on launch |
 | `--mode auto\|video2exr\|exr2video` | **GUI only:** which tab (`auto` from `--open`) |
@@ -77,8 +84,8 @@ uv run python main.py video2exr -i plate.mov --frame-range 1-100 --workers 4
 | `-i` / `--input` | *(required)* | Input video file |
 | `-o` / `--output-dir` | `<input_dir>/<stem>/` | Directory for EXR frames |
 | `--ocio` | bundled / `$OCIO` | Config file path |
-| `--src` | auto | Source color space (probe + aliases) |
-| `--dst` | ACEScg / scene_linear | Destination scene space |
+| `--src` | auto | Source color space (probe + aliases; falls back toward Rec.709-ish) |
+| `--dst` | `ACEScg` / scene_linear | Destination scene space |
 | `--exr-compression` | `dwaa` | `none`, `rle`, `zip`, `zips`, `piz`, `pxr24`, `b44`, `b44a`, `dwaa`, `dwab` |
 | `--dwa-level` | library | DWA level for `dwaa`/`dwab` (`0` = lossless) |
 | `--zip-level` | library | ZIP level 1–9 for `zip`/`zips` |
@@ -87,9 +94,10 @@ uv run python main.py video2exr -i plate.mov --frame-range 1-100 --workers 4
 | `--start-frame` | `1001` | First output frame number |
 | `--frame-range` | all | Nuke-style, e.g. `1-100`, `1-50x2` |
 | `--deinterlace` | `auto` | `auto` / `on` / `off` |
+| `--workers` | global | Parallel workers (`0` = auto, `1` = serial); overrides global `--workers` |
 
 **Output naming:** `stem.####.exr` inside the output directory (pad width from
-`--padding`).
+`--padding`). Default directory is `<input_parent>/<stem>/` (same idea as the GUI).
 
 ---
 
@@ -104,34 +112,65 @@ uv run python main.py exr2video -i ./plate --codec h264 --crf 18
 
 | Option | Default | Notes |
 |--------|---------|--------|
-| `-i` / `--input` | *(required)* | Sequence **directory** or any **existing frame** from the sequence (not a literal `####` string) |
-| `-o` / `--output` | next to sequence | Video path; extension follows codec if omitted |
+| `-i` / `--input` | *(required)* | Sequence **directory** or any **existing frame** from the sequence (not a literal `####` path that does not exist on disk) |
+| `-o` / `--output` | next to sequence | Video path; default extension follows codec family (below) |
 | `--fps` | `24` | Frame rate |
 | `--ocio` | bundled / `$OCIO` | Config file path |
 | `--src` | EXR meta / scene_linear | Scene-linear source space |
-| `--dst` | display Rec.709 | Display / delivery space |
+| `--dst` | `Output - Rec.709` | Display / delivery space |
 | `--scale` | `1.0` | Output scale |
-| `--codec` | platform default | See codec ladder below |
+| `--codec` | `prores` | Codec key — see ladder below (default = ProRes 422 HQ, **10-bit** software) |
 | `--crf` | codec default | H.264 / HEVC quality |
-| `--preset` | codec default | x264 / x265 preset |
+| `--preset` | codec default | x264 / x265 preset name |
 | `--frame-range` | all | e.g. `1001-1100` |
+| `--workers` | global | Same meaning as `video2exr` |
+
+**Default output path** when `-o` is omitted: sibling of the sequence folder,
+named after the folder, with a codec-appropriate extension:
+
+| Codec family | Default extension |
+|--------------|-------------------|
+| ProRes / CineForm (default path) | `.mov` |
+| `h264`, `hevc`, `hevc_8`, `hevc_12` | `.mp4` |
+| `dnxhr_*` | `.mxf` |
+| `ffv1`, `ffv1_12` | `.mkv` |
 
 ### Codecs (honest bit depths)
 
-| Key pattern | Notes |
-|-------------|--------|
-| `prores_*` (software) | FFmpeg `prores_ks` — **10-bit** encode (not true 12-bit) |
-| `prores_vt_*` | **macOS only** VideoToolbox; 4444/XQ ~12-bit |
-| `dnxhr_*` | DNxHR LB…444 |
-| CineForm keys | 10 / 12-bit variants |
-| `h264`, `hevc`, `hevc_8`, `hevc_12` | Delivery; CRF/preset apply |
-| `ffv1`, `ffv1_12` | Archival FFV1 |
+Keys match `exr2video --codec`. Software ProRes is **always 10-bit** encode
+(`prores_ks`); do not treat 4444/XQ as true 12-bit on that path. VideoToolbox
+variants are **macOS only**.
 
-List available keys on your build:
+| Key | Encode (this app) | Notes |
+|-----|-------------------|--------|
+| `prores_proxy` | 10-bit 4:2:2 | Software ProRes Proxy |
+| `prores_lt` | 10-bit 4:2:2 | Software ProRes LT |
+| `prores_422` | 10-bit 4:2:2 | Software ProRes 422 |
+| `prores` | 10-bit 4:2:2 | **Default** — software ProRes 422 HQ |
+| `prores_4444` | 10-bit 4:4:4:4 | Software; not true 12-bit |
+| `prores_xq` | 10-bit 4:4:4:4 | Software; not true 12-bit |
+| `prores_vt_proxy` … `prores_vt_hq` | 10-bit 4:2:2 | VideoToolbox (macOS) |
+| `prores_vt_4444`, `prores_vt_xq` | ~12-bit 4:4:4:4 | VideoToolbox (macOS) |
+| `cineform` | 10-bit 4:2:2 | GoPro CineForm |
+| `cineform_rgb` | 12-bit RGB | CineForm RGB |
+| `dnxhr_lb` / `sq` / `hq` | 8-bit 4:2:2 | DNxHR |
+| `dnxhr_hqx` | 10-bit 4:2:2 | DNxHR HQX |
+| `dnxhr_444` | 10-bit 4:4:4 | DNxHR 444 |
+| `h264` | 8-bit 4:2:0 | CRF / preset apply |
+| `hevc` | 10-bit 4:2:0 | Default HEVC key |
+| `hevc_8` | 8-bit 4:2:0 | |
+| `hevc_12` | 12-bit 4:2:0 | |
+| `ffv1` | 10-bit 4:4:4 | Lossless |
+| `ffv1_12` | 12-bit 4:4:4 | Lossless |
+
+List keys on your build (filters macOS-only codecs on other OSes):
 
 ```bash
 uv run python main.py exr2video --help
 ```
+
+Research notes for true cross-platform 12-bit ProRes (not shipped):
+[plan-12bit-prores-oxideav.md](./plan-12bit-prores-oxideav.md).
 
 ---
 
@@ -159,5 +198,6 @@ uv run python main.py exr2video --help
 ## See also
 
 - `main.py --help`, `video2exr --help`, `exr2video --help` (always current)
+- [GUI](./gui.md)
 - [Nuke integration](./nuke.md)
-- [Releasing](../AGENTS.md#releasing-and-deployment)
+- [Releasing](./releasing.md)

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,0 +1,114 @@
+---
+title: GUI
+weight: 15
+description: Tabs, overlays, preferences, and post-convert actions
+---
+
+Desktop UI for **video ↔ OpenEXR** with **OpenColorIO**. Launch with no
+subcommand:
+
+```bash
+uv run python main.py
+# or packaged:
+exr_converter
+"/Applications/EXR Converter.app/Contents/MacOS/exr_converter"
+```
+
+Optional launch flags (`--open`, `--gui-ocio`, `--mode`) are documented in
+[CLI — GUI launch](./cli.md#gui-launch-for-shells--nuke). Nuke can fill them in
+from a Read — see [nuke.md](./nuke.md).
+
+---
+
+## Tabs
+
+| Tab | Direction | Notes |
+|-----|-----------|--------|
+| **Video → EXR** | Decode video → OCIO → EXR sequence | No slate / burn-in / watermark |
+| **EXR → Video** | EXR sequence → OCIO → video | Slate, burn-in, and watermark available |
+
+Mode can be forced with `--mode video2exr|exr2video`, or inferred from `--open`
+(`auto`: EXR-like paths open **EXR → Video**, common video extensions open
+**Video → EXR**).
+
+---
+
+## Color (OCIO)
+
+- Config picker: bundled **ACES Studio Config v4**, other built-ins, `$OCIO`, or
+  a custom file. Incompatible Nuke/library configs may appear **greyed out** with
+  a tooltip when the linked OpenColorIO cannot load them.
+- Source / destination spaces follow the active config; aliases are remapped
+  where possible (`find_equivalent_space`).
+- Bundled ACES Studio needs **OpenColorIO 2.5+**. From source, run
+  `make ensure-ocio` if OIIO rewired you to 2.4.
+
+---
+
+## Slate / burn-in / watermark
+
+Available on **EXR → Video** only (checkboxes on that tab).
+
+| Feature | Behavior |
+|---------|----------|
+| **Prepend slate** | One-frame slate composited before the sequence |
+| **Burn-in** | Per-frame text overlay |
+| **Watermark** | Text watermark (opacity, size, angle, optional tile) |
+
+Overlays are authored in a display/sRGB-oriented space, linearised into a
+scene-linear **compositing space** (prefer ACES2065-1 via `aces_interchange`,
+else `scene_linear`), alpha-composited, then OCIO-transformed to the encode
+display space. Rendering is **QPainter** (no embedded browser).
+
+**Slate thumbnail** (EXR → video): which source frame is used for the slate
+still is set under **File → Preferences…** — first / middle / last of the
+sequence. Extraction uses the known EXR frame list (not a video seek).
+
+---
+
+## Codecs
+
+Same honest bit-depth ladder as the CLI. Default is software **ProRes 422 HQ**
+(`prores`, **10-bit**). macOS-only VideoToolbox ProRes keys appear only on
+Darwin. Full key list and bit depths: [CLI codecs](./cli.md#codecs-honest-bit-depths).
+
+---
+
+## After convert
+
+Checkboxes under the convert actions (persisted in `QSettings`):
+
+| Toggle | Default | Action |
+|--------|---------|--------|
+| **Copy path** | on | Copy the output path to the clipboard |
+| **Open result** | off | Open the **video** with the preferred player (Preferences). No-op for EXR output — use **Show in folder**. |
+| **Show in folder** | off | Reveal the file or sequence folder in the OS file manager |
+
+### Preferences (`File → Preferences…`)
+
+| Setting | Purpose |
+|---------|---------|
+| **Video player** | System default, or a custom app/CLI path (IINA, VLC, mpv, …). Used by **Open result**. |
+| **Slate thumbnail frame** | First / middle / last frame of the EXR sequence for the slate still |
+
+Settings org/app: `QSettings("VFXTools", "EXRConverter")`.
+
+---
+
+## macOS notes
+
+- Release builds use an **ad-hoc** signature (not Apple notarized). After install:
+
+  ```bash
+  xattr -cr "/Applications/EXR Converter.app"
+  ```
+
+- The running Dock icon uses the bundle `.icns` (not a sharp PNG override).
+
+---
+
+## See also
+
+- [CLI reference](./cli.md)
+- [Nuke integration](./nuke.md)
+- [README](../README.md)

--- a/docs/nuke.md
+++ b/docs/nuke.md
@@ -1,4 +1,8 @@
-# EXR Converter — Nuke integration
+---
+title: Nuke integration
+weight: 20
+description: Open a Read node and session OCIO from Nuke
+---
 
 Launch **EXR Converter** from Nuke with:
 
@@ -19,13 +23,20 @@ Set an environment variable to the **binary** (not only the `.app` wrapper):
 # macOS app bundle binary
 export EXR_CONVERTER="/Applications/EXR Converter.app/Contents/MacOS/exr_converter"
 
+# Windows (example)
+set EXR_CONVERTER=C:\Program Files\EXR Converter\exr_converter.exe
+
 # or a source checkout
 export EXR_CONVERTER="/path/to/exr-converter/.venv/bin/python"
 export EXR_CONVERTER_ARGS="/path/to/exr-converter/main.py"   # optional second token
 ```
 
-If `EXR_CONVERTER` is unset, the script probes common install locations
-(`/Applications/EXR Converter.app/…`, `exr_converter` on `PATH`, etc.).
+If `EXR_CONVERTER` is unset, the script probes common install locations:
+
+- `/Applications/EXR Converter.app/Contents/MacOS/exr_converter`
+- `~/Applications/EXR Converter.app/…`
+- `%ProgramFiles%\EXR Converter\exr_converter.exe`
+- `exr_converter` on `PATH`
 
 ### 2. Load the menu
 
@@ -55,7 +66,12 @@ $NUKE_PATH/
 
 Restart Nuke. You should see:
 
-**Nuke menu → EXR Converter → Open selected Read…**
+**Nuke menu → EXR Converter**
+
+| Command | Action |
+|---------|--------|
+| **Open selected Read…** | Launch with that Read’s path + session OCIO |
+| **Open EXR Converter only…** | Launch the app with no pre-filled path |
 
 Also under **Nodes → EXR Converter** for discoverability.
 
@@ -82,8 +98,11 @@ exr_converter --open <read file> --gui-ocio <config.ocio> --mode exr2video|video
 | Source | Knob / logic |
 |--------|----------------|
 | Media path | Read `file` knob (evaluated), sequence-friendly |
-| OCIO | Root `customOCIOConfigPath` when set and on disk; else `$OCIO`; else omit (app default) |
+| OCIO | Root `customOCIOConfigPath` (and a few aliases) when set and on disk; else `$OCIO`; else omit (app default) |
 | Mode | `.exr` / sequence → `exr2video`; common video extensions → `video2exr` |
+
+See [CLI — GUI launch](./cli.md#gui-launch-for-shells--nuke) and [GUI](./gui.md)
+for what the app does with those flags.
 
 ---
 
@@ -95,6 +114,7 @@ exr_converter --open <read file> --gui-ocio <config.ocio> --mode exr2video|video
 | “Could not find EXR Converter” | Set `EXR_CONVERTER` to the binary path |
 | Wrong OCIO | Set a custom OCIO path on the Nuke root, or `export OCIO=/path/config.ocio` before Nuke |
 | App opens but empty input | Path may not expand (relative/missing frames); use an absolute evaluated path on the Read |
+| OCIO greyed out in the app | Linked OpenColorIO cannot load that config (often version skew); pick a compatible config or fix OCIO 2.5 linkage |
 
 ---
 
@@ -105,6 +125,9 @@ import exr_converter_nuke as ecn
 
 # Selected node(s)
 ecn.open_selected_read()
+
+# Launch only
+ecn.launch()
 
 # Explicit path
 ecn.launch(open_path="/show/shot/plate.%04d.exr", ocio_path="/configs/studio.ocio")

--- a/docs/plan-12bit-prores-oxideav.md
+++ b/docs/plan-12bit-prores-oxideav.md
@@ -1,4 +1,8 @@
-# Plan: Cross-platform 12-bit ProRes via oxideav
+---
+title: 12-bit ProRes plan (oxideav)
+weight: 90
+description: Research notes — not implemented
+---
 
 **Status:** research complete · implementation not started  
 **Date:** 2026-08-06  

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,4 +1,8 @@
-# Releasing EXR Converter
+---
+title: Releasing
+weight: 30
+description: Tagging, Auto-tag, and the Release workflow
+---
 
 The full release and deployment process (protected `main`, Makefile, GitHub
 Actions, `gh` CLI, checklist, troubleshooting) lives in:
@@ -12,6 +16,12 @@ User-facing history (required on every release):
 **Short path:** merge a release PR that bumps `pyproject.toml` → **Auto-tag
 release** pushes `vX.Y.Z` if missing → **Release** builds and publishes. You do
 not need a manual tag push after merge (that was what skipped 0.5.0 until fixed).
+
+**Docs site:** Markdown under `docs/` is built with Hugo (`site/`) and published
+by the **Docs** workflow on push to `main` (path filters under `docs/`, `site/`).
+That is independent of the versioned app **Release** workflow. Preview locally
+with `make docs-serve`. Public URL:
+[derek-rein.github.io/exr-converter](https://derek-rein.github.io/exr-converter/).
 
 Related design notes (not release machinery):
 [plan-12bit-prores-oxideav.md](./plan-12bit-prores-oxideav.md).

--- a/main.py
+++ b/main.py
@@ -18,7 +18,6 @@ def main() -> int:
     if args.headless:
         parser.error("Use: main.py video2exr ... or main.py exr2video ...")
 
-    from PySide6.QtGui import QIcon
     from PySide6.QtWidgets import QApplication
 
     import src.rc_resources  # noqa: F401 — register Qt resources
@@ -30,7 +29,13 @@ def main() -> int:
     app.setApplicationName(APP_NAME)
     app.setStyle("Fusion")
     app.setStyleSheet(load_stylesheet())
-    app.setWindowIcon(QIcon(":/icon.png"))
+    # macOS: do not setWindowIcon — Dock must use the .app bundle's .icns
+    # (CFBundleIconFile). A runtime PNG becomes NSApplication.applicationIconImage
+    # and draws a sharp full-bleed square while the app is running.
+    if sys.platform != "darwin":
+        from PySide6.QtGui import QIcon
+
+        app.setWindowIcon(QIcon(":/icon.png"))
 
     win = MainWindow()
     # Nuke / shell launch: pre-fill media + OCIO before the event loop runs.
@@ -47,6 +52,16 @@ def main() -> int:
         from PySide6.QtCore import QTimer
 
         from src.core.ocio_utils import get_bundled_aces_studio_path
+
+        # HTTPS / Check for Updates needs Python ssl + OpenSSL dylibs in the bundle.
+        try:
+            import ssl as _ssl
+
+            _ssl.create_default_context()
+            print(f"smoke: ssl OK ({_ssl.OPENSSL_VERSION})")
+        except Exception as e:
+            print(f"SMOKE FAIL: Python ssl unavailable (HTTPS broken): {e}", file=sys.stderr)
+            return 4
 
         ver = _OCIO.GetVersion()
         nums = tuple(int(x) for x in ver.split(".")[:3] if x.isdigit())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.5.3"
+version = "0.5.4"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1,0 +1,328 @@
+:root {
+  --bg: #0f1216;
+  --bg-elev: #171b22;
+  --border: #2a3140;
+  --text: #e8ecf1;
+  --muted: #9aa6b5;
+  --link: #7db4ff;
+  --link-hover: #a8ccff;
+  --accent: #3d8bfd;
+  --code-bg: #1a2030;
+  --radius: 10px;
+  --max: 52rem;
+  --font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font);
+  font-size: 1.02rem;
+  line-height: 1.65;
+  color: var(--text);
+  background: radial-gradient(1200px 600px at 10% -10%, #1a2740 0%, transparent 55%),
+    radial-gradient(900px 500px at 100% 0%, #1a2230 0%, transparent 50%), var(--bg);
+}
+
+a {
+  color: var(--link);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+}
+
+a:hover {
+  color: var(--link-hover);
+}
+
+.wrap {
+  width: min(100% - 2rem, var(--max));
+  margin-inline: auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(12px);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  border-bottom: 1px solid var(--border);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 0;
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.brand:hover {
+  color: var(--link-hover);
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  font-size: 0.95rem;
+}
+
+.nav a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.nav a:hover,
+.nav a.active {
+  color: var(--text);
+}
+
+.main {
+  padding: 2rem 0 4rem;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.footer-inner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.6rem;
+  padding: 1.25rem 0 2rem;
+}
+
+.footer-inner a {
+  color: var(--muted);
+}
+
+.footer-inner a:hover {
+  color: var(--link);
+}
+
+.sep {
+  opacity: 0.5;
+}
+
+.hero h1,
+.doc-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+}
+
+.crumb {
+  margin: 0 0 0.35rem;
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+.crumb a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.crumb a:hover {
+  color: var(--link);
+}
+
+.hero-shot {
+  margin: 2rem 0 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--bg-elev);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
+}
+
+.hero-shot img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.content > :first-child {
+  margin-top: 0;
+}
+
+.content h2,
+.content h3 {
+  margin-top: 2rem;
+  scroll-margin-top: 5rem;
+  letter-spacing: -0.02em;
+}
+
+.content h2 {
+  font-size: 1.35rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.35rem;
+}
+
+.content h3 {
+  font-size: 1.12rem;
+}
+
+.content p,
+.content ul,
+.content ol,
+.content table,
+.content pre,
+.content blockquote {
+  margin: 0.9rem 0;
+}
+
+.content li + li {
+  margin-top: 0.25rem;
+}
+
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  display: block;
+  overflow-x: auto;
+}
+
+.content th,
+.content td {
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.content th {
+  background: var(--bg-elev);
+}
+
+.content code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 0.1em 0.35em;
+}
+
+.content pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.95rem 1rem;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+.content pre code {
+  background: none;
+  border: 0;
+  padding: 0;
+  font-size: 0.86rem;
+}
+
+.content blockquote {
+  margin-inline: 0;
+  padding: 0.2rem 0 0.2rem 1rem;
+  border-left: 3px solid var(--accent);
+  color: var(--muted);
+}
+
+.content hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2rem 0;
+}
+
+.content img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+}
+
+.toc {
+  margin: 1.25rem 0 1.75rem;
+  padding: 0.85rem 1rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.92rem;
+}
+
+.toc-title {
+  margin: 0 0 0.4rem;
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.toc ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.toc li {
+  margin: 0.2rem 0;
+}
+
+.toc a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.toc a:hover {
+  color: var(--link);
+}
+
+.page-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+}
+
+.page-list li {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.page-list a {
+  text-decoration: none;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+/* Chroma (hugo highlight) — keep readable on dark bg */
+.chroma {
+  background: transparent !important;
+}
+
+@media (max-width: 640px) {
+  .header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,0 +1,27 @@
+---
+title: EXR Converter
+---
+
+Desktop app and CLI for converting between **video** and **OpenEXR** sequences
+with **OpenColorIO** color management, slate / burn-in / watermark overlays,
+and packaged binaries for Linux, macOS, and Windows.
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [CLI reference](docs/cli/) | `video2exr`, `exr2video`, GUI launch flags |
+| [GUI](docs/gui/) | Tabs, slate/burn-in, preferences, post-convert |
+| [Nuke integration](docs/nuke/) | Menu helpers to open a Read + session OCIO |
+| [Releasing](docs/releasing/) | How releases are tagged and published |
+| [12-bit ProRes notes](docs/plan-12bit-prores-oxideav/) | Design notes (not shipped) |
+
+## Downloads
+
+Get the latest builds from
+[GitHub Releases](https://github.com/derek-rein/exr-converter/releases/latest).
+
+## Source
+
+Development, issues, and the full README live on
+[github.com/derek-rein/exr-converter](https://github.com/derek-rein/exr-converter).

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -1,0 +1,82 @@
+# Hugo site for EXR Converter docs.
+# Source of truth for pages: ../docs/*.md (mounted as content/docs).
+# Build:  make docs-build   (or: hugo -s site)
+# Serve:  make docs-serve
+
+baseURL = "https://derek-rein.github.io/exr-converter/"
+title = "EXR Converter"
+enableRobotsTXT = true
+enableGitInfo = false
+# Disable taxonomy lists we don't use
+disableKinds = ["taxonomy", "term", "RSS"]
+
+[params]
+  description = "Desktop GUI and CLI for converting video ↔ OpenEXR with OpenColorIO."
+  github = "https://github.com/derek-rein/exr-converter"
+  releases = "https://github.com/derek-rein/exr-converter/releases"
+
+[menus]
+  [[menus.main]]
+    name = "Docs"
+    pageRef = "/docs"
+    weight = 10
+  [[menus.main]]
+    name = "CLI"
+    pageRef = "/docs/cli"
+    weight = 20
+  [[menus.main]]
+    name = "GUI"
+    pageRef = "/docs/gui"
+    weight = 25
+  [[menus.main]]
+    name = "Nuke"
+    pageRef = "/docs/nuke"
+    weight = 30
+  [[menus.main]]
+    name = "GitHub"
+    url = "https://github.com/derek-rein/exr-converter"
+    weight = 90
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+    [markup.goldmark.extensions]
+      typographer = false
+  [markup.highlight]
+    style = "github-dark"
+    noClasses = false
+    lineNos = false
+  [markup.tableOfContents]
+    startLevel = 2
+    endLevel = 3
+    ordered = false
+
+# Mount repo docs/ as the docs section. Keep Hugo-only bits under site/.
+[module]
+  [[module.mounts]]
+    source = "content"
+    target = "content"
+  [[module.mounts]]
+    source = "../docs"
+    target = "content/docs"
+  [[module.mounts]]
+    source = "layouts"
+    target = "layouts"
+  [[module.mounts]]
+    source = "static"
+    target = "static"
+  [[module.mounts]]
+    source = "assets"
+    target = "assets"
+  # Screenshots for the home page
+  [[module.mounts]]
+    source = "../resources/screenshots"
+    target = "static/screenshots"
+  # App icon → site favicon (same source as the desktop app)
+  [[module.mounts]]
+    source = "../resources/icons/icon.png"
+    target = "static/favicon.png"
+  [[module.mounts]]
+    source = "../resources/icons/icon.ico"
+    target = "static/favicon.ico"

--- a/site/layouts/_default/_markup/render-link.html
+++ b/site/layouts/_default/_markup/render-link.html
@@ -1,0 +1,44 @@
+{{- /* Rewrite in-repo .md links to Hugo pretty URLs; leave http(s) and anchors alone. */ -}}
+{{- $u := .Destination -}}
+{{- $text := .Text -}}
+{{- $title := .Title -}}
+{{- if or (strings.HasPrefix $u "http://") (strings.HasPrefix $u "https://") (strings.HasPrefix $u "mailto:") (strings.HasPrefix $u "#") -}}
+  <a href="{{ $u | safeURL }}"{{ with $title }} title="{{ . }}"{{ end }}{{ if strings.HasPrefix $u "http" }} rel="noopener"{{ end }}>{{ $text }}</a>
+{{- else if or (strings.HasPrefix $u "../") (strings.Contains $u "AGENTS.md") (strings.Contains $u "CHANGELOG.md") (strings.Contains $u "README.md") (strings.Contains $u "integrations/") -}}
+  {{- /* Point sibling-repo paths at GitHub so they work on Pages. */ -}}
+  {{- $path := strings.TrimPrefix "../" $u -}}
+  {{- $path = strings.TrimPrefix "./" $path -}}
+  {{- /* Preserve #fragments on GitHub blob URLs */ -}}
+  {{- $frag := "" -}}
+  {{- if strings.Contains $path "#" -}}
+    {{- $parts := split $path "#" -}}
+    {{- $path = index $parts 0 -}}
+    {{- $frag = printf "#%s" (index $parts 1) -}}
+  {{- end -}}
+  {{- $gh := printf "%s/blob/main/%s%s" site.Params.github $path $frag -}}
+  <a href="{{ $gh | safeURL }}"{{ with $title }} title="{{ . }}"{{ end }} rel="noopener">{{ $text }}</a>
+{{- else -}}
+  {{- $lookup := strings.TrimPrefix "./" $u -}}
+  {{- $frag := "" -}}
+  {{- if strings.Contains $lookup "#" -}}
+    {{- $parts := split $lookup "#" -}}
+    {{- $lookup = index $parts 0 -}}
+    {{- $frag = printf "#%s" (index $parts 1) -}}
+  {{- end -}}
+  {{- if strings.HasSuffix $lookup ".md" -}}
+    {{- $lookup = strings.TrimSuffix ".md" $lookup -}}
+  {{- end -}}
+  {{- /* Resolve relative to the current section (docs/cli.md → docs/nuke). */ -}}
+  {{- $page := .Page.GetPage $lookup -}}
+  {{- if not $page -}}
+    {{- $page = site.GetPage $lookup -}}
+  {{- end -}}
+  {{- if not $page -}}
+    {{- $page = site.GetPage (printf "docs/%s" $lookup) -}}
+  {{- end -}}
+  {{- if $page -}}
+    <a href="{{ $page.RelPermalink }}{{ $frag }}"{{ with $title }} title="{{ . }}"{{ end }}>{{ $text }}</a>
+  {{- else -}}
+    <a href="{{ $u | safeURL }}"{{ with $title }} title="{{ . }}"{{ end }}>{{ $text }}</a>
+  {{- end -}}
+{{- end -}}

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ site.Language.Lang | default "en" }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} · {{ site.Title }}{{ end }}</title>
+  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ site.Params.description }}{{ end }}">
+  <link rel="icon" href="{{ "favicon.ico" | relURL }}" sizes="any">
+  <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/png" sizes="256x256">
+  <link rel="apple-touch-icon" href="{{ "favicon.png" | relURL }}">
+  {{ $css := resources.Get "css/style.css" | minify | fingerprint }}
+  <link rel="stylesheet" href="{{ $css.RelPermalink }}">
+  <link rel="canonical" href="{{ .Permalink }}">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="{{ site.Home.RelPermalink }}">{{ site.Title }}</a>
+      <nav class="nav" aria-label="Main">
+        {{ range site.Menus.main }}
+          <a href="{{ .URL }}"
+             {{- if strings.HasPrefix .URL "http" }} rel="noopener" target="_blank"{{ end -}}
+             {{- if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} class="active"{{ end -}}
+          >{{ .Name }}</a>
+        {{ end }}
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap main">
+    {{ block "main" . }}{{ end }}
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer-inner">
+      <span>{{ site.Title }}</span>
+      <span class="sep">·</span>
+      <a href="{{ site.Params.github }}">GitHub</a>
+      <span class="sep">·</span>
+      <a href="{{ site.Params.releases }}">Releases</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/site/layouts/_default/list.html
+++ b/site/layouts/_default/list.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<article class="doc">
+  <header class="doc-header">
+    <h1>{{ .Title }}</h1>
+  </header>
+  <div class="content">
+    {{ .Content }}
+    {{ if .Pages }}
+    <ul class="page-list">
+      {{ range .Pages.ByWeight }}
+      <li>
+        <a href="{{ .RelPermalink }}"><strong>{{ .Title }}</strong></a>
+        {{ with .Description }}<span class="muted"> — {{ . }}</span>{{ end }}
+      </li>
+      {{ end }}
+    </ul>
+    {{ end }}
+  </div>
+</article>
+{{ end }}

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+<article class="doc">
+  <header class="doc-header">
+    <p class="crumb"><a href="{{ "docs/" | relURL }}">Docs</a></p>
+    <h1>{{ .Title }}</h1>
+  </header>
+  {{ with .TableOfContents }}
+    {{ if gt (len .) 32 }}
+    <aside class="toc" aria-label="On this page">
+      <p class="toc-title">On this page</p>
+      {{ . }}
+    </aside>
+    {{ end }}
+  {{ end }}
+  <div class="content">
+    {{ .Content }}
+  </div>
+</article>
+{{ end }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,0 +1,14 @@
+{{ define "main" }}
+<section class="hero">
+  <h1>{{ .Title }}</h1>
+  <div class="content">
+    {{ .Content }}
+  </div>
+  {{ with resources.GetMatch "screenshots/*" }}{{ end }}
+  <figure class="hero-shot">
+    <img src="{{ "screenshots/exr_converter_screenshot.png" | relURL }}"
+         alt="EXR Converter — EXR to Video tab"
+         width="1200" height="750" loading="eager">
+  </figure>
+</section>
+{{ end }}

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.5.3"
+APP_VERSION = "0.5.4"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/gui/window.py
+++ b/src/gui/window.py
@@ -145,7 +145,10 @@ class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("EXR Converter")
-        self.setWindowIcon(QIcon(":/icon.png"))
+        # macOS Dock icon comes from the bundle .icns; a runtime PNG override
+        # replaces the system tile and shows sharp square corners while running.
+        if sys.platform != "darwin":
+            self.setWindowIcon(QIcon(":/icon.png"))
         self.setMinimumSize(700, 640)
         self.setAcceptDrops(True)
         self._settings = QSettings(APP_ORG, APP_NAME)
@@ -418,12 +421,40 @@ class MainWindow(QMainWindow):
             )
             return
 
+        # Keep urllib + Python ssl (do not pull QtNetwork just for updates).
+        # Nuitka must ship ssl/OpenSSL; excluding libssl/libcrypto yields
+        # "unknown url type: https" and breaks this path.
+        releases_url = f"https://github.com/{GITHUB_REPO}/releases"
+
+        def _https_unavailable(detail: str) -> None:
+            QMessageBox.warning(
+                self,
+                "Update Check",
+                "HTTPS is unavailable in this build (Python SSL failed),\n"
+                "so automatic update checks cannot reach GitHub.\n\n"
+                f"{detail}\n\n"
+                "Opening the releases page in your browser instead.",
+            )
+            QDesktopServices.openUrl(QUrl(releases_url))
+
+        try:
+            import ssl as _ssl
+
+            _ssl.create_default_context()
+        except Exception as e:
+            _https_unavailable(str(e))
+            return
+
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
         try:
             req = Request(api_url, headers={"Accept": "application/vnd.github+json"})
             with urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read())
         except (URLError, OSError, ValueError) as e:
+            err = str(e)
+            if "unknown url type: https" in err.lower():
+                _https_unavailable(err)
+                return
             QMessageBox.warning(self, "Update Check", f"Could not reach GitHub:\n{e}")
             return
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.5.3"
+version = "0.5.4"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

Patch release **0.5.4** with packaging/UI fixes and the docs site work.

### Fixed
- **Check for Updates:** stop excluding OpenSSL from Nuitka macOS bundles (`unknown url type: https`); SSL smoke test; browser fallback if HTTPS still broken
- **macOS Dock icon:** do not override Dock with runtime `setWindowIcon` PNG (sharp corners while running)

### Added / docs
- Hugo docs site + GitHub Pages workflow (`docs.yml`)
- GUI docs page; CLI/Nuke accuracy pass

## Test plan
- [ ] CI green on this PR (`ci-ok`)
- [ ] After merge: Auto-tag creates `v0.5.4` → Release workflow builds artifacts
- [ ] Packaged macOS: Help → Check for Updates reaches GitHub
- [ ] Packaged macOS: Dock icon corners match open vs closed
- [ ] Docs site deploys on merge (Docs workflow)

## Release process
- Changelog: `[0.5.4] — 2026-08-08`
- Version bump commit: `release: 0.5.4`
- Local tag `v0.5.4` exists; **not** pushed (auto-tag after merge to `main`)