### PR TITLE
release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+---
+
+## [0.7.0] — 2026-08-09
+
 ### Added
 
 - **Image sequences beyond EXR → video:** `exr2video` (CLI + GUI) accepts
@@ -396,7 +400,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/derek-rein/exr-converter/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/derek-rein/exr-converter/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/derek-rein/exr-converter/compare/v0.5.4...v0.6.0
 [0.5.4]: https://github.com/derek-rein/exr-converter/compare/v0.5.3...v0.5.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.6.1"
+version = "0.7.0"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.6.1"
+APP_VERSION = "0.7.0"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.6.1"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

- Bump app version **0.6.1 → 0.7.0** (`pyproject.toml`, `APP_VERSION`, `uv.lock`).
- Roll **CHANGELOG** `[Unreleased]` into `[0.7.0] — 2026-08-09` (multi-format sequences, sequence/video browsers with List|Grid|Preview, path QoL, Video→EXR open-result player, ingest-only V2E, dot-pad naming, colour fixes).

After merge, **Auto-tag release** should create `v0.7.0` and dispatch the **Release** workflow (Nuitka artifacts).

## Test plan

- [ ] CI `ci-ok` green on this PR
- [ ] After merge: Auto-tag creates `v0.7.0`
- [ ] Release workflow lint/test/gate/build publish artifacts for `v0.7.0`