### PR TITLE
release: 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.8.2] — 2026-08-10
+
+### Fixed
+
+- **GitHub Release publish when SignPath is off:** optional Windows Authenticode
+  job no longer blocks the publish step (v0.8.1 built and Cosigned all platform
+  binaries but never created the GitHub Release). Re-ships the 0.8.1 product
+  fixes and release-pipeline hardening with a working publish path.
+
+---
+
 ## [0.8.1] — 2026-08-10
 
 ### Changed
@@ -506,7 +517,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/derek-rein/exr-converter/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/derek-rein/exr-converter/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/derek-rein/exr-converter/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/derek-rein/exr-converter/compare/v0.6.1...v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.8.1"
+version = "0.8.2"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.8.1"
+APP_VERSION = "0.8.2"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.8.1"
+version = "0.8.2"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

Patch **0.8.2** re-ships 0.8.1 product + CI work with a **working GitHub Release publish path**.

v0.8.1 built and Cosign-signed all four platforms, but the `release` job was skipped when optional SignPath was off (GitHub needs-chain skip propagation). Fix is already on main (#19); this release publishes the artifacts.

## Test plan

- [ ] PR CI green
- [ ] Auto-tag `v0.8.2` + Release dispatch
- [ ] **release** job succeeds (not skipped)
- [ ] `gh release view v0.8.2` has 4 binaries + 4 sigstore bundles