### PR TITLE
fix(ci): publish release when SignPath is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -710,6 +710,10 @@ jobs:
 
   release:
     needs: sign
+    # sign may depend on a *skipped* optional sign-windows job. GitHub treats a
+    # skipped job in the needs chain as non-success for the default success()
+    # gate, so we must re-check needs.sign.result explicitly or publish never runs.
+    if: ${{ always() && needs.sign.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
v0.8.1 built and Cosign-signed all four platform artifacts, but the **release** job was skipped because optional `sign-windows` was skipped and GitHub propagates that through the needs chain (default `success()` is false).

## Fix
Gate `release` with `if: always() && needs.sign.result == 'success'`.

## After merge
Re-dispatch Release for v0.8.1 (tag already exists; no GitHub Release yet).