### PR TITLE
release: 0.8.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Workflows pin actions by full SHA with trailing `# vX` comments so Dependabot
+# can bump pins.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -6,8 +6,12 @@
 #   (GitHub recursion guard). So auto-tag must call `gh workflow run Release`
 #   after pushing the tag. That *does* work with GITHUB_TOKEN.
 #
+# Dispatch uses --ref main so the *workflow file* is latest; the build checks
+# out the tag via inputs.tag (see RELEASE_REF in release.yml).
+#
 # Also recovers: if the tag exists but no GitHub Release was published yet,
-# re-trigger Release (e.g. after a failed publish or the 0.5.1 gap).
+# re-trigger Release (e.g. after a failed publish). Skips re-dispatch while a
+# Release run is already queued/in progress to avoid stacking full Nuitka builds.
 
 name: Auto-tag release
 
@@ -28,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -45,6 +49,18 @@ jobs:
           fi
           TAG="v${VERSION}"
           echo "version=${VERSION} tag=${TAG}"
+
+          # Refuse to mint a tag for a version with no CHANGELOG section.
+          if ! grep -qE "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md missing '## [${VERSION}]' — refusing to tag" >&2
+            echo "Roll [Unreleased] into [X.Y.Z] on the release PR before merging." >&2
+            exit 1
+          fi
+          if ! grep -qE "^\[${VERSION}\]:" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md missing compare link '[${VERSION}]:' at bottom" >&2
+            exit 1
+          fi
+          echo "OK: CHANGELOG has section and compare link for ${VERSION}"
 
           TAG_EXISTS=false
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
@@ -66,6 +82,20 @@ jobs:
           # Publish if there is no GitHub Release yet (new tag or previous miss).
           if gh release view "${TAG}" >/dev/null 2>&1; then
             echo "GitHub Release ${TAG} already exists — nothing to dispatch."
+            exit 0
+          fi
+
+          # Avoid stacking full multi-OS builds when a Release is already active
+          # (e.g. every main push while a publish is mid-flight). Concurrency on
+          # Release also serializes same-tag runs; this skips the expensive queue.
+          ACTIVE=$(
+            gh run list --workflow=Release --limit 30 \
+              --json status \
+              --jq '[.[] | select(.status=="in_progress" or .status=="queued" or .status=="pending" or .status=="waiting" or .status=="requested")] | length'
+          )
+          if [ "${ACTIVE:-0}" -gt 0 ]; then
+            echo "Release workflow already active (${ACTIVE} run(s)) — skip re-dispatch."
+            echo "If it fails, the next main push (or: gh workflow run Release --ref main -f tag=${TAG}) will retry."
             exit 0
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,18 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.3"
+          enable-cache: true
+          # Same key as test (ubuntu) so we can restore what test saved;
+          # do not save here or we race the concurrent test matrix cell.
+          cache-suffix: ${{ github.workflow }}
+          save-cache: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -42,13 +47,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.3"
+          enable-cache: true
+          # Separate from Release workflow jobs so concurrent CI+Release
+          # runs don't fight over the same cache key (noisy annotations).
+          cache-suffix: ${{ github.workflow }}
+          prune-cache: true
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/debug-windows-ocio.yml
+++ b/.github/workflows/debug-windows-ocio.yml
@@ -12,13 +12,16 @@ jobs:
   probe:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.3"
+          enable-cache: true
+          cache-suffix: ${{ github.workflow }}
+          prune-cache: true
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3
         with:
           hugo-version: "0.164.0"
           extended: true
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/public
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,14 @@
 #
 # Triggers:
 #   1. push of tag v* (human / PAT push — GITHUB_TOKEN tag pushes do NOT fire this)
-#   2. workflow_dispatch on a tag ref (used by Auto-tag release after merge to main)
+#   2. workflow_dispatch (Auto-tag after merge: --ref main -f tag=vX.Y.Z)
 #
 # Gate: lint + full pytest suite (unit + integration) must pass on all
 # platforms before any Nuitka build or GitHub Release is published.
+#
+# Cosign OIDC identity for workflow_dispatch (normal auto-tag path) is:
+#   …/release.yml@refs/heads/main
+# For a human tag-push trigger it is …@refs/tags/vX.Y.Z.
 
 name: Release
 
@@ -29,6 +33,12 @@ on:
         type: string
         default: ""
 
+# One pipeline per tag across push:tags and workflow_dispatch. Never cancel an
+# in-flight Nuitka build — queue the newer run instead.
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write
@@ -46,15 +56,55 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.RELEASE_REF }}
 
-      - uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
+      - name: Validate tag, pyproject version, and CHANGELOG
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || '' }}
+        run: |
+          set -euo pipefail
+          TAG="${RELEASE_TAG}"
+          VERSION="${TAG#v}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: RELEASE_TAG must be vX.Y.Z, got: ${TAG}" >&2
+            exit 1
+          fi
+          PY=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$VERSION" != "$PY" ]; then
+            # Emergency rebuild: explicit source_ref may diverge from the tag.
+            if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$SOURCE_REF" ]; then
+              echo "WARNING: emergency rebuild source_ref=${SOURCE_REF}; tag ${TAG} vs pyproject ${PY}"
+            else
+              echo "ERROR: tag ${TAG} does not match pyproject version ${PY} on ${RELEASE_REF}" >&2
+              exit 1
+            fi
+          else
+            echo "OK: tag ${TAG} matches pyproject ${PY} on ${RELEASE_REF}"
+          fi
+          if ! grep -qE "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md missing '## [${VERSION}]' section — refuse to ship" >&2
+            exit 1
+          fi
+          if ! grep -qE "^\[${VERSION}\]:" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md missing compare link '[${VERSION}]:' at bottom" >&2
+            exit 1
+          fi
+          echo "OK: CHANGELOG has section and compare link for ${VERSION}"
 
-      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.3"
+          enable-cache: true
+          # Same key as test (ubuntu) so we can restore what test saved;
+          # do not save here or we race the concurrent test matrix cell.
+          cache-suffix: ${{ github.workflow }}
+          save-cache: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -75,15 +125,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.RELEASE_REF }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.3"
+          enable-cache: true
+          # Separate from CI workflow jobs so concurrent CI+Release runs
+          # don't fight over the same cache key (noisy annotations).
+          cache-suffix: ${{ github.workflow }}
+          prune-cache: true
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -131,6 +186,8 @@ jobs:
 
   build:
     needs: gate
+    # Nuitka + packaging can be slow; fail hung jobs instead of burning runner hours.
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -151,20 +208,24 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.RELEASE_REF }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.3"
+          enable-cache: true
+          # Bundle group + build path; keep off the test cache key.
+          cache-suffix: ${{ github.workflow }}-build
+          prune-cache: true
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
       - name: Cache Nuitka and ccache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.cache/Nuitka
@@ -175,6 +236,13 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --group bundle
+
+      # Linux: fix_bundle_ocio uses patchelf for RPATH / SONAME rewrites.
+      - name: Install patchelf (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends patchelf
 
       # oiio-python may rewire PyOpenColorIO.so → OCIO 2.4; reinstall 2.5 first.
       - name: Ensure OpenColorIO 2.5+ linkage
@@ -219,12 +287,14 @@ jobs:
           else
             EXTRA_FLAGS+=("--linux-icon=${{ steps.icon.outputs.path }}")
           fi
+          # Flags kept in sync with `make bundle` (shared strip set + LTO).
           uv run python -m nuitka \
             $MODE \
             --output-dir=dist \
             --output-filename=exr_converter \
             --assume-yes-for-downloads \
             --python-flag=-OO \
+            --lto=yes \
             --enable-plugin=pyside6 \
             --nofollow-import-to=tkinter \
             --nofollow-import-to=unittest \
@@ -234,6 +304,10 @@ jobs:
             --noinclude-qt-translations \
             --noinclude-qt-plugins=printsupport,mediaservice,iconengines \
             --noinclude-dlls='*Qt6WebEngine*' \
+            --noinclude-dlls='*Qt6Svg*' \
+            --noinclude-dlls='*Qt6Pdf*' \
+            --noinclude-dlls='*Qt6Positioning*' \
+            --noinclude-dlls='*Qt6PrintSupport*' \
             --include-package-data=av \
             --include-package=OpenImageIO \
             --include-package-data=OpenImageIO \
@@ -431,6 +505,7 @@ jobs:
             --icon "EXR Converter.app" 150 190 \
             --hide-extension "EXR Converter.app" \
             --app-drop-link 450 190 \
+            --overwrite \
             "${{ matrix.artifact }}.${{ matrix.ext }}" \
             "dist/EXR Converter.app"
 
@@ -454,8 +529,12 @@ jobs:
             > "${APPDIR}/AppRun"
           chmod +x "${APPDIR}/AppRun"
 
+          # Pin a release tag (not "continuous") for reproducible packaging.
+          APPIMAGETOOL_VER="1.9.1"
+          APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
           curl -fSL -o appimagetool \
-            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+            "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VER}/appimagetool-x86_64.AppImage"
+          echo "${APPIMAGETOOL_SHA256}  appimagetool" | sha256sum -c -
           chmod +x appimagetool
           ARCH=x86_64 VERSION="${VERSION}" ./appimagetool \
             --no-appstream --comp zstd \
@@ -471,115 +550,245 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ env.RELEASE_TAG }}".Replace("v","")
-          iscc "/DAppVersion=$version" installer.iss
+          # windows-* images currently ship Inno Setup 6; fail clearly if gone.
+          $iscc = Get-Command iscc -ErrorAction SilentlyContinue
+          if (-not $iscc) {
+            $candidates = @(
+              "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+              "${env:ProgramFiles}\Inno Setup 6\ISCC.exe"
+            )
+            foreach ($p in $candidates) {
+              if (Test-Path $p) { $iscc = @{ Source = $p }; break }
+            }
+          }
+          if (-not $iscc) {
+            throw "iscc (Inno Setup) not found on runner — install Inno Setup 6 or update this step"
+          }
+          $isccPath = if ($iscc.Source) { $iscc.Source } else { $iscc.Path }
+          & $isccPath "/DAppVersion=$version" installer.iss
+          if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit $LASTEXITCODE" }
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.${{ matrix.ext }}
 
-  # ── Cosign (Sigstore keyless) ─────────────────────────────────────────────
-  sign:
+  # ── SignPath Foundation (Windows Authenticode) — optional ────────────────
+  # Free for qualifying open-source projects. Eliminates SmartScreen warnings.
+  #
+  # Enable by setting repository variables + secrets (see AGENTS.md):
+  #   vars:  SIGNPATH_PROJECT_SLUG, SIGNPATH_SIGNING_POLICY_SLUG,
+  #          SIGNPATH_ARTIFACT_CONFIGURATION_SLUG (optional, default exr_converter)
+  #   secrets: SIGNPATH_API_TOKEN, SIGNPATH_ORGANIZATION_ID
+  #   + SignPath GitHub App installed on this repo
+  #
+  # When vars.SIGNPATH_PROJECT_SLUG is empty, this job is skipped.
+  # Must run *before* Cosign so signatures cover the Authenticode binary.
+  sign-windows:
+    if: ${{ vars.SIGNPATH_PROJECT_SLUG != '' }}
     needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: exr_converter-windows-x86_64-setup
+          path: unsigned
+
+      # SignPath requires github-artifact-id from upload-artifact in *this* job.
+      - name: Re-upload Windows setup for SignPath
+        id: upload-unsigned
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: windows-setup-for-signpath
+          path: unsigned/*
+          retention-days: 1
+
+      - name: Submit Windows installer to SignPath
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG || 'exr_converter' }}
+          github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed
+
+      - name: Normalize signed installer name
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Ensure the signed binary keeps the release asset name.
+          mkdir -p signed-out
+          found=$(find signed -type f -name '*.exe' | head -1)
+          test -n "$found"
+          cp "$found" signed-out/exr_converter-windows-x86_64-setup.exe
+          ls -la signed-out/
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: exr_converter-windows-x86_64-setup-signed
+          path: signed-out/exr_converter-windows-x86_64-setup.exe
+
+  # ── Cosign (Sigstore keyless) + GitHub build provenance ───────────────────
+  # Runs after optional SignPath so Cosign/attest cover the final Windows bits.
+  sign:
+    needs: [build, sign-windows]
+    if: ${{ always() && needs.build.result == 'success' && (needs.sign-windows.result == 'success' || needs.sign-windows.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
+      attestations: write
     steps:
-      - uses: sigstore/cosign-installer@v4.1.1
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          path: artifacts
-          merge-multiple: true
+          path: downloaded
+
+      - name: Assemble final binaries for signing
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          for name in \
+            exr_converter-linux-x86_64 \
+            exr_converter-macos-arm64 \
+            exr_converter-macos-x86_64
+          do
+            test -d "downloaded/${name}"
+            cp -a "downloaded/${name}/." artifacts/
+          done
+          WIN_SIGNED="downloaded/exr_converter-windows-x86_64-setup-signed"
+          WIN_UNSIGNED="downloaded/exr_converter-windows-x86_64-setup"
+          if [ -d "$WIN_SIGNED" ]; then
+            echo "Cosign target: SignPath-signed Windows installer"
+            cp -a "${WIN_SIGNED}/." artifacts/
+          else
+            echo "Cosign target: unsigned Windows installer (SignPath not enabled)"
+            test -d "$WIN_UNSIGNED"
+            cp -a "${WIN_UNSIGNED}/." artifacts/
+          fi
+          echo "--- artifacts to sign ---"
+          ls -la artifacts/
+          test "$(find artifacts -type f | wc -l)" -ge 4
+
+      # SLSA-style build provenance stored in GitHub Attestations.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            artifacts/*.AppImage
+            artifacts/*.dmg
+            artifacts/*.exe
 
       - name: Sign all artifacts with Cosign
         shell: bash
         run: |
+          set -euo pipefail
           for f in artifacts/*; do
             [ -f "$f" ] || continue
+            case "$f" in
+              *.sigstore.json) continue ;;
+            esac
             echo "Signing $f ..."
             cosign sign-blob "$f" \
               --bundle "${f}.sigstore.json" \
               --yes
           done
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: cosign-bundles
-          path: artifacts/*.sigstore.json
-
-  # ── SignPath Foundation (Windows Authenticode) ────────────────────────────
-  # Free for qualifying open-source projects. Eliminates SmartScreen warnings.
-  #
-  # Prerequisites (one-time manual setup):
-  #   1. Apply at https://signpath.org/ (requires OSI license, MFA, active maintenance)
-  #   2. Install the SignPath GitHub App on this repo
-  #   3. Create a signing policy + artifact configuration in SignPath dashboard
-  #   4. Add secrets: SIGNPATH_API_TOKEN, SIGNPATH_ORGANIZATION_ID
-  #   5. Set variables: SIGNPATH_PROJECT_SLUG, SIGNPATH_SIGNING_POLICY_SLUG
-  #
-  # Uncomment the job below once onboarded:
-  #
-  # sign-windows:
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/download-artifact@v7
-  #       with:
-  #         name: exr_converter-windows-x86_64
-  #         path: unsigned
-  #
-  #     - name: Submit to SignPath
-  #       uses: signpath/github-action-submit-signing-request@v1
-  #       with:
-  #         api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-  #         organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
-  #         project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-  #         signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
-  #         artifact-configuration-slug: exr_converter
-  #         github-artifact-id: ${{ needs.build.outputs.windows-artifact-id }}
-  #         wait-for-completion: true
-  #         output-artifact-directory: signed
-  #
-  #     - uses: actions/upload-artifact@v6
-  #       with:
-  #         name: exr_converter-windows-x86_64-signed
-  #         path: signed/
+          name: release-assets
+          path: artifacts/*
 
   release:
     needs: sign
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          path: artifacts
-          merge-multiple: true
+          ref: ${{ env.RELEASE_REF }}
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-assets
+          path: release-assets
+
+      - name: Verify release asset set
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "--- release-assets ---"
+          ls -la release-assets/
+          test "$(find release-assets -type f ! -name '*.sigstore.json' | wc -l)" -ge 4
+          test "$(find release-assets -type f -name '*.sigstore.json' | wc -l)" -ge 4
+
+      - name: Build release notes from CHANGELOG
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          {
+            echo "## Changelog"
+            echo
+            python3 scripts/extract_changelog_section.py "${VERSION}"
+            echo
+            echo "## Verify artifact signatures"
+            echo
+            echo "### Cosign (Sigstore keyless)"
+            echo
+            echo "All release artifacts are signed with [Sigstore Cosign](https://docs.sigstore.dev/) (keyless)."
+            echo "Each artifact has a matching \`.sigstore.json\` bundle."
+            echo
+            echo '```bash'
+            echo "# Install cosign: https://docs.sigstore.dev/cosign/system_config/installation/"
+            echo "# Identity is release.yml on main (auto-tag dispatch) or on tags/v* (tag push)."
+            echo "cosign verify-blob <ARTIFACT_FILE> \\"
+            echo "  --bundle <ARTIFACT_FILE>.sigstore.json \\"
+            echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\"
+            echo "  --certificate-identity-regexp 'https://github.com/derek-rein/exr-converter/\\.github/workflows/release\\.yml@refs/(heads/main|tags/v.+)'"
+            echo '```'
+            echo
+            echo "### GitHub build provenance"
+            echo
+            echo "Additionally, SLSA-style provenance is published to GitHub Attestations:"
+            echo
+            echo '```bash'
+            echo "gh attestation verify <ARTIFACT_FILE> -R derek-rein/exr-converter"
+            echo '```'
+            echo
+            echo "### macOS note"
+            echo
+            echo "These builds use an **ad-hoc** code signature (not Apple notarized)."
+            echo "On first launch, right-click the app and select **Open**, or run:"
+            echo
+            echo '```bash'
+            echo 'xattr -cr "/Applications/EXR Converter.app"'
+            echo '```'
+            echo
+            echo "### Windows note"
+            echo
+            echo "Unless SignPath Authenticode is enabled for this release, Windows SmartScreen"
+            echo "may warn on first run. Prefer the Cosign/\`gh attestation\` checks above."
+          } > release-notes.md
+          echo "--- release-notes.md ---"
+          head -40 release-notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2.6.1
+        # v3 targets Node 24 (v2.x still declares Node 20 → deprecation annotations)
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: "EXR Converter ${{ env.RELEASE_TAG }}"
           generate_release_notes: true
-          files: artifacts/*
-          body: |
-            ## Verify artifact signatures
-
-            All release artifacts are signed with [Sigstore Cosign](https://docs.sigstore.dev/) (keyless).
-            Each artifact has a matching `.sigstore.json` bundle that proves it was built by this repository's GitHub Actions workflow.
-
-            ```bash
-            # Install cosign: https://docs.sigstore.dev/cosign/system_config/installation/
-            cosign verify-blob <ARTIFACT_FILE> \
-              --bundle <ARTIFACT_FILE>.sigstore.json \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-              --certificate-identity-regexp "github.com/derek-rein/exr-converter"
-            ```
-
-            ### macOS note
-            These builds use an ad-hoc code signature. On first launch, right-click the app and select **Open**, or run:
-            ```bash
-            xattr -cr "/Applications/EXR Converter.app"
-            ```
+          files: release-assets/*
+          body_path: release-notes.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,19 +195,25 @@ feature commits (PR → main)
         │  1. scripts/bump_app_version.py → pyproject + APP_VERSION
         │  2. uv lock
         │  3. commit: "release: X.Y.Z"  (only version files)
-        │  4. optional local tag vX.Y.Z  (not required for publish)
+        │  4. optional local annotated tag vX.Y.Z  (not required for publish)
         ▼
- PR → main → merge
+ PR → main → merge  (CHANGELOG must already have ## [X.Y.Z] + compare link)
         │
  Auto-tag release workflow (on push to main)
-        │  if pyproject version X.Y.Z has no tag → create + push tag
-        │  if no GitHub Release for that tag yet → `gh workflow run Release --ref vX.Y.Z`
+        │  refuse if CHANGELOG lacks ## [X.Y.Z]
+        │  if pyproject version X.Y.Z has no tag → create + push annotated tag
+        │  if no GitHub Release yet and no Release run active →
+        │      `gh workflow run Release --ref main -f tag=vX.Y.Z`
         ▼
- GitHub Actions “Release” (tag push **or** workflow_dispatch on the tag)
-        │  lint → test (3 OS) → gate → Nuitka → Cosign → GitHub Release
+ GitHub Actions “Release”
+   triggers: push tags v*  (human/PAT)  OR  workflow_dispatch (auto-tag)
+   concurrency: one run per tag (cancel-in-progress: false)
+        │  validate tag↔pyproject + CHANGELOG
+        │  lint → test (3 OS) → gate → Nuitka (4 targets)
+        │  → optional SignPath (Windows) → Cosign + GH attestations → publish
         ▼
  Artifacts: Linux AppImage, macOS DMG (arm64 + x86_64), Windows installer
-            (+ .sigstore.json bundles)
+            (+ .sigstore.json bundles; GH attestations for provenance)
 ```
 
 Tags are plain semver: **`v1.2.3`**. The tag is the published app version
@@ -215,8 +221,14 @@ Tags are plain semver: **`v1.2.3`**. The tag is the published app version
 
 **Critical GitHub quirk:** a tag created with the default **`GITHUB_TOKEN` does
 not start other workflows** (recursion guard). Auto-tag therefore **dispatches**
-Release via `workflow_dispatch` after pushing the tag. Human `git push origin v*`
-with a real user/PAT still triggers Release on `push: tags` as usual.
+Release via `workflow_dispatch` after pushing the tag. The dispatch uses
+**`--ref main`** so the *workflow file* is latest; the build checks out the tag
+via `inputs.tag` (`RELEASE_REF`). Human `git push origin v*` with a real
+user/PAT still triggers Release on `push: tags`.
+
+**Do not double-fire:** after merge, prefer Auto-tag only. Do not also push the
+local `vX.Y.Z` tag unless Auto-tag failed — a human tag push *and* a late
+dispatch can race (concurrency serializes same-tag runs, but wastes minutes).
 
 ### Prerequisites
 
@@ -233,9 +245,10 @@ with a real user/PAT still triggers Release on `push: tags` as usual.
 git checkout main && git pull origin main
 git checkout -b release/X.Y.Z
 
-# Before tagging: CHANGELOG.md must have [X.Y.Z] notes (move from [Unreleased])
+# Before tagging: CHANGELOG.md must have [X.Y.Z] notes + bottom compare link
+# (Auto-tag and Release gate both refuse to ship without them.)
 make release PART=minor PUSH=0    # or patch / major
-# → commit "release: X.Y.Z" + local tag vX.Y.Z
+# → commit "release: X.Y.Z" + local annotated tag vX.Y.Z
 # Include CHANGELOG.md in the release PR if not already on main
 # (bump only commits version files — commit changelog separately on the branch)
 
@@ -245,9 +258,10 @@ gh pr checks
 gh pr merge --merge          # or --squash per preference
 
 git checkout main && git pull origin main
-# Auto-tag release workflow pushes vX.Y.Z if missing → Release workflow runs.
+# Auto-tag: creates vX.Y.Z if missing → dispatches Release (--ref main -f tag=…).
 # Manual fallback if auto-tag is disabled or failed:
-#   git tag vX.Y.Z && git push origin vX.Y.Z
+#   git tag -a vX.Y.Z -m "release: X.Y.Z" && git push origin vX.Y.Z
+#   # or: gh workflow run Release --ref main -f tag=vX.Y.Z
 
 gh run list --workflow="Auto-tag release" --limit 3
 gh run list --workflow=Release --limit 3
@@ -294,23 +308,50 @@ gh pr checks
 
 | Job | Role |
 |-----|------|
-| `lint` | Ruff check + format |
+| `lint` | Tag↔pyproject + CHANGELOG gate, then Ruff check + format |
 | `test` | Full pytest on ubuntu / macos / windows |
 | `gate` | Aborts release if lint or any OS test failed |
-| `build` | Nuitka → AppImage / DMG / Windows setup |
-| sign / publish | Cosign + GitHub Release upload |
+| `build` | Nuitka → AppImage / DMG / Windows setup (180m timeout; LTO + Qt strip aligned with `make bundle`) |
+| `sign-windows` | Optional SignPath Authenticode (skipped unless vars configured; runs **before** Cosign) |
+| `sign` | Assemble final bits → Cosign keyless + `actions/attest-build-provenance` |
+| `release` | CHANGELOG section + verify notes → single GitHub Release upload |
 
-Local package only: `make bundle` (no GitHub Release).
+Local package only: `make bundle` (no GitHub Release). Shared Nuitka strip/LTO
+flags match CI; packaging (DMG/AppImage/Inno) is CI-only.
+
+### Actions hygiene
+
+- Third-party actions are **SHA-pinned** with trailing `# vX` comments.
+- [`.github/dependabot.yml`](.github/dependabot.yml) opens weekly grouped PRs for
+  `github-actions` bumps.
+- `astral-sh/setup-uv` pins **uv 0.12.3** (not `latest`).
+- AppImage packaging pins **appimagetool 1.9.1** and verifies SHA-256.
+
+### SignPath (optional Windows Authenticode)
+
+Skipped until you set repository **variables** (and matching **secrets**):
+
+| Kind | Name |
+|------|------|
+| secret | `SIGNPATH_API_TOKEN`, `SIGNPATH_ORGANIZATION_ID` |
+| variable | `SIGNPATH_PROJECT_SLUG`, `SIGNPATH_SIGNING_POLICY_SLUG` |
+| variable (optional) | `SIGNPATH_ARTIFACT_CONFIGURATION_SLUG` (default `exr_converter`) |
+
+Also install the SignPath GitHub App and create a project/policy/artifact
+configuration in the SignPath dashboard. When `SIGNPATH_PROJECT_SLUG` is empty,
+`sign-windows` is skipped and the unsigned Inno setup is published (Cosign still
+applies).
 
 ### Checklist before shipping
 
 - [ ] Feature work tested (`make test` / PR CI)
-- [ ] **[CHANGELOG.md](./CHANGELOG.md)** updated: `[Unreleased]` rolled into `[X.Y.Z]`
+- [ ] **[CHANGELOG.md](./CHANGELOG.md)** updated: `[Unreleased]` rolled into `[X.Y.Z]` **and** bottom compare link `[X.Y.Z]:` updated
 - [ ] On branch `release/X.Y.Z` (not direct push to `main`)
 - [ ] Working tree free of unrelated unstaged work
 - [ ] Correct `PART`; `make release … PUSH=0` → PR → merge
-- [ ] Auto-tag (or manual `git push origin vX.Y.Z`) fires Release; `gh run watch` green
+- [ ] Auto-tag (or manual tag / `gh workflow run`) fires Release; `gh run watch` green
 - [ ] `gh release view vX.Y.Z` has artifacts + signatures
+- [ ] After merge: **do not** also push a local tag unless Auto-tag failed
 
 ### Troubleshooting
 
@@ -319,15 +360,36 @@ Local package only: `make bundle` (no GitHub Release).
 | `GH013` / must use pull request | Use `release/X.Y.Z` + PR; `PUSH=0` |
 | Required status checks on main | Ship via PR so `ci-ok` runs on the PR head |
 | `No changes to commit` from `make release` | Version already bumped; `python3 scripts/bump_app_version.py show` |
+| Auto-tag refuses: CHANGELOG missing section | Add `## [X.Y.Z]` + `[X.Y.Z]:` compare link, merge fix PR |
 | Tag exists locally not on remote | After merge, retag if needed, `git push origin vX.Y.Z`. Never force-push a published public tag lightly |
 | Gate red on Release | Fix forward with a new patch; prefer not rewriting a published tag |
 | Wrong version in GUI binary | Tag must be `vX.Y.Z`; check inject-version step and `APP_VERSION` on the tagged commit |
 | OCIO 2.4 vs 2.5 in CI/local | `scripts/ensure_ocio.py` / `make ensure-ocio` |
+| `Unable to reserve cache` (setup-uv) | Benign race if two writers share a key; CI/Release use `cache-suffix` + lint `save-cache: false` |
+| Two Release runs for one tag | Concurrency group `release-vX.Y.Z` queues; avoid double-trigger (tag push + dispatch) |
 
 ### Artifact verification (users)
 
-Cosign keyless signatures ship as `*.sigstore.json` next to each asset. See README
-/ GitHub Release body for `cosign verify-blob` commands.
+**Cosign** keyless signatures ship as `*.sigstore.json` next to each asset.
+Auto-tag dispatches Release from **main**, so the OIDC certificate identity is
+typically:
+
+`https://github.com/derek-rein/exr-converter/.github/workflows/release.yml@refs/heads/main`
+
+(A pure human `git push` of the tag uses `@refs/tags/vX.Y.Z` instead.)
+
+```bash
+cosign verify-blob <ARTIFACT_FILE> \
+  --bundle <ARTIFACT_FILE>.sigstore.json \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github.com/derek-rein/exr-converter/\.github/workflows/release\.yml@refs/(heads/main|tags/v.+)'
+```
+
+**GitHub Attestations** (SLSA-style build provenance) are also recorded:
+
+```bash
+gh attestation verify <ARTIFACT_FILE> -R derek-rein/exr-converter
+```
 
 ### macOS Gatekeeper
 
@@ -343,8 +405,8 @@ xattr -cr "/Applications/EXR Converter.app"
 |----------|---------|------|
 | [CI](.github/workflows/ci.yml) | push / PR to `main` | Ruff + full pytest on 3 OS; job **`ci-ok`** requires all green |
 | [Docs](.github/workflows/docs.yml) | push / PR paths under `docs/`, `site/` | Hugo build; deploy to Pages on `main` only |
-| [Auto-tag release](.github/workflows/auto-tag-release.yml) | push to `main` | If `pyproject` version has no `vX.Y.Z` tag → push tag |
-| [Release](.github/workflows/release.yml) | tag `v*` | Same lint + tests via **`gate`** before Nuitka / publish |
+| [Auto-tag release](.github/workflows/auto-tag-release.yml) | push to `main` | CHANGELOG gate; if no `vX.Y.Z` tag → push tag; if no GitHub Release and no active run → `workflow_dispatch` Release |
+| [Release](.github/workflows/release.yml) | tag `v*` **or** `workflow_dispatch` | Tag/CHANGELOG validate + lint + tests via **`gate`** before Nuitka / Cosign / publish |
 
 Branch protection on `main` should require `ci-ok`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.8.1] — 2026-08-10
+
+### Changed
+
+- **Release pipeline hardening:** tag/CHANGELOG gates, per-tag concurrency,
+  pinned actions + uv 0.12.3, appimagetool 1.9.1 with SHA-256, Cosign identity
+  bound to `release.yml`, GitHub build provenance attestations, CHANGELOG
+  section in GitHub Release notes, optional SignPath Authenticode job (off until
+  configured). Auto-tag uses `--ref main -f tag=vX.Y.Z` and skips re-dispatch
+  while a Release run is already active.
+
+### Fixed
+
+- **Underscore EXR sequences load again:** folder browse / EXR → Video input
+  re-accepts ``name_####.ext`` pads (e.g. ``04_5d_00000.exr``) that 0.7+ had
+  ignored while standardizing **writes** on ``name.####.ext``. Frame range
+  auto-fill and the sequence browser list both sequences when a folder mixes
+  pads. Opening a folder prefers a sequence whose name matches the folder
+  name. Video → EXR output still uses dot pads only.
+- **Browser volumes / drives at top level:** the sequence and video file trees
+  no longer hide external disks. On macOS, ``QFileSystemModel`` treats
+  ``/Volumes`` as hidden under ``/``, so sticks never appeared; on Windows,
+  only the system drive was rooted. Both browsers now use a multi-root tree
+  (each mount is a top-level row) plus a **Volumes** section in the places
+  sidebar. Mounts refresh every few seconds while Browse is open.
+
+---
+
 ## [0.8.0] — 2026-08-09
 
 ### Changed
@@ -478,7 +506,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/derek-rein/exr-converter/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/derek-rein/exr-converter/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/derek-rein/exr-converter/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/derek-rein/exr-converter/compare/v0.6.0...v0.6.1

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,8 @@ src/rc_resources.py: resources.qrc resources/icons/icon.png resources/style.qss
 
 ICON ?= resources/icons/icon.icns
 
+# Shared Nuitka strip flags must stay aligned with .github/workflows/release.yml
+# (LTO + Qt noinclude set). Local target is macOS-oriented; CI is multi-OS.
 bundle: resources
 	$(UV) sync --group bundle
 	$(PYTHON) scripts/ensure_ocio.py
@@ -169,12 +171,15 @@ release:
 	git add pyproject.toml src/core/constants.py uv.lock; \
 	if git diff --staged --quiet; then echo "No changes to commit."; exit 1; fi; \
 	git commit -m "release: $${VERSION}"; \
-	git tag "$${TAG}"; \
-	echo "Created commit + tag $${TAG}"; \
+	git tag -a "$${TAG}" -m "release: $${VERSION}"; \
+	echo "Created commit + annotated tag $${TAG}"; \
 	if [ "$(PUSH)" = "1" ]; then \
 	  git push origin HEAD; \
 	  git push origin "$${TAG}"; \
 	  echo "Pushed branch and tag $${TAG} (Release workflow runs on tag push)."; \
+	  echo "NOTE: under protected main prefer PUSH=0 + PR; Auto-tag dispatches Release after merge."; \
+	  echo "Do NOT also re-push the same tag after merge — Auto-tag handles that path."; \
 	else \
-	  echo "PUSH=0: tag is local only. To run Release workflow: git push origin HEAD && git push origin $${TAG}"; \
+	  echo "PUSH=0: tag is local only. Preferred path: push branch → PR → merge → Auto-tag dispatches Release."; \
+	  echo "Manual fallback if Auto-tag is disabled: git push origin HEAD && git push origin $${TAG}"; \
 	fi

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Targets the [VFX Reference Platform CY2026](https://vfxplatform.com/#reference-p
 | macOS Intel | [**DMG**](https://github.com/derek-rein/exr-converter/releases/latest/download/exr_converter-macos-x86_64.dmg) |
 | Linux x86_64 | [**AppImage**](https://github.com/derek-rein/exr-converter/releases/latest/download/exr_converter-linux-x86_64.AppImage) |
 
-All release artifacts are [signed with Sigstore Cosign](https://docs.sigstore.dev/) — see the [releases page](https://github.com/derek-rein/exr-converter/releases) for verification instructions.
+All release artifacts are [signed with Sigstore Cosign](https://docs.sigstore.dev/)
+and carry [GitHub build provenance attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+— see the [releases page](https://github.com/derek-rein/exr-converter/releases)
+for `cosign verify-blob` and `gh attestation verify` commands.
 
 ### Running on macOS
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,7 +117,7 @@ uv run python main.py exr2video -i ./plate --codec h264 --crf 18
 
 | Option | Default | Notes |
 |--------|---------|--------|
-| `-i` / `--input` | *(required)* | Sequence **directory** or any **existing frame** from the sequence (not a literal `####` path that does not exist on disk) |
+| `-i` / `--input` | *(required)* | Sequence **directory** or any **existing frame** from the sequence (``name.####.ext`` or ``name_####.ext``; not a literal `####` path that does not exist on disk) |
 | `-o` / `--output` | next to sequence | Video path; default extension follows codec family (below) |
 | `--fps` | `24` | Frame rate |
 | `--ocio` | bundled / `$OCIO` | Config file path |

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -25,7 +25,7 @@ from a Read — see [nuke.md](./nuke.md).
 | Tab | Direction | Notes |
 |-----|-----------|--------|
 | **Video → EXR** | Decode video → OCIO → EXR sequence | **Ingest only** — never slate / burn-in / watermark. Output field uses ``name.####.exr``; that basename is written (not forced to the video stem). |
-| **EXR → Video** | Image sequence → OCIO → video | OpenEXR primary; also DPX, PNG, JPEG, WebP. Slate / burn-in / watermark via that tab’s controls. Sequences must be ``name.####.ext`` (dot pad). |
+| **EXR → Video** | Image sequence → OCIO → video | OpenEXR primary; also DPX, PNG, JPEG, WebP. Slate / burn-in / watermark via that tab’s controls. Sequences may use ``name.####.ext`` or ``name_####.ext`` pads. |
 
 Mode can be forced with `--mode video2exr|exr2video`, or inferred from `--open`
 (`auto`: image-sequence paths open **EXR → Video**, common video extensions open
@@ -46,9 +46,10 @@ Right-click the **Input** or **Output** path field for:
 field, **⌘-click** (macOS) or **Ctrl-click** (Windows/Linux) on **Browse…**
 reveals that path in the OS file manager instead.
 
-**Sequence browser** lists every supported still sequence in a folder. Mixed
-folders prefer EXR, then DPX. Display-encoded stills (PNG/JPEG/WebP) auto-suggest
-an **sRGB** source color space; EXR/DPX default toward scene-linear / metadata.
+**Sequence browser** lists every supported still sequence in a folder
+(``name.####.ext`` or ``name_####.ext``). Mixed folders prefer EXR, then DPX.
+Display-encoded stills (PNG/JPEG/WebP) auto-suggest an **sRGB** source color
+space; EXR/DPX default toward scene-linear / metadata.
 
 **Views:** the top bar has **List | Grid | Preview** plus **Inspect** (always
 available). **List** is the metadata table; **Grid** shows first-frame
@@ -62,8 +63,22 @@ Preview ↔ last list/grid mode; **Esc** leaves Preview; **Left/Right** step
 frames. Double-click or **Open** commits the **selected** sequence via its
 **first-frame path** (not the folder alone), so multi-sequence directories keep
 the chosen basename through convert, restore, and slate. Typing only a
-directory still resolves to the preferred first sequence on disk (EXR, then
-DPX). The slate editor reuses the player with live burn-in/watermark overlays.
+directory still resolves a default sequence on disk (EXR first, then DPX;
+prefers a basename matching the folder name when several sequences share the
+folder). The slate editor reuses the player with live burn-in/watermark overlays.
+
+**Volumes / drives:** both browsers show mounted volumes as **top-level** rows
+in the folder tree and under a **Volumes** heading in the places sidebar
+(system disk first, then other mounts by name). That covers:
+
+| Platform | What you see |
+|----------|----------------|
+| **macOS** | Boot volume (e.g. Macintosh HD) plus each entry under `/Volumes` (USB, network, disk images). macOS hides `/Volumes` from a plain “root `/`” file model, so sticks would otherwise be invisible. |
+| **Windows** | Each drive letter (`C:\`, `D:\`, …), not only the system drive. |
+| **Linux** | `/` plus user-facing mounts (typically `/media/…`, `/mnt/…`, `/run/media/…`); pseudo filesystems (`proc`, `sysfs`, …) are omitted. |
+
+The list refreshes every few seconds while Browse is open so plug-in / eject
+updates without restarting the dialog.
 
 **Browser layout memory** (both input browsers):
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,9 +13,26 @@ User-facing history (required on every release):
 
 **[CHANGELOG.md](../CHANGELOG.md)**
 
-**Short path:** merge a release PR that bumps `pyproject.toml` → **Auto-tag
-release** pushes `vX.Y.Z` if missing → **Release** builds and publishes. You do
-not need a manual tag push after merge (that was what skipped 0.5.0 until fixed).
+**Short path:** merge a release PR that bumps `pyproject.toml` **and** rolls
+`CHANGELOG.md` (`## [X.Y.Z]` + compare link) → **Auto-tag release** pushes
+`vX.Y.Z` if missing → dispatches **Release** with
+`gh workflow run Release --ref main -f tag=vX.Y.Z` → lint/tests/gate → Nuitka
+→ Cosign → GitHub Release.
+
+You do **not** need a manual tag push after merge (that was what skipped 0.5.0
+until fixed). After merge, do **not** also push a local `vX.Y.Z` unless Auto-tag
+failed — dual triggers race and waste runner minutes.
+
+**Hard gates (automated):** Auto-tag and Release refuse to ship if
+`CHANGELOG.md` lacks `## [X.Y.Z]` / the bottom compare link, or if the tag does
+not match `pyproject.toml` version (except explicit emergency
+`source_ref=` rebuilds).
+
+**Provenance:** each asset gets a Cosign `.sigstore.json` bundle **and** a
+GitHub Attestations record (`gh attestation verify`). Release notes include the
+CHANGELOG section for that version plus verify commands. Optional SignPath
+Authenticode for Windows is off until repository vars/secrets are set (see
+AGENTS.md).
 
 **Docs site:** Markdown under `docs/` is built with Hugo (`site/`) and published
 by the **Docs** workflow on push to `main` (path filters under `docs/`, `site/`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.8.0"
+version = "0.8.1"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/scripts/extract_changelog_section.py
+++ b/scripts/extract_changelog_section.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Extract a versioned section from CHANGELOG.md."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def extract_section(changelog: Path, version: str) -> str:
+    """Return the ``## [version]`` section body (through next ``## [`` or EOF)."""
+    text = changelog.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    heading = f"## [{version}]"
+    start: int | None = None
+    for i, line in enumerate(lines):
+        if line.startswith(heading):
+            start = i
+            break
+    if start is None:
+        print(f"error: no section for version {version!r} in {changelog}", file=sys.stderr)
+        raise SystemExit(1)
+
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith("## ["):
+            end = j
+            break
+
+    section = "".join(lines[start:end])
+    return section.rstrip("\n") + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        print(
+            f"usage: {Path(sys.argv[0]).name} VERSION [OUTPUT_PATH]",
+            file=sys.stderr,
+        )
+        return 2
+
+    version = args[0]
+    out_path = Path(args[1]) if len(args) > 1 else None
+    repo_root = Path(__file__).resolve().parent.parent
+    changelog = repo_root / "CHANGELOG.md"
+    if not changelog.is_file():
+        print(f"error: CHANGELOG.md not found at {changelog}", file=sys.stderr)
+        return 1
+
+    section = extract_section(changelog, version)
+    if out_path is None:
+        sys.stdout.write(section)
+    else:
+        out_path.write_text(section, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.8.0"
+APP_VERSION = "0.8.1"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/core/sequence.py
+++ b/src/core/sequence.py
@@ -12,9 +12,9 @@ from .constants import (
     is_scene_referred_image_ext,
 )
 
-# Canonical sequence naming for this app: ``name.####.ext`` (dot frame pad only).
-# fileseq reports basenames as ``name.`` for that form; underscore pads (``name_``)
-# are not supported for discovery or writing.
+# **Writes** use ``name.####.ext`` (dot frame pad only). **Reads** accept both
+# common pads: ``name.####.ext`` (fileseq basename ends with ``.``) and
+# ``name_####.ext`` (basename ends with ``_``).
 _DOT_PAD_PATTERN = re.compile(
     r"^(?P<name>.+)\.(?P<pad>#+)\.(?P<ext>[A-Za-z0-9]+)$",
     re.IGNORECASE,
@@ -33,6 +33,19 @@ def is_dot_frame_sequence(seq: fileseq.FileSequence) -> bool:
         return False
 
 
+def is_underscore_frame_sequence(seq: fileseq.FileSequence) -> bool:
+    """True when *seq* uses ``name_####.ext`` (basename ends with ``_``)."""
+    try:
+        return str(seq.basename()).endswith("_")
+    except Exception:
+        return False
+
+
+def is_supported_frame_sequence(seq: fileseq.FileSequence) -> bool:
+    """True when *seq* is a readable still sequence (dot or underscore pad)."""
+    return is_dot_frame_sequence(seq) or is_underscore_frame_sequence(seq)
+
+
 def parse_dot_sequence_output(
     path: str,
 ) -> tuple[str, str | None, int | None]:
@@ -44,7 +57,8 @@ def parse_dot_sequence_output(
     - ``/out/shot.1001.exr`` → ``("/out", "shot", None)`` (pad from UI/CLI)
     - ``/out`` or ``/out/`` → ``("/out", None, None)`` (name from video stem)
 
-    Underscore pads (``shot_####.exr``) are rejected with :class:`ValueError`.
+    Underscore pads (``shot_####.exr``) are rejected for **output** paths —
+    writes always use ``name.####.ext``. Reads still accept underscore pads.
     """
     raw = (path or "").strip()
     if not raw:
@@ -95,8 +109,10 @@ def _probe_resolution(filepath: str) -> tuple[int, int]:
 def _find_image_seqs(directory: str) -> list[fileseq.FileSequence]:
     """Return image FileSequences found in *directory*, sorted by format priority then basename.
 
-    Only **dot-padded** sequences (``name.####.ext``) are returned. Underscore
-    pads (``name_####.ext``) are ignored — this app always uses name-dot-frame.
+    Accepts both common pads:
+
+    - ``name.####.ext`` (dot) — preferred for **writing**
+    - ``name_####.ext`` (underscore) — common on disk from cameras / other tools
 
     OpenEXR sequences sort first so mixed folders still pick EXR by default.
     """
@@ -104,12 +120,36 @@ def _find_image_seqs(directory: str) -> list[fileseq.FileSequence]:
     out = [
         s
         for s in seqs
-        if is_image_sequence_ext(s.extension()) and s.frameSet() and is_dot_frame_sequence(s)
+        if is_image_sequence_ext(s.extension()) and s.frameSet() and is_supported_frame_sequence(s)
     ]
     return sorted(
         out,
         key=lambda s: (image_sequence_ext_priority(s.extension()), s.basename()),
     )
+
+
+def _pick_default_sequence(
+    seqs: list[fileseq.FileSequence],
+    directory: str,
+) -> fileseq.FileSequence:
+    """Choose a default sequence when the input is a folder (not a frame file).
+
+    Prefers a sequence whose basename matches the folder name (e.g. folder
+    ``04_5d`` → ``04_5d_#####.exr`` over ``04_5d-2.####.exr``), then falls
+    back to the sorted list order (EXR first, then basename).
+    """
+    if not seqs:
+        raise RuntimeError(f"No image sequences found in {directory}")
+    if len(seqs) == 1:
+        return seqs[0]
+    folder = Path(directory).name
+    if not folder:
+        return seqs[0]
+    exact = [s for s in seqs if s.basename().rstrip("._") == folder]
+    if exact:
+        # Prefer underscore/dot variants of the folder name; keep EXR-first order.
+        return exact[0]
+    return seqs[0]
 
 
 # Back-compat alias used by older call sites / tests.
@@ -334,7 +374,7 @@ def find_exr_sequence(input_path: str) -> tuple[list[str], str]:
             return [str(p)], p.stem
         raise RuntimeError(f"Not a supported image sequence frame: {p.name}")
 
-    seq = seqs[0]
+    seq = _pick_default_sequence(seqs, scan_dir)
     fs = seq.frameSet()
     if not fs:
         raise RuntimeError(f"Image sequence has no frames in {scan_dir}")
@@ -378,7 +418,7 @@ def find_exr_sequence_info(
             # Build a one-frame sequence for an isolated still.
             seq = fileseq.FileSequence(str(p))
     if seq is None:
-        seq = seqs[0]
+        seq = _pick_default_sequence(seqs, scan_dir)
 
     fs = seq.frameSet()
     if not fs:

--- a/src/gui/browser_state.py
+++ b/src/gui/browser_state.py
@@ -15,9 +15,21 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from PySide6.QtCore import QByteArray, QModelIndex, QSettings
-from PySide6.QtWidgets import QFileSystemModel, QTreeView
+from PySide6.QtWidgets import QTreeView
+
+
+@runtime_checkable
+class DirTreeModel(Protocol):
+    """Subset of QFileSystemModel / MultiRootDirModel used by browser helpers."""
+
+    def index(self, *args): ...  # path str or (row, col, parent)
+    def filePath(self, index: QModelIndex) -> str: ...
+    def isDir(self, index: QModelIndex) -> bool: ...
+    def rowCount(self, parent: QModelIndex = ...) -> int: ...
+
 
 # Shared by sequence + video browsers.
 BROWSER_GEOMETRY_KEY = "ui/browser_geometry"
@@ -208,7 +220,7 @@ def save_shared_geometry(geometry: QByteArray, settings: QSettings | None = None
     s.setValue(BROWSER_GEOMETRY_KEY, geometry)
 
 
-def collect_expanded_dirs(tree: QTreeView, model: QFileSystemModel) -> list[str]:
+def collect_expanded_dirs(tree: QTreeView, model: DirTreeModel) -> list[str]:
     """Return absolute paths of expanded directories currently loaded in the model."""
     out: list[str] = []
 
@@ -228,7 +240,7 @@ def collect_expanded_dirs(tree: QTreeView, model: QFileSystemModel) -> list[str]
     return out
 
 
-def expand_path_chain(tree: QTreeView, model: QFileSystemModel, path: str) -> bool:
+def expand_path_chain(tree: QTreeView, model: DirTreeModel, path: str) -> bool:
     """Expand every ancestor of *path* (and the path itself if it is a dir)."""
     if not path:
         return False
@@ -263,7 +275,7 @@ def expand_path_chain(tree: QTreeView, model: QFileSystemModel, path: str) -> bo
 
 def restore_tree_expanded(
     tree: QTreeView,
-    model: QFileSystemModel,
+    model: DirTreeModel,
     paths: list[str],
     focus_path: str = "",
 ) -> None:

--- a/src/gui/browser_volumes.py
+++ b/src/gui/browser_volumes.py
@@ -1,0 +1,579 @@
+"""Mounted volumes for file browsers (cross-platform).
+
+``QFileSystemModel`` with the usual ``Dirs | NoDotAndDotDot`` filter does **not**
+show macOS ``/Volumes`` (it is treated as a hidden directory), so external
+drives never appear under ``/``. On Windows, ``QDir.rootPath()`` is typically
+only the system drive (``C:/``), so ``D:`` / USB sticks are also invisible.
+
+This module:
+
+* lists **user-facing volumes** via :class:`~PySide6.QtCore.QStorageInfo`
+* provides :class:`MultiRootDirModel` — each volume is a **top-level** tree row,
+  with children from a shared :class:`~PySide6.QtWidgets.QFileSystemModel`
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from PySide6.QtCore import (
+    QAbstractItemModel,
+    QDir,
+    QMimeData,
+    QModelIndex,
+    QObject,
+    QStorageInfo,
+    Qt,
+    QUrl,
+    Signal,
+)
+from PySide6.QtWidgets import QFileSystemModel
+
+# Pseudo / system filesystems that are not useful as browser roots.
+_SKIP_FS_TYPES = frozenset(
+    {
+        "autofs",
+        "devfs",
+        "devtmpfs",
+        "proc",
+        "sysfs",
+        "tmpfs",
+        "cgroup",
+        "cgroup2",
+        "squashfs",
+        "overlay",
+        "rpc_pipefs",
+        "fusectl",
+        "debugfs",
+        "tracefs",
+        "configfs",
+        "pstore",
+        "securityfs",
+        "mqueue",
+        "hugetlbfs",
+        "binfmt_misc",
+        "bpf",
+        "nsfs",
+        "ramfs",
+        "rootfs",
+    }
+)
+
+# Path prefixes that are never useful browser roots (platform-specific).
+_SKIP_PATH_PREFIXES_UNIX = (
+    "/System/Volumes",  # macOS APFS helpers (Data, Preboot, VM, …)
+    "/private/var/vm",
+    "/dev",
+    "/proc",
+    "/sys",
+    "/run/user",  # often per-session bus mounts; real media is under /run/media
+)
+
+
+@dataclass(frozen=True, slots=True)
+class VolumeInfo:
+    """One user-facing mount the browser should treat as a top-level root."""
+
+    path: str
+    """Absolute mount path (``/``, ``/Volumes/KINGSTON``, ``C:/``, …)."""
+
+    name: str
+    """Label for the tree / places sidebar (volume name or drive letter)."""
+
+    is_system_root: bool = False
+    """True for the OS boot volume (``/`` or ``C:/``)."""
+
+
+def _norm_mount_path(path: str) -> str:
+    """Normalize a mount path for comparison (stable separators, no trailing slash)."""
+    raw = (path or "").strip()
+    if not raw:
+        return ""
+    # QStorageInfo / QDir use forward slashes on Windows; Path handles either.
+    p = Path(raw)
+    try:
+        # Prefer absolute form without resolving symlinks (keeps /Volumes/Name).
+        s = os.path.abspath(str(p))
+    except (OSError, RuntimeError, ValueError):
+        s = str(p)
+    if sys.platform == "win32":
+        s = s.replace("/", "\\")
+        # Drive roots: keep trailing backslash form as ``C:\`` style → strip to ``C:``
+        if len(s) == 3 and s[1] == ":" and s[2] in "\\/":
+            return s[:2] + "\\"
+        if len(s) == 2 and s[1] == ":":
+            return s + "\\"
+        return s.rstrip("\\") or s
+    # Unix: keep ``/`` as-is; strip trailing slashes from others.
+    if s != "/":
+        s = s.rstrip("/")
+    return s or "/"
+
+
+def _fs_type_str(info: QStorageInfo) -> str:
+    raw = info.fileSystemType()
+    if isinstance(raw, (bytes, bytearray)):
+        return bytes(raw).decode("utf-8", "replace").lower()
+    return str(raw or "").lower()
+
+
+def _should_skip_mount(info: QStorageInfo) -> bool:
+    if not info.isValid() or not info.isReady():
+        return True
+    path = _norm_mount_path(info.rootPath())
+    if not path:
+        return True
+
+    fs = _fs_type_str(info)
+    if fs in _SKIP_FS_TYPES:
+        return True
+
+    if sys.platform != "win32":
+        for prefix in _SKIP_PATH_PREFIXES_UNIX:
+            if path == prefix or path.startswith(prefix + "/"):
+                return True
+        # Linux session garbage under /run except conventional media mounts.
+        if path.startswith("/run/") and not path.startswith("/run/media"):
+            return True
+
+    # Zero-size pseudo mounts (skip unless it is the system root).
+    if not info.isRoot() and info.bytesTotal() <= 0:
+        return True
+
+    return False
+
+
+def _display_name_for(info: QStorageInfo, path: str) -> str:
+    name = (info.displayName() or info.name() or "").strip()
+    if name:
+        return name
+    if sys.platform == "win32":
+        # ``C:\`` → ``C:``
+        drive = path.rstrip("\\/")
+        return drive or path
+    base = Path(path).name
+    return base or path
+
+
+def list_browser_volumes() -> list[VolumeInfo]:
+    """Return mounted volumes suitable as browser roots (deduped, stable order).
+
+    Order: system root first, then other volumes by display name (case-insensitive).
+    """
+    found: list[VolumeInfo] = []
+    seen_paths: set[str] = set()
+    # Device identity for dedupe (``/`` vs ``/Volumes/Macintosh HD``).
+    seen_devices: set[str] = set()
+
+    for info in QStorageInfo.mountedVolumes():
+        if _should_skip_mount(info):
+            continue
+        path = _norm_mount_path(info.rootPath())
+        if path in seen_paths:
+            continue
+
+        device_raw = info.device()
+        if isinstance(device_raw, (bytes, bytearray)):
+            device = bytes(device_raw).decode("utf-8", "replace")
+        else:
+            device = str(device_raw or "")
+
+        # Prefer the true system root over firmlink duplicates (macOS).
+        if device and device in seen_devices and not info.isRoot():
+            continue
+
+        name = _display_name_for(info, path)
+        found.append(
+            VolumeInfo(
+                path=path,
+                name=name,
+                is_system_root=bool(info.isRoot()),
+            )
+        )
+        seen_paths.add(path)
+        if device:
+            seen_devices.add(device)
+
+    # Windows fallback: ensure every drive letter from QDir.drives() is present
+    # even if QStorageInfo briefly omits a ready stick.
+    if sys.platform == "win32":
+        for drive in QDir.drives():
+            path = _norm_mount_path(drive.absolutePath())
+            if not path or path in seen_paths:
+                continue
+            # Only add if the path exists / is a directory.
+            try:
+                if not Path(path).exists():
+                    continue
+            except OSError:
+                continue
+            found.append(
+                VolumeInfo(
+                    path=path,
+                    name=path.rstrip("\\/") or path,
+                    is_system_root=False,
+                )
+            )
+            seen_paths.add(path)
+
+    if not found:
+        # Absolute fallback so the tree is never empty.
+        root = _norm_mount_path(QDir.rootPath() or ("C:\\" if sys.platform == "win32" else "/"))
+        found.append(VolumeInfo(path=root, name=root, is_system_root=True))
+
+    roots = [v for v in found if v.is_system_root]
+    others = sorted(
+        [v for v in found if not v.is_system_root],
+        key=lambda v: (v.name.lower(), v.path.lower()),
+    )
+    # At most one system root (first).
+    ordered = (roots[:1] if roots else []) + others
+    if not roots and others:
+        return others
+    return ordered
+
+
+class MultiRootDirModel(QAbstractItemModel):
+    """Directory tree with each :func:`list_browser_volumes` entry as a top-level row.
+
+    Public API mirrors the subset of :class:`QFileSystemModel` used by the
+    browsers and :mod:`browser_state` helpers: ``index(path)``, ``filePath``,
+    ``isDir``, ``rowCount``, ``fileName``.
+    """
+
+    volumes_changed = Signal()
+
+    def __init__(self, parent: QObject | None = None):
+        super().__init__(parent)
+        self._fs = QFileSystemModel(self)
+        self._fs.setFilter(QDir.Filter.Dirs | QDir.Filter.NoDotAndDotDot)
+        # Watch the whole machine so every volume path can resolve.
+        # Windows: empty root → "My Computer" (all drives). Else filesystem root.
+        if sys.platform == "win32":
+            self._fs.setRootPath("")
+        else:
+            self._fs.setRootPath(QDir.rootPath() or "/")
+
+        self._volumes: list[VolumeInfo] = []
+        self._path_to_id: dict[str, int] = {}
+        self._id_to_path: list[str] = []
+
+        self._fs.directoryLoaded.connect(self._on_directory_loaded)
+        self.refresh_volumes()
+
+    # -- volume list ----------------------------------------------------------
+
+    def volumes(self) -> list[VolumeInfo]:
+        return list(self._volumes)
+
+    def refresh_volumes(self) -> bool:
+        """Rescan mounts. Returns True when the top-level list changed."""
+        new = list_browser_volumes()
+        if new == self._volumes:
+            # Still touch each root so QFileSystemModel keeps them warm.
+            for v in new:
+                self._fs.index(v.path)
+            return False
+        self.beginResetModel()
+        self._volumes = new
+        self._path_to_id.clear()
+        self._id_to_path.clear()
+        for v in self._volumes:
+            self._id_for(v.path)
+            self._fs.index(v.path)
+        self.endResetModel()
+        self.volumes_changed.emit()
+        return True
+
+    # -- path id map ----------------------------------------------------------
+
+    def _id_for(self, path: str) -> int:
+        key = _norm_mount_path(path)
+        if key not in self._path_to_id:
+            self._path_to_id[key] = len(self._id_to_path)
+            self._id_to_path.append(key)
+        return self._path_to_id[key]
+
+    def _path_of(self, index: QModelIndex) -> str:
+        if not index.isValid():
+            return ""
+        iid = index.internalId()
+        if 0 <= iid < len(self._id_to_path):
+            return self._id_to_path[iid]
+        return ""
+
+    def _volume_containing(self, path: str) -> VolumeInfo | None:
+        norm = _norm_mount_path(path)
+        if not norm:
+            return None
+        best: VolumeInfo | None = None
+        best_len = -1
+        for v in self._volumes:
+            vp = _norm_mount_path(v.path)
+            if not vp:
+                continue
+            if norm == vp:
+                return v
+            # Prefix match with boundary (avoid C:\ matching C:\foo vs C:\foobar — path sep).
+            if sys.platform == "win32":
+                prefix = vp if vp.endswith("\\") else vp + "\\"
+                if norm.lower().startswith(prefix.lower()) or norm.lower() == vp.lower():
+                    if len(vp) > best_len:
+                        best = v
+                        best_len = len(vp)
+            else:
+                if norm == vp or norm.startswith(vp.rstrip("/") + "/"):
+                    if len(vp) > best_len:
+                        best = v
+                        best_len = len(vp)
+        return best
+
+    # -- QFileSystemModel-compatible helpers ----------------------------------
+
+    def filePath(self, index: QModelIndex) -> str:  # noqa: N802 — Qt API
+        return self._path_of(index)
+
+    def fileName(self, index: QModelIndex) -> str:  # noqa: N802 — Qt API
+        if not index.isValid():
+            return ""
+        path = self._path_of(index)
+        for v in self._volumes:
+            if _norm_mount_path(v.path) == _norm_mount_path(path):
+                return v.name
+        return Path(path).name or path
+
+    def isDir(self, index: QModelIndex) -> bool:  # noqa: N802 — Qt API
+        if not index.isValid():
+            return False
+        # All nodes in this model are directories (filter is dirs-only).
+        return True
+
+    def index(self, *args):  # type: ignore[override]
+        """``index(row, column, parent=…)`` or ``index(path: str)``."""
+        if len(args) == 1 and isinstance(args[0], str):
+            return self._index_for_path(args[0])
+        row = int(args[0]) if args else 0
+        column = int(args[1]) if len(args) > 1 else 0
+        parent = args[2] if len(args) > 2 else QModelIndex()
+        return self._index_row_col(row, column, parent)
+
+    def _index_row_col(self, row: int, column: int, parent: QModelIndex) -> QModelIndex:
+        if row < 0 or column != 0:
+            return QModelIndex()
+        if not parent.isValid():
+            if row >= len(self._volumes):
+                return QModelIndex()
+            return self.createIndex(row, column, self._id_for(self._volumes[row].path))
+
+        parent_path = self._path_of(parent)
+        if not parent_path:
+            return QModelIndex()
+        fs_parent = self._fs.index(parent_path)
+        if not fs_parent.isValid():
+            return QModelIndex()
+        fs_child = self._fs.index(row, 0, fs_parent)
+        if not fs_child.isValid():
+            return QModelIndex()
+        child_path = self._fs.filePath(fs_child)
+        if not child_path:
+            return QModelIndex()
+        return self.createIndex(row, column, self._id_for(child_path))
+
+    def _index_for_path(self, path: str) -> QModelIndex:
+        if not path:
+            return QModelIndex()
+        norm = _norm_mount_path(path)
+        vol = self._volume_containing(norm)
+        if vol is None:
+            # Path may exist but volume list is stale — try raw fs index under root.
+            fs_idx = self._fs.index(path)
+            if not fs_idx.isValid():
+                try:
+                    fs_idx = self._fs.index(str(Path(path)))
+                except (OSError, RuntimeError, ValueError):
+                    return QModelIndex()
+            if not fs_idx.isValid():
+                return QModelIndex()
+            # If it is a volume root we know, use top-level row.
+            for i, v in enumerate(self._volumes):
+                if _norm_mount_path(v.path) == norm:
+                    return self.createIndex(i, 0, self._id_for(v.path))
+            # Build via parent chain under whatever volume matches after refresh.
+            return QModelIndex()
+
+        vol_path = _norm_mount_path(vol.path)
+        if norm == vol_path or (sys.platform == "win32" and norm.lower() == vol_path.lower()):
+            try:
+                row = next(
+                    i for i, v in enumerate(self._volumes) if _norm_mount_path(v.path) == vol_path
+                )
+            except StopIteration:
+                return QModelIndex()
+            return self.createIndex(row, 0, self._id_for(vol_path))
+
+        # Child of a volume: need correct *row among siblings* for createIndex.
+        fs_idx = self._fs.index(norm)
+        if not fs_idx.isValid():
+            fs_idx = self._fs.index(path)
+        if not fs_idx.isValid():
+            return QModelIndex()
+        return self.createIndex(fs_idx.row(), 0, self._id_for(self._fs.filePath(fs_idx)))
+
+    # -- QAbstractItemModel ---------------------------------------------------
+
+    def columnCount(self, parent: QModelIndex | None = None) -> int:  # noqa: ARG002
+        return 1
+
+    def rowCount(self, parent: QModelIndex | None = None) -> int:
+        if parent is None:
+            parent = QModelIndex()
+        if not parent.isValid():
+            return len(self._volumes)
+        path = self._path_of(parent)
+        if not path:
+            return 0
+        fs_idx = self._fs.index(path)
+        if not fs_idx.isValid():
+            return 0
+        return self._fs.rowCount(fs_idx)
+
+    def parent(self, index: QModelIndex) -> QModelIndex:  # type: ignore[override]
+        if not index.isValid():
+            return QModelIndex()
+        path = self._path_of(index)
+        if not path:
+            return QModelIndex()
+        # Volume roots have no parent.
+        for v in self._volumes:
+            if _norm_mount_path(v.path) == _norm_mount_path(path):
+                return QModelIndex()
+            if (
+                sys.platform == "win32"
+                and _norm_mount_path(v.path).lower() == _norm_mount_path(path).lower()
+            ):
+                return QModelIndex()
+
+        parent_path = str(Path(path).parent)
+        # Windows drive root's parent is the volume itself (already handled).
+        if sys.platform == "win32":
+            if len(path) <= 3 and path[1:2] == ":":
+                return QModelIndex()
+        else:
+            if path == "/":
+                return QModelIndex()
+
+        vol = self._volume_containing(path)
+        if vol is not None and _norm_mount_path(parent_path) == _norm_mount_path(vol.path):
+            # Parent is the volume top-level row.
+            try:
+                row = next(
+                    i
+                    for i, v in enumerate(self._volumes)
+                    if _norm_mount_path(v.path) == _norm_mount_path(vol.path)
+                )
+            except StopIteration:
+                return QModelIndex()
+            return self.createIndex(row, 0, self._id_for(vol.path))
+
+        # Deeper parent: row among its siblings via QFileSystemModel.
+        fs_parent = self._fs.index(parent_path)
+        if not fs_parent.isValid():
+            return self._index_for_path(parent_path)
+        return self.createIndex(fs_parent.row(), 0, self._id_for(parent_path))
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):
+        if not index.isValid():
+            return None
+        path = self._path_of(index)
+        if not path:
+            return None
+        if role == Qt.ItemDataRole.DisplayRole:
+            return self.fileName(index)
+        if role == Qt.ItemDataRole.ToolTipRole:
+            return path
+        if role in (
+            Qt.ItemDataRole.DecorationRole,
+            Qt.ItemDataRole.FontRole,
+            Qt.ItemDataRole.ForegroundRole,
+            Qt.ItemDataRole.BackgroundRole,
+            Qt.ItemDataRole.SizeHintRole,
+        ):
+            fs_idx = self._fs.index(path)
+            if fs_idx.isValid():
+                return self._fs.data(fs_idx, role)
+        return None
+
+    def flags(self, index: QModelIndex):
+        if not index.isValid():
+            return Qt.ItemFlag.NoItemFlags
+        return (
+            Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsDragEnabled
+        )
+
+    def mimeTypes(self) -> list[str]:
+        return ["text/uri-list"]
+
+    def mimeData(self, indexes: list[QModelIndex]) -> QMimeData:  # type: ignore[override]
+        """Expose folder paths as ``file://`` URLs for drag → Favorites."""
+        md = QMimeData()
+        urls: list[QUrl] = []
+        seen: set[str] = set()
+        for idx in indexes:
+            if not idx.isValid() or idx.column() != 0:
+                continue
+            path = self._path_of(idx)
+            if not path or path in seen:
+                continue
+            seen.add(path)
+            urls.append(QUrl.fromLocalFile(path))
+        if urls:
+            md.setUrls(urls)
+        return md
+
+    def hasChildren(self, parent: QModelIndex | None = None) -> bool:
+        if parent is None:
+            parent = QModelIndex()
+        if not parent.isValid():
+            return bool(self._volumes)
+        path = self._path_of(parent)
+        if not path:
+            return False
+        fs_idx = self._fs.index(path)
+        if not fs_idx.isValid():
+            return True  # assume expandable until loaded
+        return self._fs.hasChildren(fs_idx) or self._fs.canFetchMore(fs_idx)
+
+    def canFetchMore(self, parent: QModelIndex) -> bool:
+        if not parent.isValid():
+            return False
+        path = self._path_of(parent)
+        fs_idx = self._fs.index(path) if path else QModelIndex()
+        return bool(fs_idx.isValid() and self._fs.canFetchMore(fs_idx))
+
+    def fetchMore(self, parent: QModelIndex) -> None:
+        if not parent.isValid():
+            return
+        path = self._path_of(parent)
+        fs_idx = self._fs.index(path) if path else QModelIndex()
+        if fs_idx.isValid() and self._fs.canFetchMore(fs_idx):
+            self._fs.fetchMore(fs_idx)
+
+    def _on_directory_loaded(self, path: str) -> None:
+        """Propagate QFileSystemModel loads into our indexes."""
+        if not path:
+            return
+        # Prefer a targeted dataChanged when we can resolve the index; fall
+        # back to layoutChanged so the tree refetches row counts.
+        idx = self._index_for_path(path)
+        if not idx.isValid():
+            # Volume may still be loading under a path we track as a root.
+            for i, v in enumerate(self._volumes):
+                if _norm_mount_path(v.path) == _norm_mount_path(path):
+                    idx = self.createIndex(i, 0, self._id_for(v.path))
+                    break
+        self.layoutChanged.emit()
+        if idx.isValid():
+            self.dataChanged.emit(idx, idx)

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -46,7 +46,6 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QDoubleSpinBox,
     QFileDialog,
-    QFileSystemModel,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
@@ -127,6 +126,7 @@ from .browser_state import (
     settings_bool,
     tree_vscroll_value,
 )
+from .browser_volumes import MultiRootDirModel, list_browser_volumes
 from .preferences import (
     file_manager_label,
     path_is_revealable,
@@ -748,15 +748,41 @@ class _FavoritesDropList(QListWidget):
             super().dropEvent(event)
 
 
+def _places_divider_item(list_widget: QListWidget) -> None:
+    """Insert a thin horizontal rule row into a places list."""
+    divider = QListWidgetItem()
+    divider.setFlags(Qt.ItemFlag.NoItemFlags)
+    divider.setSizeHint(divider.sizeHint().expandedTo(QWidget().sizeHint()))
+    list_widget.addItem(divider)
+
+    from .style import _PALETTE
+
+    frame = QWidget()
+    frame_layout = QVBoxLayout(frame)
+    frame_layout.setContentsMargins(4, 6, 4, 4)
+    frame_layout.setSpacing(0)
+    line = QWidget()
+    line.setFixedHeight(1)
+    line.setStyleSheet(f"background: {_PALETTE['BORDER']};")
+    frame_layout.addWidget(line)
+    list_widget.setItemWidget(divider, frame)
+
+
 class _PlacesSidebar(QWidget):
-    """Sidebar listing OS locations and user-defined favorite directories."""
+    """Sidebar listing volumes, OS locations, and user-defined favorites."""
 
     navigate_requested = Signal(str)
 
     def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
-        self.setFixedWidth(140)
+        self.setFixedWidth(150)
         self._current_dir = ""
+        # Row ranges for rebuildable sections (volumes + static places stay fixed
+        # after first build except the volumes block which is refreshed).
+        self._vol_header_row = -1
+        self._vol_start = 0
+        self._vol_end = 0  # exclusive
+        self._fav_start = 0
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -768,6 +794,20 @@ class _PlacesSidebar(QWidget):
         self._list.customContextMenuRequested.connect(self._ctx_menu)
         self._list.dirs_dropped.connect(self._on_dirs_dropped)
 
+        # -- Volumes (drives / external media) — rebuilt by refresh_volumes --
+        vol_header = QListWidgetItem("Volumes")
+        vol_header.setFlags(Qt.ItemFlag.NoItemFlags)
+        font = vol_header.font()
+        font.setBold(True)
+        vol_header.setFont(font)
+        self._list.addItem(vol_header)
+        self._vol_header_row = 0
+        self._vol_start = 1
+        self._vol_end = 1
+        self._rebuild_volume_items()
+
+        _places_divider_item(self._list)
+
         for icon, name, location in _OS_PLACES:
             path = QStandardPaths.writableLocation(location)
             if not path or not Path(path).is_dir():
@@ -777,22 +817,7 @@ class _PlacesSidebar(QWidget):
             item.setToolTip(path)
             self._list.addItem(item)
 
-        divider = QListWidgetItem()
-        divider.setFlags(Qt.ItemFlag.NoItemFlags)
-        divider.setSizeHint(divider.sizeHint().expandedTo(QWidget().sizeHint()))
-        self._list.addItem(divider)
-
-        from .style import _PALETTE
-
-        frame = QWidget()
-        frame_layout = QVBoxLayout(frame)
-        frame_layout.setContentsMargins(4, 6, 4, 4)
-        frame_layout.setSpacing(0)
-        line = QWidget()
-        line.setFixedHeight(1)
-        line.setStyleSheet(f"background: {_PALETTE['BORDER']};")
-        frame_layout.addWidget(line)
-        self._list.setItemWidget(divider, frame)
+        _places_divider_item(self._list)
 
         header = QListWidgetItem("\u2605  Favorites")
         header.setFlags(Qt.ItemFlag.NoItemFlags)
@@ -827,6 +852,31 @@ class _PlacesSidebar(QWidget):
         layout.addLayout(btn_row)
 
         self._list.itemClicked.connect(self._on_clicked)
+
+    def refresh_volumes(self) -> None:
+        """Rescan mounted volumes in the places list."""
+        self._rebuild_volume_items()
+
+    def _rebuild_volume_items(self) -> None:
+        """Replace volume rows under the Volumes header without touching favorites."""
+        # Remove previous volume rows (from _vol_start to _vol_end exclusive).
+        while self._vol_end > self._vol_start:
+            self._list.takeItem(self._vol_start)
+            self._vol_end -= 1
+            self._fav_start = max(self._vol_start, self._fav_start - 1)
+
+        volumes = list_browser_volumes()
+        insert_at = self._vol_start
+        for vol in volumes:
+            # Prefer a disk glyph; system root gets a computer glyph.
+            icon = "\U0001f5a5" if vol.is_system_root else "\U0001f4be"
+            item = QListWidgetItem(f"{icon}  {vol.name}")
+            item.setData(Qt.ItemDataRole.UserRole, vol.path)
+            item.setToolTip(vol.path)
+            self._list.insertItem(insert_at, item)
+            insert_at += 1
+            self._fav_start += 1
+        self._vol_end = insert_at
 
     def set_current_dir(self, path: str) -> None:
         self._current_dir = path
@@ -895,7 +945,7 @@ class _PlacesSidebar(QWidget):
         save_favorite_paths(favs)
 
 
-def _setup_dir_tree(tree: QTreeView, fs_model: QFileSystemModel, places: _PlacesSidebar) -> None:
+def _setup_dir_tree(tree: QTreeView, fs_model: MultiRootDirModel, places: _PlacesSidebar) -> None:
     """Enable dragging folders to favorites + a right-click menu on a dir tree."""
     tree.setDragEnabled(True)
     tree.setDragDropMode(QAbstractItemView.DragDropMode.DragOnly)
@@ -920,7 +970,7 @@ def _setup_dir_tree(tree: QTreeView, fs_model: QFileSystemModel, places: _Places
     tree.customContextMenuRequested.connect(_menu)
 
 
-def _tree_click_toggle_expand(tree: QTreeView, fs_model: QFileSystemModel, index) -> None:
+def _tree_click_toggle_expand(tree: QTreeView, fs_model: MultiRootDirModel, index) -> None:
     """Single-click folder: expand if collapsed, collapse if already expanded.
 
     Branch-indicator clicks are handled by QTreeView itself (and do not emit
@@ -933,6 +983,24 @@ def _tree_click_toggle_expand(tree: QTreeView, fs_model: QFileSystemModel, index
         tree.collapse(index)
     else:
         tree.expand(index)
+
+
+def _wire_volume_refresh(
+    places: _PlacesSidebar,
+    model: MultiRootDirModel,
+    parent: QObject,
+) -> QTimer:
+    """Poll mounts so USB plug-in/eject updates places + tree roots."""
+
+    def _tick() -> None:
+        places.refresh_volumes()
+        model.refresh_volumes()
+
+    timer = QTimer(parent)
+    timer.setInterval(3000)
+    timer.timeout.connect(_tick)
+    timer.start()
+    return timer
 
 
 # ---------------------------------------------------------------------------
@@ -1551,18 +1619,17 @@ class SequenceBrowserDialog(QDialog):
         self._places = _PlacesSidebar()
         self._places.navigate_requested.connect(self._navigate_to)
 
-        self._fs_model = QFileSystemModel()
-        self._fs_model.setRootPath(QDir.rootPath())
-        self._fs_model.setFilter(QDir.Filter.Dirs | QDir.Filter.NoDotAndDotDot)
+        # Multi-root: each mounted volume is a top-level row (macOS /Volumes is
+        # hidden from QFileSystemModel under ``/``; Windows other drives too).
+        self._fs_model = MultiRootDirModel(self)
         self._tree = QTreeView()
         self._tree.setModel(self._fs_model)
         self._tree.setHeaderHidden(True)
-        for col in range(1, self._fs_model.columnCount()):
-            self._tree.hideColumn(col)
         self._tree.setMinimumWidth(200)
         tree_header = self._tree.header()
         tree_header.setStretchLastSection(True)
         tree_header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        self._volume_timer = _wire_volume_refresh(self._places, self._fs_model, self)
 
         self._searchable_tree = _SearchableTree(self._tree, dirs_only=True)
         self._searchable_tree.result_navigated.connect(self._navigate_to)
@@ -2594,18 +2661,15 @@ class VideoBrowserDialog(QDialog):
         self._places = _PlacesSidebar()
         self._places.navigate_requested.connect(self._navigate_to)
 
-        self._fs_model = QFileSystemModel()
-        self._fs_model.setRootPath(QDir.rootPath())
-        self._fs_model.setFilter(QDir.Filter.Dirs | QDir.Filter.NoDotAndDotDot)
+        self._fs_model = MultiRootDirModel(self)
         self._tree = QTreeView()
         self._tree.setModel(self._fs_model)
         self._tree.setHeaderHidden(True)
-        for col in range(1, self._fs_model.columnCount()):
-            self._tree.hideColumn(col)
         self._tree.setMinimumWidth(200)
         tree_header = self._tree.header()
         tree_header.setStretchLastSection(True)
         tree_header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        self._volume_timer = _wire_volume_refresh(self._places, self._fs_model, self)
 
         self._searchable_tree = _SearchableTree(self._tree, ext_filter=_VIDEO_EXTS)
         self._searchable_tree.result_navigated.connect(self._navigate_to)

--- a/tests/test_browser_volumes.py
+++ b/tests/test_browser_volumes.py
@@ -1,0 +1,140 @@
+"""Unit tests for mounted-volume discovery (file browser roots)."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.gui.browser_volumes import (
+    VolumeInfo,
+    _norm_mount_path,
+    _should_skip_mount,
+    list_browser_volumes,
+)
+
+
+def test_norm_mount_path_unix() -> None:
+    if sys.platform == "win32":
+        pytest.skip("unix path rules")
+    assert _norm_mount_path("/") == "/"
+    assert _norm_mount_path("/Volumes/Disk/") == "/Volumes/Disk"
+    assert _norm_mount_path("  /media/user/stick  ") == "/media/user/stick"
+
+
+def test_norm_mount_path_windows() -> None:
+    if sys.platform != "win32":
+        # Logic still applies when we force win-style strings through the helper
+        # only on Windows; skip elsewhere.
+        pytest.skip("windows path rules")
+    assert _norm_mount_path("C:\\") in ("C:\\", "C:/")
+    assert _norm_mount_path("D:") == "D:\\" or _norm_mount_path("D:").startswith("D:")
+
+
+def _mock_volume(
+    *,
+    path: str,
+    name: str = "",
+    display: str = "",
+    is_root: bool = False,
+    ready: bool = True,
+    valid: bool = True,
+    fs: bytes = b"apfs",
+    device: bytes = b"/dev/disk1",
+    bytes_total: int = 10**12,
+) -> MagicMock:
+    v = MagicMock()
+    v.rootPath.return_value = path
+    v.name.return_value = name
+    v.displayName.return_value = display or name or path
+    v.isRoot.return_value = is_root
+    v.isReady.return_value = ready
+    v.isValid.return_value = valid
+    v.fileSystemType.return_value = fs
+    v.device.return_value = device
+    v.bytesTotal.return_value = bytes_total
+    v.isReadOnly.return_value = False
+    return v
+
+
+def test_should_skip_pseudo_fs() -> None:
+    proc = _mock_volume(path="/proc", fs=b"proc", is_root=False, bytes_total=0)
+    assert _should_skip_mount(proc) is True
+
+
+def test_should_skip_macos_system_volumes() -> None:
+    if sys.platform == "win32":
+        pytest.skip("unix skip prefixes")
+    data = _mock_volume(
+        path="/System/Volumes/Data",
+        name="Data",
+        fs=b"apfs",
+        is_root=False,
+        device=b"disk3s5",
+    )
+    assert _should_skip_mount(data) is True
+
+
+def test_should_keep_external_volume() -> None:
+    stick = _mock_volume(
+        path="/Volumes/KINGSTON",
+        name="KINGSTON",
+        display="KINGSTON",
+        fs=b"exfat",
+        is_root=False,
+        device=b"/dev/disk8s1",
+    )
+    assert _should_skip_mount(stick) is False
+
+
+def test_list_browser_volumes_live() -> None:
+    """Smoke: real machine has at least the system root."""
+    vols = list_browser_volumes()
+    assert vols
+    assert isinstance(vols[0], VolumeInfo)
+    assert vols[0].path
+    # Exactly one system root when present.
+    roots = [v for v in vols if v.is_system_root]
+    assert len(roots) <= 1
+
+
+def test_list_browser_volumes_dedupes_macos_firmlink(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``/`` and ``/Volumes/Macintosh HD`` share a device — keep system root only."""
+    if sys.platform == "win32":
+        pytest.skip("macOS firmlink case")
+
+    root = _mock_volume(
+        path="/",
+        name="Macintosh HD",
+        display="Macintosh HD",
+        is_root=True,
+        device=b"/dev/disk3s1s1",
+        fs=b"apfs",
+    )
+    firm = _mock_volume(
+        path="/Volumes/Macintosh HD",
+        name="Macintosh HD",
+        display="Macintosh HD",
+        is_root=False,
+        device=b"/dev/disk3s1s1",  # same device
+        fs=b"apfs",
+    )
+    stick = _mock_volume(
+        path="/Volumes/USB",
+        name="USB",
+        display="USB",
+        is_root=False,
+        device=b"/dev/disk9s1",
+        fs=b"exfat",
+    )
+    monkeypatch.setattr(
+        "src.gui.browser_volumes.QStorageInfo.mountedVolumes",
+        staticmethod(lambda: [root, firm, stick]),
+    )
+    vols = list_browser_volumes()
+    paths = [v.path for v in vols]
+    assert "/" in paths
+    assert "/Volumes/Macintosh HD" not in paths
+    assert "/Volumes/USB" in paths
+    assert vols[0].is_system_root is True

--- a/tests/test_image_sequence.py
+++ b/tests/test_image_sequence.py
@@ -149,7 +149,8 @@ class TestSequenceDiscovery:
         assert pad >= 4
         assert seq.extension().lower() == ".png"
 
-    def test_underscore_sequences_ignored(self, tmp_path: Path) -> None:
+    def test_underscore_sequences_discovered(self, tmp_path: Path) -> None:
+        """Reads accept both name.####.ext and name_####.ext pads."""
         d = tmp_path / "mix"
         d.mkdir()
         for fnum in (1, 2, 3):
@@ -159,16 +160,43 @@ class TestSequenceDiscovery:
                 compression="zip",
             )
             write_exr(
-                str(d / f"bad_{fnum:05d}.exr"),
+                str(d / f"also_{fnum:05d}.exr"),
                 np.full((4, 4, 3), 0.9, dtype=np.float32),
                 compression="zip",
             )
-        paths, basename = find_exr_sequence(str(d))
-        assert basename == "good"
-        assert all("bad_" not in p for p in paths)
         rows = scan_exr_sequences(str(d))
-        assert len(rows) == 1
-        assert rows[0]["name"] == "good"
+        names = {r["name"] for r in rows}
+        assert names == {"good", "also"}
+        # Directory default: first by basename when neither matches folder name.
+        paths, basename = find_exr_sequence(str(d))
+        assert basename in names
+        assert len(paths) == 3
+        # Selecting an underscore frame resolves that sequence fully.
+        paths_u, name_u, frames_u, _pad, _seq = find_exr_sequence_info(str(d / "also_00001.exr"))
+        assert name_u == "also"
+        assert frames_u == [1, 2, 3]
+        assert all("also_" in p for p in paths_u)
+
+    def test_folder_name_prefers_matching_sequence(self, tmp_path: Path) -> None:
+        """Folder ``shot`` prefers ``shot_####`` over ``shot-alt.####``."""
+        d = tmp_path / "shot"
+        d.mkdir()
+        for fnum in (1001, 1002):
+            write_exr(
+                str(d / f"shot-alt.{fnum:04d}.exr"),
+                np.full((4, 4, 3), 0.2, dtype=np.float32),
+                compression="zip",
+            )
+            write_exr(
+                str(d / f"shot_{fnum:05d}.exr"),
+                np.full((4, 4, 3), 0.8, dtype=np.float32),
+                compression="zip",
+            )
+        paths, name, frames, _pad, seq = find_exr_sequence_info(str(d))
+        assert name == "shot"
+        assert frames == [1001, 1002]
+        assert all(Path(p).name.startswith("shot_") for p in paths)
+        assert str(seq.basename()).endswith("_")
 
     def test_parse_dot_sequence_output(self) -> None:
         d, name, pad = parse_dot_sequence_output("/tmp/out/04_5d-2.####.exr")

--- a/tests/test_pipeline_features.py
+++ b/tests/test_pipeline_features.py
@@ -495,8 +495,8 @@ class TestSequenceAndRoundTrip:
         assert len(rows) >= 1
         assert rows[0]["frames"] == 3
 
-    def test_underscore_frame_names_ignored(self, tmp_path: Path):
-        """App only supports name.####.ext (dot pad); underscore pads are ignored."""
+    def test_underscore_frame_names_discovered(self, tmp_path: Path):
+        """Reads accept name_####.ext (underscore pad) sequences."""
         d = tmp_path / "us"
         d.mkdir()
         for i in range(3):
@@ -505,8 +505,10 @@ class TestSequenceAndRoundTrip:
                 np.full((16, 32, 3), 0.3, dtype=np.float32),
                 compression="zip",
             )
-        with pytest.raises(RuntimeError, match="No image sequences"):
-            find_exr_sequence(str(d))
+        paths, basename = find_exr_sequence(str(d))
+        assert basename == "04_5d"
+        assert len(paths) == 3
+        assert all("04_5d_" in p for p in paths)
 
     def test_round_trip_video_exr_video(self, tmp_path: Path):
         vid = tmp_path / "in.mov"

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.8.0"
+version = "0.8.1"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

Patch **0.8.1**:

- **Fixes:** underscore EXR sequences again; multi-root browser volumes (macOS `/Volumes`, Windows drives)
- **CI/CD:** release pipeline hardening (CHANGELOG/tag gates, concurrency, SHA-pinned actions, uv 0.12.3, Cosign + GitHub attestations, CHANGELOG in release notes, optional SignPath)

## Test plan

- [x] `ruff check` / format on changed Python
- [x] unit tests for sequences + browser volumes
- [ ] PR CI green (`ci-ok`)
- [ ] Auto-tag creates `v0.8.1` and dispatches Release
- [ ] Release gate + multi-OS Nuitka + Cosign + GitHub Release assets