### PR TITLE
release: 0.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      # oiio-python can rewire PyOpenColorIO to a vendored 2.4 dylib; bundled
+      # ACES Studio is config v2.5 and needs library 2.5+ (same as CI).
+      - name: Ensure OpenColorIO 2.5+ linkage
+        run: uv run python scripts/ensure_ocio.py
+
       - name: Run full test suite (unit + integration)
         shell: bash
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.6.1] — 2026-08-08
+
+### Fixed
+
+- **Release CI:** run ``ensure_ocio`` before the Release workflow test matrix
+  (same as CI). Without it, ``oiio-python`` can leave PyOpenColorIO on 2.4 and
+  the bundled ACES Studio 2.5 config fails to load, aborting the gate.
+
+---
+
 ## [0.6.0] — 2026-08-08
 
 ### Added
@@ -331,7 +341,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/derek-rein/exr-converter/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/derek-rein/exr-converter/compare/v0.5.4...v0.6.0
 [0.5.4]: https://github.com/derek-rein/exr-converter/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/derek-rein/exr-converter/compare/v0.5.2...v0.5.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.6.0"
+version = "0.6.1"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.6.0"
+APP_VERSION = "0.6.1"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/tests/test_ocio_gpu_plane.py
+++ b/tests/test_ocio_gpu_plane.py
@@ -14,6 +14,17 @@ from src.gui.ocio_gpu_plane import (
 )
 
 
+def _load_bundled_aces_or_skip() -> OCIO.Config:
+    """Load bundled ACES Studio; skip if missing or OCIO lib is too old (2.4)."""
+    path = ocio_utils.get_bundled_aces_studio_path()
+    if path is None or not path.is_file():
+        pytest.skip("bundled ACES Studio config not present")
+    ok, err = ocio_utils.is_ocio_config_loadable(path)
+    if not ok:
+        pytest.skip(f"bundled ACES Studio not loadable: {err}")
+    return OCIO.Config.CreateFromFile(str(path))
+
+
 def test_gpu_ocio_modules_importable() -> None:
     assert gpu_ocio_available() is True
 
@@ -31,11 +42,7 @@ def test_nuke_viewer_gamma_power() -> None:
 
 def test_nuke_gamma_after_display_not_ocio_ec() -> None:
     """At extreme γ, post-display power ≠ pre-display OCIO EC LINEAR gamma."""
-    path = ocio_utils.get_bundled_aces_studio_path()
-    if path is None or not path.is_file():
-        pytest.skip("bundled ACES Studio config not present")
-
-    cfg = OCIO.Config.CreateFromFile(str(path))
+    cfg = _load_bundled_aces_or_skip()
     working = ocio_utils.get_compositing_space(cfg)
     display = cfg.getDefaultDisplay()
     view = cfg.getDefaultView(display)
@@ -78,11 +85,7 @@ def test_rewrite_sampler1d_handles_nested_parens() -> None:
 
 
 def test_viewer_gpu_shader_extracts_from_bundled_aces() -> None:
-    path = ocio_utils.get_bundled_aces_studio_path()
-    if path is None or not path.is_file():
-        pytest.skip("bundled ACES Studio config not present")
-
-    cfg = OCIO.Config.CreateFromFile(str(path))
+    cfg = _load_bundled_aces_or_skip()
     working = ocio_utils.get_compositing_space(cfg)
     display = cfg.getDefaultDisplay()
     view = cfg.getDefaultView(display)

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.6.0"
+version = "0.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

**0.6.1** patch: fix Release workflow gate by running `ensure_ocio` before tests (same as CI). 0.6.0 Release aborted on OCIO 2.4 vs ACES Studio 2.5.

## Test plan
- [ ] CI green
- [ ] Release workflow passes gate and publishes artifacts for v0.6.1