### PR TITLE
release: 0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,6 +248,45 @@ jobs:
       - name: Ensure OpenColorIO 2.5+ linkage
         run: uv run python scripts/ensure_ocio.py
 
+      # Optional RED R3D SDK (private feed). Builds libr3d_bridge for packaging.
+      # Secret R3D_SDK_READ_TOKEN must read derek-rein/r3d-sdk-private releases.
+      # Without the secret, Release still ships; R3D convert reports SDK missing.
+      - name: Fetch private R3D SDK
+        id: r3d_sdk
+        shell: bash
+        env:
+          R3D_SDK_READ_TOKEN: ${{ secrets.R3D_SDK_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${R3D_SDK_READ_TOKEN:-}" ]; then
+            echo "R3D_SDK_READ_TOKEN not set — skipping R3D bridge"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          SDK_ROOT="$(uv run python scripts/fetch_r3d_sdk.py --out "${RUNNER_TEMP}/r3d-sdk")"
+          echo "R3D_SDK_ROOT=${SDK_ROOT}" >> "$GITHUB_ENV"
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "Fetched R3D SDK → ${SDK_ROOT}"
+
+      - name: R3D bridge build deps (Linux)
+        if: runner.os == 'Linux' && steps.r3d_sdk.outputs.enabled == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends g++ uuid-dev
+
+      # Puts cl.exe / link.exe on PATH for the R3D static lib link step.
+      - name: Enable MSVC environment (Windows)
+        if: runner.os == 'Windows' && steps.r3d_sdk.outputs.enabled == 'true'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Build R3D bridge
+        if: steps.r3d_sdk.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/build_r3d_bridge.py -v
+          ls -la build/r3d/
+
       - name: Inject version from tag
         shell: bash
         run: |
@@ -344,6 +383,33 @@ jobs:
               || find dist/main.dist -name 'OpenColorIO_2_4.dll' | grep -q . \
               || { echo "ERROR: OpenColorIO_2_4.dll missing from Windows bundle" >&2; exit 1; }
           fi
+
+      # Ship only Redistributable dylibs/so/dll + our bridge (private app dir).
+      # Never package SDK headers or static libs into the user-facing artifact.
+      - name: Install R3D runtime into bundle
+        if: steps.r3d_sdk.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            uv run python scripts/install_r3d_into_bundle.py "dist/EXR Converter.app"
+          else
+            uv run python scripts/install_r3d_into_bundle.py dist/main.dist
+          fi
+          # Sanity: no headers/static libs leaked into the private r3d dir.
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            R3D_DIR="dist/EXR Converter.app/Contents/MacOS/r3d"
+          else
+            R3D_DIR="dist/main.dist/r3d"
+          fi
+          test -d "$R3D_DIR"
+          if find "$R3D_DIR" \( -iname '*.a' -o -iname '*.lib' -o -iname 'R3DSDK.h' \) | grep -q .; then
+            echo "ERROR: forbidden SDK artifacts under $R3D_DIR" >&2
+            find "$R3D_DIR" | head -50
+            exit 1
+          fi
+          echo "OK: R3D redistributables in $R3D_DIR"
+          ls -la "$R3D_DIR" | head -20
 
       - name: Slim macOS bundle
         if: runner.os == 'macOS'

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,14 @@ build/
 site/public/
 site/resources/
 site/.hugo_build.lock
+
+# RED R3D SDK (proprietary — never commit headers, static libs, docs, or samples)
+R3DSDK*/
+r3d_sdk/
+**/R3DSDKv*/
+.r3d-sdk/
+.r3d-sdk-location.example
+
+# Optional local R3D bridge build output (contains RED Redistributable copies)
+build/r3d/
+resources/r3d/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ site/                   # Hugo config + theme; mounts docs/ → GitHub Pages
 | Area | Start here |
 |------|------------|
 | Convert pipeline | `src/core/convert.py`, `src/core/video.py`, `src/core/exr_io.py` |
+| Optional R3D / N-RAW | `src/core/r3d.py`, `native/r3d/`, `scripts/build_r3d_bridge.py`, `scripts/fetch_r3d_sdk.py`, `scripts/install_r3d_into_bundle.py`, [docs/r3d.md](./docs/r3d.md) |
+| Private full SDK (local) | `~/code/r3d-sdk-private/R3DSDKv9_2_1` — never commit; CI feed = private repo `derek-rein/r3d-sdk-private` release `sdk-9.2.1` |
 | Codec ladder / bit depth labels | `src/core/constants.py` |
 | CLI | `src/cli.py` |
 | Main window / post-convert actions | `src/gui/window.py` |
@@ -423,6 +425,7 @@ Branch protection on `main` should require `ci-ok`.
 | [docs/gui.md](./docs/gui.md) | GUI tabs, overlays, preferences, post-convert |
 | [docs/nuke.md](./docs/nuke.md) | Nuke menu integration |
 | [docs/plan-12bit-prores-oxideav.md](./docs/plan-12bit-prores-oxideav.md) | Future 12-bit ProRes plan (not implemented) |
+| [docs/r3d.md](./docs/r3d.md) | Optional RED R3D / N-RAW (proprietary SDK; license + build) |
 | [docs/releasing.md](./docs/releasing.md) | Short pointer here + docs-site note |
 | [integrations/nuke/](./integrations/nuke/) | Nuke `menu.py` + helpers |
 
@@ -433,6 +436,9 @@ Public site: `make docs-serve` / `make docs-build`; workflow **Docs** deploys to
 
 - Do not assume system `ffmpeg` / `ffplay` / `mpv` are installed for core features.
 - Do not claim software ProRes is 12-bit.
+- Do not commit the proprietary RED R3D SDK (headers, static libs, docs, samples)
+  or claim the SDK is open-source; only Redistributable dylibs/so/dll may ship,
+  in a private app directory, with required EULA terms — see [docs/r3d.md](./docs/r3d.md).
 - Do not reintroduce Qt WebEngine for slate.
 - Do not push version tags without a changelog section and green Release gate intent.
 - Do not hand-edit `src/rc_resources.py` or force-push published release tags without a deliberate recovery process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,27 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+---
+
+## [0.9.0] — 2026-08-10
+
 ### Added
 
+- **Optional RED R3D / N-RAW decode:** Video → EXR accepts `.r3d` and `.nev` when
+  the R3D SDK bridge is built (`make r3d-bridge` + official RED R3D SDK).
+  Decodes with IPP2 primary development (REDWideGamutRGB + Log3G10) for OCIO
+  pipelines. See [docs/r3d.md](./docs/r3d.md). The proprietary SDK is not
+  redistributed in source form.
+- **R3D CI feed:** Release builds can fetch the full SDK from a private GitHub
+  Release (`scripts/fetch_r3d_sdk.py` + secret `R3D_SDK_READ_TOKEN`), link the
+  bridge, and ship only Redistributable libs + `libr3d_bridge` under a private
+  app `r3d/` folder.
+- **R3D preview & thumbnails:** Video browser grid and sequence-player scrub use
+  low-res R3D SDK decode (not full premium). Convert remains full-quality.
+- **R3D → EXR metadata:** Camera, ISO, lens, FPS, and per-frame timecode written
+  as `exrconverter:r3d:*` attributes on output EXRs.
+- **About dialog:** RED Redistributable end-user notice (button opens full text)
+  when R3D support is present.
 - **File browser row context menu:** List/Grid right-click on sequence and video
   browsers includes **Copy File Path** and **Copy Folder Path** (same actions as
   the Input/Output path fields). Video browser also gains Preview / Open on that
@@ -533,7 +552,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/derek-rein/exr-converter/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/derek-rein/exr-converter/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/derek-rein/exr-converter/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/derek-rein/exr-converter/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+### Added
+
+- **File browser row context menu:** List/Grid right-click on sequence and video
+  browsers includes **Copy File Path** and **Copy Folder Path** (same actions as
+  the Input/Output path fields). Video browser also gains Preview / Open on that
+  menu for parity with the sequence browser.
+
+### Fixed
+
+- **File browser close while previewing:** the window close button (X) and Cancel
+  now close the sequence and video browsers immediately, even when Preview is
+  active. Escape still leaves Preview and returns to List/Grid first.
+- **Input color space highlight:** the amber auto-detect cue only appears when
+  media probe sets the source space, then clears on a timer (or immediately if
+  you pick a space manually / load a preset). It no longer stays stuck on.
+
 ---
 
 ## [0.8.2] — 2026-08-10

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #   make release PUSH=0                   # … local only; push branch + tag yourself to trigger CI
 
 .PHONY: help run lint typecheck fmt test test-unit resources bundle clean bump release \
-	sync ensure-ocio docs-serve docs-build
+	sync ensure-ocio docs-serve docs-build r3d-bridge r3d-sdk-fetch
 
 APP_NAME := exr_converter
 MACOS_BUNDLE_NAME := EXR Converter
@@ -41,6 +41,8 @@ help:
 	@echo "  make bundle                            # Nuitka standalone build"
 	@echo "  make clean                             # remove build artifacts"
 	@echo "  make docs-serve / docs-build           # Hugo site from docs/ (local / CI)"
+	@echo "  make r3d-sdk-fetch                     # download private R3D SDK (CI feed / gh auth)"
+	@echo "  make r3d-bridge                        # build optional RED R3D bridge (needs SDK)"
 	@echo ""
 	@echo "  make bump PART=patch|minor|major       # bump version (no git)"
 	@echo "  make release PART=… PUSH=0             # preferred: bump+commit+tag on release/* branch"
@@ -61,6 +63,15 @@ sync:
 
 ensure-ocio:
 	$(PYTHON) scripts/ensure_ocio.py
+
+# Optional RED R3D SDK bridge (proprietary SDK; not required for normal builds).
+# Discovers ~/code/r3d-sdk-private/R3DSDKv9_2_1 or R3D_SDK_ROOT.
+# CI: make r3d-sdk-fetch then r3d-bridge (needs R3D_SDK_READ_TOKEN / gh auth).
+r3d-sdk-fetch:
+	$(PYTHON) scripts/fetch_r3d_sdk.py
+
+r3d-bridge:
+	$(PYTHON) scripts/build_r3d_bridge.py
 
 # ── Run ──────────────────────────────────────────────────────────────────────
 
@@ -104,6 +115,8 @@ ICON ?= resources/icons/icon.icns
 bundle: resources
 	$(UV) sync --group bundle
 	$(PYTHON) scripts/ensure_ocio.py
+	# Optional R3D: build bridge when SDK is present (local stash or prior fetch).
+	-@$(PYTHON) scripts/build_r3d_bridge.py
 	$(PYTHON) -m nuitka \
 		--standalone \
 		--output-dir=dist \
@@ -140,6 +153,8 @@ bundle: resources
 	mv dist/main.app "dist/$(MACOS_BUNDLE_NAME).app"
 	# Nuitka rewires PyOpenColorIO → OIIO’s OCIO 2.4; put 2.5 back.
 	$(PYTHON) scripts/fix_bundle_ocio.py "dist/$(MACOS_BUNDLE_NAME).app"
+	# Optional R3D runtime (bridge + RED Redistributable only) into private app dir.
+	-$(PYTHON) scripts/install_r3d_into_bundle.py "dist/$(MACOS_BUNDLE_NAME).app"
 
 # ── Docs site (Hugo → GitHub Pages) ──────────────────────────────────────────
 # Source of truth: docs/*.md  ·  site config/theme: site/  ·  preview: http://127.0.0.1:1313/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Desktop app and CLI for converting between **video** and **OpenEXR** sequences with **OpenColorIO** color management and built-in **slate rendering**. Uses **PyAV** for decode/encode, **OpenImageIO** for EXR (and other still) I/O, and **PySide6** (QPainter) for the GUI and slate compositing. **EXR → video** also accepts **DPX** and display still sequences (**PNG**, **JPEG**, **WebP**).
 
+**Optional RED R3D / N-RAW:** when built with the official RED R3D SDK bridge, **Video → EXR** can decode `.r3d` and `.nev` (IPP2 primary → Log3G10 REDWideGamutRGB for OCIO), including browser thumbnails, sequence-player preview, and camera/timecode metadata on written EXRs. Release binaries may ship only RED’s allowed Redistributable libraries in a private app folder — see [docs/r3d.md](docs/r3d.md) and **Help → About** for the redistributable notice.
+
 Targets the [VFX Reference Platform CY2026](https://vfxplatform.com/#reference-platform): Python 3.13, Qt/PySide 6.8, OpenColorIO 2.5, OpenEXR 3.4, NumPy 2.3.
 
 ## Downloads
@@ -37,7 +39,7 @@ Then open it normally (double-click, or right-click → **Open**). If macOS stil
 | **Language & tooling** | Python 3.13, [uv](https://docs.astral.sh/uv/) for deps and runs, [Ruff](https://docs.astral.sh/ruff/) in CI, [Nuitka](https://nuitka.net/) for standalone bundles |
 | **UI** | [PySide6](https://doc.qt.io/qtforpython/) (Qt 6.8), Nuke-inspired dark theme |
 | **Imaging & color** | [OpenImageIO](https://openimageio.org/) (`oiio-python`), [OpenColorIO 2.5](https://opencolorio.org/) display/render transforms with a wide-gamut scene-linear **compositing space** for all overlay (slate / burn-in / watermark) compositing — prefers **ACES2065-1 (AP0)** via the `aces_interchange` role so sRGB-authored overlays are linearised and alpha-over'd without ever clipping or shifting the user's footage; falls back to the `scene_linear` role (e.g. ACEScg) on non-ACES configs.<br>Bundles the official **ACES Studio Config v4** (from [ASWF OpenColorIO-Config-ACES](https://github.com/AcademySoftwareFoundation/OpenColorIO-Config-ACES), BSD-3-Clause) which includes dozens of camera IDTs including **Apple Log** (iPhone 15/16 Pro cinematic / ProRes Log), ARRI LogC3/4, RED Log3G10, Sony S-Log/Venice, Canon, DJI, and many more. |
-| **Video & sequences** | [PyAV](https://github.com/PyAV-Org/PyAV) (FFmpeg bindings) for video I/O, [fileseq](https://github.com/justinfx/fileseq) for frame sequences & ranges |
+| **Video & sequences** | [PyAV](https://github.com/PyAV-Org/PyAV) (FFmpeg bindings) for video I/O, [fileseq](https://github.com/justinfx/fileseq) for frame sequences & ranges; optional **RED R3D SDK** bridge for `.r3d` / `.nev` |
 | **Slate / burn-in / watermark** | Native **QPainter** preview and offscreen capture (no embedded browser); burn-in and watermark are linearised into the working space and alpha-composited per-frame, then OCIO-transformed to display before encode |
 
 CI runs on **GitHub Actions**; releases publish binaries for Linux, macOS (Apple Silicon + Intel), and Windows.
@@ -69,6 +71,7 @@ built with Hugo from [`site/`](site/) and published to GitHub Pages:
 |-------|--|
 | [CLI](docs/cli.md) | `video2exr` / `exr2video` / GUI launch flags |
 | [GUI](docs/gui.md) | Tabs, overlays, preferences, post-convert |
+| [R3D / N-RAW](docs/r3d.md) | Optional RED SDK (license, build, CI, preview) |
 | [Nuke](docs/nuke.md) | Menu: open selected Read + session OCIO |
 
 ```bash

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -12,3 +12,12 @@ as the code (and [CHANGELOG.md](../CHANGELOG.md)). See
 [AGENTS.md — Documentation](../AGENTS.md#documentation-required).
 
 ## Guides
+
+| Guide | Topics |
+|-------|--------|
+| [CLI](./cli.md) | `video2exr`, `exr2video`, GUI launch flags |
+| [GUI](./gui.md) | Tabs, browsers, overlays, preferences, post-convert |
+| [Nuke](./nuke.md) | Nuke menu integration |
+| [R3D / N-RAW](./r3d.md) | Optional RED R3D SDK (proprietary; build + license) |
+| [Releasing](./releasing.md) | Pointer to maintainer release process |
+| [12-bit ProRes plan](./plan-12bit-prores-oxideav.md) | Future work (not implemented) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,14 +77,17 @@ For a one-click Nuke menu that fills these in from a **Read** node, see
 uv run python main.py video2exr -i plate.mov
 uv run python main.py video2exr -i plate.mov -o /tmp/exr_out --exr-compression zip
 uv run python main.py video2exr -i plate.mov --frame-range 1-100 --workers 4
+# Optional RED R3D / N-RAW (requires local R3D SDK bridge — docs/r3d.md):
+uv run python main.py video2exr -i clip.R3D -o /tmp/exr_out \
+  --src "Log3G10 REDWideGamutRGB" --dst ACEScg
 ```
 
 | Option | Default | Notes |
 |--------|---------|--------|
-| `-i` / `--input` | *(required)* | Input video file |
+| `-i` / `--input` | *(required)* | Input video file (also `.r3d` / `.nev` when R3D support is built) |
 | `-o` / `--output-dir` | `<input_dir>/<stem>/` | Directory for EXR frames |
 | `--ocio` | bundled / `$OCIO` | Config file path |
-| `--src` | auto | Stream color tags / codec ranking → **`Output - Rec.709`** (alias-resolved). Not an OIIO still probe. |
+| `--src` | auto | Stream color tags / codec ranking → **`Output - Rec.709`** (alias-resolved). R3D/N-RAW defaults toward **Log3G10 REDWideGamutRGB**. Not an OIIO still probe. |
 | `--dst` | `ACEScg` / scene_linear | Destination scene space (role fallbacks; not media probing) |
 | `--exr-compression` | `dwaa` | `none`, `rle`, `zip`, `zips`, `piz`, `pxr24`, `b44`, `b44a`, `dwaa`, `dwab` |
 | `--dwa-level` | library | DWA level for `dwaa`/`dwab` (`0` = lossless) |
@@ -98,6 +101,10 @@ uv run python main.py video2exr -i plate.mov --frame-range 1-100 --workers 4
 
 **Output naming:** `stem.####.exr` inside the output directory (pad width from
 `--padding`). Default directory is `<input_parent>/<stem>/` (same idea as the GUI).
+
+**RED R3D / N-RAW:** optional. Requires building the R3D bridge against the
+official proprietary SDK — see [r3d.md](./r3d.md). Without it, `.r3d` / `.nev`
+inputs error with a clear missing-SDK message.
 
 ---
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -24,7 +24,7 @@ from a Read — see [nuke.md](./nuke.md).
 
 | Tab | Direction | Notes |
 |-----|-----------|--------|
-| **Video → EXR** | Decode video → OCIO → EXR sequence | **Ingest only** — never slate / burn-in / watermark. Output field uses ``name.####.exr``; that basename is written (not forced to the video stem). |
+| **Video → EXR** | Decode video → OCIO → EXR sequence | **Ingest only** — never slate / burn-in / watermark. Output field uses ``name.####.exr``; that basename is written (not forced to the video stem). Accepts common video containers plus optional **`.r3d` / `.nev`** when the [R3D SDK bridge](./r3d.md) is available (browser thumbs + player preview use low-res R3D decode; convert is full quality; camera/timecode metadata lands on EXRs). |
 | **EXR → Video** | Image sequence → OCIO → video | OpenEXR primary; also DPX, PNG, JPEG, WebP. Slate / burn-in / watermark via that tab’s controls. Sequences may use ``name.####.ext`` or ``name_####.ext`` pads. |
 
 Mode can be forced with `--mode video2exr|exr2video`, or inferred from `--open`

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -67,6 +67,19 @@ directory still resolves a default sequence on disk (EXR first, then DPX;
 prefers a basename matching the folder name when several sequences share the
 folder). The slate editor reuses the player with live burn-in/watermark overlays.
 
+Right-click a row in **List** or a tile in **Grid** (sequence and video
+browsers) for:
+
+| Action | Behavior |
+|--------|----------|
+| **Preview** | Switch to Preview for the selected item (**Space**) |
+| **Open** | Accept the selection (same as the Open button) |
+| **Copy File Path** | First-frame path (sequence) or video file path |
+| **Copy Folder Path** | Containing directory |
+
+(Same **Copy File Path** / **Copy Folder Path** labels as the Input/Output
+path-field menu.)
+
 **Volumes / drives:** both browsers show mounted volumes as **top-level** rows
 in the folder tree and under a **Volumes** heading in the places sidebar
 (system disk first, then other mounts by name). That covers:

--- a/docs/r3d.md
+++ b/docs/r3d.md
@@ -1,0 +1,163 @@
+---
+title: RED R3D / N-RAW support
+weight: 40
+description: Optional RED R3D SDK integration for .R3D and Nikon N-RAW
+---
+
+**EXR Converter** can decode **RED R3D** (`.r3d`) and **Nikon N-RAW** (`.nev`)
+clips when built against the official **RED R3D Software Developer’s Kit**.
+Without the SDK bridge, those extensions are recognized in the UI but conversion
+fails with a clear “SDK missing” message.
+
+Related: [CLI](./cli.md) · [GUI](./gui.md) · [AGENTS.md](../AGENTS.md)
+
+---
+
+## What you get
+
+| Item | Behavior |
+|------|----------|
+| Formats | `.r3d` (classic multi-part + R3D NE), `.nev` (N-RAW) |
+| Decode | CPU path via R3D SDK (IPP2 **Primary Development** → **REDWideGamutRGB + Log3G10**) |
+| OCIO | Auto-detect source space prefers Log3G10 / RWG names on the active config |
+| Output | Same video→EXR pipeline (EXR compression, scale ladder, frame range, workers) |
+| GPU | Not used in this integration yet (CUDA / Metal / OpenCL left for a later pass) |
+| Preview | Sequence player + video browser (half-res decode for scrub) |
+| Thumbnails | Grid thumbs via sixteenth-res decode (fast ID, not full premium) |
+| Metadata | Clip + per-frame timecode written to EXR as ``exrconverter:r3d:*`` attrs |
+
+Scale maps to the SDK resolution ladder (full / half / quarter / …) for faster
+proxies; odd scale factors may apply a small software resize after decode.
+
+---
+
+## License (read this)
+
+The R3D SDK is **proprietary** (RED.COM / Nikon). Terms live in the
+**SDK License Agreement** shipped with the SDK package — always verify the
+copy you downloaded.
+
+Summary of constraints that affect this project (not a substitute for the legal text):
+
+- **Royalty-free** use to build applications that add significant functionality.
+- You may redistribute **only** the **Redistributable** dynamic libraries (+ LUTs
+  in original form) in a **private (non-shared) directory** used only by your app.
+- You must **not** redistribute: headers, static libraries, sample source, or
+  documentation.
+- End-user distribution must include required **EULA** language protecting RED
+  (no reverse engineering, ownership, disclaimers, liability limits, etc.).
+- Pure open-source licenses can conflict with those mandatory end-user
+  restrictions. Practical options: optional/offline install of redistributables,
+  clear docs, and a product EULA when shipping binaries that include RED libs.
+
+**Do not commit the R3D SDK tree into the public git repository.** This repo only
+contains *our* bridge source (`native/r3d/`) and Python glue (`src/core/r3d.py`).
+
+Contact RED for edge cases: `RED-r3dsdk@nikon.com`.
+
+---
+
+## Where the full SDK lives (maintainers)
+
+| Location | Purpose |
+|----------|---------|
+| `~/code/r3d-sdk-private/R3DSDKv9_2_1/` | Local full SDK unpack (headers + static + redistributable) |
+| Private GitHub repo [`derek-rein/r3d-sdk-private`](https://github.com/derek-rein/r3d-sdk-private) | README + package script only (**no SDK blobs in git**) |
+| Private Release tag `sdk-9.2.1` asset `R3DSDKv9_2_1-full.tar.gz` | **CI build-time feed** for public `exr-converter` Releases |
+
+Public **GitHub Release artifacts** for EXR Converter may include only:
+
+- `libr3d_bridge.{dylib,so,dll}`
+- RED `Redistributable/*` dynamic libraries
+
+…under a private app folder (`…/r3d/`), never headers or static libs.
+
+### Refresh the private CI feed
+
+```bash
+# After unpacking a new official SDK under ~/code/r3d-sdk-private/R3DSDKv9_*
+cd ~/code/r3d-sdk-private
+./scripts/package_release.sh
+# retags/uploads R3DSDKv9_2_1-full.tar.gz to release sdk-9.2.1
+```
+
+---
+
+## Developer setup (local)
+
+```bash
+# Full SDK already at the recommended path:
+#   ~/code/r3d-sdk-private/R3DSDKv9_2_1
+
+cd ~/code/exr-converter
+make r3d-bridge
+# → build/r3d/libr3d_bridge.* + build/r3d/redistributable/
+
+# Or pull the same tarball CI uses (needs gh auth or R3D_SDK_READ_TOKEN):
+make r3d-sdk-fetch   # → .r3d-sdk/R3DSDKv9_2_1 (gitignored)
+make r3d-bridge
+```
+
+Override discovery:
+
+| Env var | Meaning |
+|---------|---------|
+| `R3D_SDK_ROOT` | Unpacked SDK root for **building** the bridge |
+| `EXR_CONVERTER_R3D_BRIDGE` | Path to `libr3d_bridge.*` (or its directory) |
+| `EXR_CONVERTER_R3D_LIBS` / `R3D_SDK_LIBS` | Folder containing `REDR3D.*` redistributables |
+| `R3D_SDK_READ_TOKEN` | PAT that can download the private Release asset |
+
+Convert:
+
+```bash
+uv run python main.py video2exr -i /path/clip.R3D -o /tmp/exr_out \
+  --src "Log3G10 REDWideGamutRGB" --dst ACEScg
+```
+
+---
+
+## CI / GitHub Release builds
+
+The **Release** workflow (Nuitka multi-OS):
+
+1. If secret **`R3D_SDK_READ_TOKEN`** is set → download `sdk-9.2.1` / `R3DSDKv9_2_1-full.tar.gz` from the private repo.
+2. Build `libr3d_bridge` (macOS / Linux / Windows + MSVC).
+3. After Nuitka, copy **bridge + Redistributable only** into `…/r3d/` next to the executable.
+4. Refuse the build if headers / `.a` / `.lib` appear under that folder.
+
+If the secret is missing, Release still publishes the app **without** R3D support.
+
+```bash
+# Set or rotate the secret (fine-grained PAT with read on r3d-sdk-private is ideal)
+gh secret set R3D_SDK_READ_TOKEN --repo derek-rein/exr-converter
+```
+
+---
+
+## Packaging layout (shipped)
+
+```text
+macOS:  EXR Converter.app/Contents/MacOS/r3d/
+Linux:  <dist>/r3d/
+Windows:<dist>/r3d/
+          libr3d_bridge.*
+          REDR3D.*  REDDecoder.*  …   # original Redistributable names only
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `R3D bridge library not found` | `make r3d-bridge` / set `EXR_CONVERTER_R3D_BRIDGE` |
+| `RED Redistributable libraries not found` | Set `EXR_CONVERTER_R3D_LIBS` or rebuild bridge (copies redistributables) |
+| `InitializeSdk failed` | Wrong folder (must contain `REDR3D.*`); SDK version mismatch |
+| CI skips R3D | Secret `R3D_SDK_READ_TOKEN` not set or cannot read private release |
+| Wrong colors | Use Log3G10 / RWG source (auto-detect) — primary pipeline is not display Rec.709 |
+| Multi-part classic R3D | Point at any part (e.g. `…_001.R3D`); the SDK loads siblings |
+
+Sample clips (from RED / Nikon, not this repo):
+
+- https://www.red.com/sample-r3d-files  
+- Nikon N-RAW / R3D NE sample downloads (see SDK `Readme.txt`)

--- a/native/r3d/r3d_bridge.cpp
+++ b/native/r3d/r3d_bridge.cpp
@@ -1,0 +1,401 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * C ABI bridge for the RED R3D SDK (CPU decode path).
+ * Links against RED static lib + loads redistributable dylibs at InitializeSdk.
+ *
+ * Redistribute only this bridge object code + RED Redistributable/ dynamic
+ * libraries (original form, private app directory). Never ship RED headers,
+ * static libs, sample sources, or SDK documentation.
+ */
+
+#include "r3d_bridge.h"
+
+#include "R3DSDK.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <new>
+#include <string>
+
+using namespace R3DSDK;
+
+namespace {
+
+std::mutex g_mu;
+bool g_initialized = false;
+std::string g_last_error;
+
+void set_error(const std::string &msg)
+{
+    g_last_error = msg;
+}
+
+unsigned char *aligned_malloc(size_t &size_needed, size_t &offset_out)
+{
+    // R3D requires 16-byte alignment for output buffers.
+    unsigned char *buffer = static_cast<unsigned char *>(std::malloc(size_needed + 15U));
+    if (!buffer) {
+        offset_out = 0;
+        size_needed = 0;
+        return nullptr;
+    }
+    uintptr_t ptr = reinterpret_cast<uintptr_t>(buffer);
+    if ((ptr % 16U) == 0U) {
+        offset_out = 0;
+        return buffer;
+    }
+    offset_out = 16U - (ptr % 16U);
+    return buffer + offset_out;
+}
+
+VideoDecodeMode map_mode(int mode)
+{
+    switch (mode) {
+    case R3D_DECODE_HALF_PREMIUM:
+        return DECODE_HALF_RES_PREMIUM;
+    case R3D_DECODE_HALF_GOOD:
+        return DECODE_HALF_RES_GOOD;
+    case R3D_DECODE_QUARTER_GOOD:
+        return DECODE_QUARTER_RES_GOOD;
+    case R3D_DECODE_EIGHTH_GOOD:
+        return DECODE_EIGHT_RES_GOOD;
+    case R3D_DECODE_SIXTEENTH_GOOD:
+        return DECODE_SIXTEENTH_RES_GOOD;
+    case R3D_DECODE_FULL_PREMIUM:
+    default:
+        return DECODE_FULL_RES_PREMIUM;
+    }
+}
+
+void dims_for_mode(size_t full_w, size_t full_h, int mode, size_t &w, size_t &h)
+{
+    size_t div = 1;
+    switch (mode) {
+    case R3D_DECODE_HALF_PREMIUM:
+    case R3D_DECODE_HALF_GOOD:
+        div = 2;
+        break;
+    case R3D_DECODE_QUARTER_GOOD:
+        div = 4;
+        break;
+    case R3D_DECODE_EIGHTH_GOOD:
+        div = 8;
+        break;
+    case R3D_DECODE_SIXTEENTH_GOOD:
+        div = 16;
+        break;
+    default:
+        div = 1;
+        break;
+    }
+    w = full_w / div;
+    h = full_h / div;
+    if (w < 1)
+        w = 1;
+    if (h < 1)
+        h = 1;
+}
+
+void apply_pipeline(Clip *clip, ImageProcessingSettings &ip, int pipeline)
+{
+    clip->GetDefaultImageProcessingSettings(ip);
+
+    if (pipeline == R3D_PIPELINE_CLIP_DEFAULT) {
+        return;
+    }
+
+    // IPP2 primary RAW development → REDWideGamutRGB + Log3G10 (ideal for OCIO).
+    // Request ColorVersion3; the SDK raises the floor to MinimumColorVersion() if needed.
+    ip.Version = ColorVersion3;
+    ip.ImagePipelineMode = Primary_Development_Only;
+    // Also set explicit RWG/Log3G10 for legacy clips that cannot use Primary mode.
+    ip.ColorSpace = ImageColorREDWideGamutRGB;
+    ip.GammaCurve = ImageGammaLog3G10;
+}
+
+} // namespace
+
+extern "C" {
+
+int r3d_bridge_available(void)
+{
+    return 1;
+}
+
+int r3d_bridge_initialize(const char *libs_path)
+{
+    std::lock_guard<std::mutex> lock(g_mu);
+    if (g_initialized) {
+        return 0;
+    }
+    if (!libs_path || !libs_path[0]) {
+        set_error("r3d_bridge_initialize: empty libs path");
+        return -1;
+    }
+    InitializeStatus st = InitializeSdk(libs_path, OPTION_RED_NONE);
+    if (st != ISInitializeOK) {
+        set_error(std::string("InitializeSdk failed: ") + std::to_string(static_cast<int>(st))
+                  + " path=" + libs_path);
+        // Still finalize so a later retry is clean.
+        FinalizeSdk();
+        return static_cast<int>(st);
+    }
+    g_initialized = true;
+    g_last_error.clear();
+    return 0;
+}
+
+void r3d_bridge_finalize(void)
+{
+    std::lock_guard<std::mutex> lock(g_mu);
+    if (g_initialized) {
+        FinalizeSdk();
+        g_initialized = false;
+    }
+}
+
+int r3d_bridge_is_initialized(void)
+{
+    std::lock_guard<std::mutex> lock(g_mu);
+    return g_initialized ? 1 : 0;
+}
+
+void r3d_bridge_sdk_version(char *buf, size_t buf_len)
+{
+    if (!buf || buf_len == 0) {
+        return;
+    }
+    const char *v = GetSdkVersion();
+    if (!v) {
+        buf[0] = '\0';
+        return;
+    }
+    std::strncpy(buf, v, buf_len - 1);
+    buf[buf_len - 1] = '\0';
+}
+
+int r3d_bridge_identify(const char *utf8_path)
+{
+    if (!utf8_path) {
+        return R3D_FILE_UNKNOWN;
+    }
+    return IdentifyFile(utf8_path);
+}
+
+void *r3d_bridge_open(const char *utf8_path)
+{
+    if (!utf8_path || !utf8_path[0]) {
+        set_error("r3d_bridge_open: empty path");
+        return nullptr;
+    }
+    if (!r3d_bridge_is_initialized()) {
+        set_error("r3d_bridge_open: SDK not initialized");
+        return nullptr;
+    }
+    Clip *clip = new (std::nothrow) Clip(utf8_path);
+    if (!clip) {
+        set_error("r3d_bridge_open: out of memory");
+        return nullptr;
+    }
+    if (clip->Status() != LSClipLoaded) {
+        set_error(std::string("Failed to load clip: ") + utf8_path
+                  + " status=" + std::to_string(static_cast<int>(clip->Status())));
+        delete clip;
+        return nullptr;
+    }
+    return clip;
+}
+
+void r3d_bridge_close(void *clip)
+{
+    if (!clip) {
+        return;
+    }
+    delete static_cast<Clip *>(clip);
+}
+
+int r3d_bridge_clip_info(void *clip_ptr, R3DBridgeClipInfo *out)
+{
+    if (!clip_ptr || !out) {
+        set_error("r3d_bridge_clip_info: null argument");
+        return -1;
+    }
+    Clip *clip = static_cast<Clip *>(clip_ptr);
+    std::memset(out, 0, sizeof(*out));
+    out->width = static_cast<uint32_t>(clip->Width());
+    out->height = static_cast<uint32_t>(clip->Height());
+    out->frame_count = static_cast<uint32_t>(clip->VideoFrameCount());
+    out->fps = clip->VideoAudioFramerate();
+    // Hint for OCIO auto-detect (primary Log3G10 / RWG).
+    std::strncpy(out->colorspace_hint, "Log3G10 REDWideGamutRGB", sizeof(out->colorspace_hint) - 1);
+    r3d_bridge_sdk_version(out->sdk_version, sizeof(out->sdk_version));
+    return 0;
+}
+
+size_t r3d_bridge_decode_buffer_bytes(
+    void *clip_ptr, int decode_mode, uint32_t *out_w, uint32_t *out_h)
+{
+    if (!clip_ptr) {
+        return 0;
+    }
+    Clip *clip = static_cast<Clip *>(clip_ptr);
+    size_t w = 0, h = 0;
+    dims_for_mode(clip->Width(), clip->Height(), decode_mode, w, h);
+    if (out_w)
+        *out_w = static_cast<uint32_t>(w);
+    if (out_h)
+        *out_h = static_cast<uint32_t>(h);
+    // 16-bit RGB interleaved
+    return w * h * 3U * 2U;
+}
+
+int r3d_bridge_decode_frame(
+    void *clip_ptr,
+    uint32_t frame_index,
+    int decode_mode,
+    int pipeline,
+    float *out_rgb_f32,
+    size_t out_rgb_bytes,
+    uint32_t *out_w,
+    uint32_t *out_h)
+{
+    if (!clip_ptr || !out_rgb_f32) {
+        set_error("r3d_bridge_decode_frame: null argument");
+        return -1;
+    }
+    Clip *clip = static_cast<Clip *>(clip_ptr);
+    if (frame_index >= clip->VideoFrameCount()) {
+        set_error("r3d_bridge_decode_frame: frame index out of range");
+        return -2;
+    }
+
+    size_t w = 0, h = 0;
+    dims_for_mode(clip->Width(), clip->Height(), decode_mode, w, h);
+    const size_t n_pix = w * h * 3U;
+    const size_t need_f32 = n_pix * sizeof(float);
+    if (out_rgb_bytes < need_f32) {
+        set_error("r3d_bridge_decode_frame: output buffer too small");
+        return -3;
+    }
+
+    size_t mem_needed = n_pix * 2U; // 16-bit
+    size_t align_offset = 0;
+    size_t adjusted = mem_needed;
+    unsigned char *img = aligned_malloc(adjusted, align_offset);
+    if (!img) {
+        set_error("r3d_bridge_decode_frame: alloc failed");
+        return -4;
+    }
+    // Pointer returned by aligned_malloc may be offset; free base separately.
+    unsigned char *base = img - align_offset;
+
+    ImageProcessingSettings *ip = new (std::nothrow) ImageProcessingSettings();
+    if (!ip) {
+        std::free(base);
+        set_error("r3d_bridge_decode_frame: IP alloc failed");
+        return -4;
+    }
+    apply_pipeline(clip, *ip, pipeline);
+
+    VideoDecodeJob job;
+    job.OutputBufferSize = mem_needed;
+    job.OutputBuffer = img;
+    job.Mode = map_mode(decode_mode);
+    job.PixelType = PixelType_16Bit_RGB_Interleaved;
+    job.ImageProcessing = ip;
+
+    DecodeStatus st = clip->DecodeVideoFrame(static_cast<size_t>(frame_index), job);
+    if (st != DSDecodeOK) {
+        delete ip;
+        std::free(base);
+        set_error(std::string("DecodeVideoFrame failed: ") + std::to_string(static_cast<int>(st)));
+        return static_cast<int>(st);
+    }
+
+    // Convert 16-bit interleaved RGB → float32 0–1.
+    const uint16_t *src = reinterpret_cast<const uint16_t *>(img);
+    const float scale = 1.0f / 65535.0f;
+    for (size_t i = 0; i < n_pix; ++i) {
+        out_rgb_f32[i] = static_cast<float>(src[i]) * scale;
+    }
+
+    if (out_w)
+        *out_w = static_cast<uint32_t>(w);
+    if (out_h)
+        *out_h = static_cast<uint32_t>(h);
+
+    delete ip;
+    std::free(base);
+    return 0;
+}
+
+const char *r3d_bridge_last_error(void)
+{
+    return g_last_error.c_str();
+}
+
+int r3d_bridge_metadata_string(
+    void *clip_ptr, const char *key, char *buf, size_t buf_len)
+{
+    if (!clip_ptr || !key || !buf || buf_len == 0) {
+        set_error("r3d_bridge_metadata_string: null argument");
+        return -1;
+    }
+    buf[0] = '\0';
+    Clip *clip = static_cast<Clip *>(clip_ptr);
+    if (!clip->MetadataExists(key)) {
+        return 0;
+    }
+    std::string val = clip->MetadataItemAsString(key);
+    if (val.empty()) {
+        return 0;
+    }
+    std::strncpy(buf, val.c_str(), buf_len - 1);
+    buf[buf_len - 1] = '\0';
+    return 1;
+}
+
+int r3d_bridge_absolute_timecode(
+    void *clip_ptr, uint32_t frame_index, char *buf, size_t buf_len)
+{
+    if (!clip_ptr || !buf || buf_len == 0) {
+        set_error("r3d_bridge_absolute_timecode: null argument");
+        return -1;
+    }
+    buf[0] = '\0';
+    Clip *clip = static_cast<Clip *>(clip_ptr);
+    if (frame_index >= clip->VideoFrameCount()) {
+        return 0;
+    }
+    const char *tc = clip->AbsoluteTimecode(static_cast<size_t>(frame_index));
+    if (!tc || !tc[0]) {
+        return 0;
+    }
+    std::strncpy(buf, tc, buf_len - 1);
+    buf[buf_len - 1] = '\0';
+    return 1;
+}
+
+int r3d_bridge_edge_timecode(
+    void *clip_ptr, uint32_t frame_index, char *buf, size_t buf_len)
+{
+    if (!clip_ptr || !buf || buf_len == 0) {
+        set_error("r3d_bridge_edge_timecode: null argument");
+        return -1;
+    }
+    buf[0] = '\0';
+    Clip *clip = static_cast<Clip *>(clip_ptr);
+    if (frame_index >= clip->VideoFrameCount()) {
+        return 0;
+    }
+    const char *tc = clip->EdgeTimecode(static_cast<size_t>(frame_index));
+    if (!tc || !tc[0]) {
+        return 0;
+    }
+    std::strncpy(buf, tc, buf_len - 1);
+    buf[buf_len - 1] = '\0';
+    return 1;
+}
+
+} // extern "C"

--- a/native/r3d/r3d_bridge.h
+++ b/native/r3d/r3d_bridge.h
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Thin C ABI over the proprietary RED R3D SDK.
+ *
+ * Build only when you have a local copy of the official R3D SDK (not redistributed
+ * with this repository). See docs/r3d.md.
+ *
+ * This header is project-owned and may be redistributed with the open-source app.
+ * Do NOT ship RED headers, static libraries, or SDK documentation.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_WIN32)
+#  if defined(R3D_BRIDGE_EXPORTS)
+#    define R3D_BRIDGE_API __declspec(dllexport)
+#  else
+#    define R3D_BRIDGE_API __declspec(dllimport)
+#  endif
+#else
+#  define R3D_BRIDGE_API __attribute__((visibility("default")))
+#endif
+
+/* Decode quality / resolution ladder (maps to R3D VideoDecodeMode). */
+enum R3DBridgeDecodeMode {
+    R3D_DECODE_FULL_PREMIUM = 0,
+    R3D_DECODE_HALF_PREMIUM = 1,
+    R3D_DECODE_HALF_GOOD = 2,
+    R3D_DECODE_QUARTER_GOOD = 3,
+    R3D_DECODE_EIGHTH_GOOD = 4,
+    R3D_DECODE_SIXTEENTH_GOOD = 5,
+};
+
+/* Color pipeline for conversion (IPP2 primary development when possible). */
+enum R3DBridgePipeline {
+    /* IPP2 primary RAW → REDWideGamutRGB + Log3G10 (best for OCIO → ACEScg). */
+    R3D_PIPELINE_PRIMARY_LOG3G10 = 0,
+    /* Clip / RMD defaults as stored on set. */
+    R3D_PIPELINE_CLIP_DEFAULT = 1,
+};
+
+/* IdentifyFile result. */
+enum R3DBridgeFileId {
+    R3D_FILE_UNKNOWN = 0,
+    R3D_FILE_R3D = 1,
+    R3D_FILE_NEV_NRAW = 3,
+    R3D_FILE_R3D_NE = 4,
+};
+
+typedef struct R3DBridgeClipInfo {
+    uint32_t width;
+    uint32_t height;
+    uint32_t frame_count;
+    float fps;
+    int file_id; /* R3DBridgeFileId */
+    char sdk_version[256];
+    char colorspace_hint[64]; /* e.g. "Log3G10 REDWideGamutRGB" */
+} R3DBridgeClipInfo;
+
+/* Returns 1 if the bridge was built with R3D SDK linkage. Always 1 for this binary. */
+R3D_BRIDGE_API int r3d_bridge_available(void);
+
+/* Initialize the SDK. *libs_path* must be a UTF-8 folder containing REDR3D.* etc.
+ * Call once before open/decode. Returns 0 on success. */
+R3D_BRIDGE_API int r3d_bridge_initialize(const char *libs_path);
+
+/* Finalize SDK (safe to call even if initialize failed). */
+R3D_BRIDGE_API void r3d_bridge_finalize(void);
+
+/* 1 if InitializeSdk succeeded in this process. */
+R3D_BRIDGE_API int r3d_bridge_is_initialized(void);
+
+/* Copy SDK version string into buf (NUL-terminated). */
+R3D_BRIDGE_API void r3d_bridge_sdk_version(char *buf, size_t buf_len);
+
+/* Quick file type without full parse. */
+R3D_BRIDGE_API int r3d_bridge_identify(const char *utf8_path);
+
+/* Open clip (spanning multi-part R3D loads automatically). Opaque handle. */
+R3D_BRIDGE_API void *r3d_bridge_open(const char *utf8_path);
+
+R3D_BRIDGE_API void r3d_bridge_close(void *clip);
+
+/* Fill info for an open clip. Returns 0 on success. */
+R3D_BRIDGE_API int r3d_bridge_clip_info(void *clip, R3DBridgeClipInfo *out);
+
+/* Decode frame_index (0-based) into *out_rgb_f32* as contiguous H×W×3 float32
+ * interleaved RGB in 0–1 (or log-encoded 0–1 for Log3G10 primary).
+ * *out_w / *out_h* receive the decoded dimensions for the chosen mode.
+ * Returns 0 on success. */
+R3D_BRIDGE_API int r3d_bridge_decode_frame(
+    void *clip,
+    uint32_t frame_index,
+    int decode_mode, /* R3DBridgeDecodeMode */
+    int pipeline, /* R3DBridgePipeline */
+    float *out_rgb_f32,
+    size_t out_rgb_bytes,
+    uint32_t *out_w,
+    uint32_t *out_h);
+
+/* Bytes required for a decode buffer at the given mode (aligned size may be larger). */
+R3D_BRIDGE_API size_t r3d_bridge_decode_buffer_bytes(
+    void *clip, int decode_mode, uint32_t *out_w, uint32_t *out_h);
+
+/* Human-readable last error (thread-local best-effort; process-wide is fine). */
+R3D_BRIDGE_API const char *r3d_bridge_last_error(void);
+
+/* Clip-level metadata string for *key* (case-insensitive RMD key).
+ * Writes NUL-terminated UTF-8 into *buf*. Returns 1 if present and non-empty,
+ * 0 if missing / empty, -1 on error. */
+R3D_BRIDGE_API int r3d_bridge_metadata_string(
+    void *clip, const char *key, char *buf, size_t buf_len);
+
+/* Absolute (TOD) timecode for *frame_index* (0-based). Returns 1 on success. */
+R3D_BRIDGE_API int r3d_bridge_absolute_timecode(
+    void *clip, uint32_t frame_index, char *buf, size_t buf_len);
+
+/* Edge (run-record) timecode for *frame_index* (0-based). Returns 1 on success. */
+R3D_BRIDGE_API int r3d_bridge_edge_timecode(
+    void *clip, uint32_t frame_index, char *buf, size_t buf_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.8.2"
+version = "0.9.0"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/scripts/build_r3d_bridge.py
+++ b/scripts/build_r3d_bridge.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Build the optional R3D SDK C ABI bridge shared library.
+
+Requires a local copy of the official RED R3D SDK (headers + static lib +
+Redistributable dynamic libraries). The SDK is proprietary — do not commit it.
+
+Usage:
+  R3D_SDK_ROOT=/path/to/R3DSDKv9_2_1 python3 scripts/build_r3d_bridge.py
+  # or place the SDK at ./R3DSDKv9_2_1 and run:
+  python3 scripts/build_r3d_bridge.py
+
+Outputs:
+  build/r3d/libr3d_bridge.{dylib,so,dll}
+  build/r3d/redistributable/   (copied RED dynamic libs for runtime)
+
+See docs/r3d.md for license and packaging notes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "native" / "r3d" / "r3d_bridge.cpp"
+HDR_DIR = ROOT / "native" / "r3d"
+OUT_DIR = ROOT / "build" / "r3d"
+
+
+def _find_sdk(explicit: str | None) -> Path:
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit).expanduser().resolve())
+    env = os.environ.get("R3D_SDK_ROOT", "").strip()
+    if env:
+        candidates.append(Path(env).expanduser().resolve())
+    # Private stash (recommended local layout) + CI fetch cache.
+    candidates.append((Path.home() / "code" / "r3d-sdk-private" / "R3DSDKv9_2_1").resolve())
+    candidates.append((ROOT / ".r3d-sdk" / "R3DSDKv9_2_1").resolve())
+    candidates.append((ROOT / ".r3d-sdk").resolve())
+    # Common local drop locations (gitignored — never commit the SDK).
+    for name in ("R3DSDKv9_2_1", "R3DSDK", "r3d_sdk"):
+        candidates.append((ROOT / name).resolve())
+        candidates.append((Path.home() / "sdk" / name).resolve())
+        candidates.append((Path.home() / "code" / "r3d-sdk-private" / name).resolve())
+
+    for c in candidates:
+        if (c / "Include" / "R3DSDK.h").is_file():
+            return c
+    raise SystemExit(
+        "R3D SDK not found. Set R3D_SDK_ROOT, or place the SDK at "
+        "~/code/r3d-sdk-private/R3DSDKv9_2_1, or run: "
+        "python3 scripts/fetch_r3d_sdk.py  (private CI feed). "
+        "See docs/r3d.md."
+    )
+
+
+def _platform_bits() -> tuple[str, str, str, list[str]]:
+    """Return (lib_subdir, redistrib_subdir, shared_ext, extra_link_args)."""
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system == "Darwin":
+        # Universal static lib covers arm64 + x86_64.
+        return (
+            "mac64",
+            "mac",
+            "dylib",
+            [
+                "-framework",
+                "Foundation",
+                "-framework",
+                "CoreFoundation",
+                "-framework",
+                "IOKit",
+                "-framework",
+                "Metal",
+                "-framework",
+                "AppKit",
+                "-lc++",
+            ],
+        )
+    if system == "Linux":
+        return "linux64", "linux", "so", ["-ldl", "-lpthread", "-luuid", "-lstdc++"]
+    if system == "Windows":
+        # Prefer VS2017 MD release static lib (compatible with VS2019+).
+        return "win64", "win", "dll", []
+    raise SystemExit(f"Unsupported platform: {system} {machine}")
+
+
+def _static_lib(sdk: Path, lib_subdir: str) -> Path:
+    system = platform.system()
+    if system == "Darwin":
+        p = sdk / "Lib" / lib_subdir / "libR3DSDK-libcpp.a"
+        if p.is_file():
+            return p
+    elif system == "Linux":
+        for name in ("libR3DSDKPIC-cpp11.a", "libR3DSDK-cpp11.a", "libR3DSDKPIC.a", "libR3DSDK.a"):
+            p = sdk / "Lib" / lib_subdir / name
+            if p.is_file():
+                return p
+    else:
+        # Windows: pick 2017 MD release.
+        for name in (
+            "R3DSDK-2017MD.lib",
+            "R3DSDK-2015MD.lib",
+            "R3DSDK-2013MD.lib",
+        ):
+            p = sdk / "Lib" / lib_subdir / name
+            if p.is_file():
+                return p
+    raise SystemExit(f"No suitable static library under {sdk / 'Lib' / lib_subdir}")
+
+
+def build(sdk: Path, out_dir: Path, verbose: bool) -> Path:
+    lib_subdir, redistrib_subdir, ext, extra = _platform_bits()
+    static = _static_lib(sdk, lib_subdir)
+    redistrib_src = sdk / "Redistributable" / redistrib_subdir
+    if not redistrib_src.is_dir():
+        raise SystemExit(f"Missing Redistributable folder: {redistrib_src}")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_lib = out_dir / f"libr3d_bridge.{ext}"
+
+    include = sdk / "Include"
+    if not SRC.is_file():
+        raise SystemExit(f"Missing bridge source: {SRC}")
+
+    system = platform.system()
+    if system == "Windows":
+        # Expect cl.exe on PATH (Developer Command Prompt).
+        cmd = [
+            "cl.exe",
+            "/nologo",
+            "/O2",
+            "/EHsc",
+            "/std:c++17",
+            f"/I{include}",
+            f"/I{HDR_DIR}",
+            "/DR3D_BRIDGE_EXPORTS",
+            "/LD",
+            str(SRC),
+            str(static),
+            f"/Fe:{out_lib}",
+        ]
+    else:
+        cxx = os.environ.get("CXX", "c++")
+        cmd = [
+            cxx,
+            "-std=c++17",
+            "-O2",
+            "-fPIC",
+            "-shared",
+            f"-I{include}",
+            f"-I{HDR_DIR}",
+            "-DR3D_BRIDGE_EXPORTS",
+            str(SRC),
+            str(static),
+            "-o",
+            str(out_lib),
+            *extra,
+        ]
+        if system == "Darwin":
+            # Allow loading RED dylibs from same folder as the bridge at runtime.
+            cmd.extend(
+                [
+                    "-Wl,-rpath,@loader_path",
+                    "-Wl,-rpath,@loader_path/redistributable",
+                ]
+            )
+        elif system == "Linux":
+            cmd.extend(["-Wl,-rpath,$ORIGIN", "-Wl,-rpath,$ORIGIN/redistributable"])
+
+    if verbose:
+        print(" ".join(cmd), file=sys.stderr)
+
+    subprocess.check_call(cmd)
+
+    # Copy only Redistributable dynamic libraries (allowed by RED license).
+    dest_redist = out_dir / "redistributable"
+    if dest_redist.exists():
+        shutil.rmtree(dest_redist)
+    shutil.copytree(redistrib_src, dest_redist)
+
+    print(f"Built {out_lib}")
+    print(f"Redistributables → {dest_redist}")
+    print(f"SDK version root: {sdk}")
+    return out_lib
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--sdk",
+        default=None,
+        help="Path to unpacked R3D SDK root (or set R3D_SDK_ROOT)",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=OUT_DIR,
+        help=f"Output directory (default: {OUT_DIR})",
+    )
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+    sdk = _find_sdk(args.sdk)
+    build(sdk, args.out.resolve(), args.verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_r3d_sdk.py
+++ b/scripts/fetch_r3d_sdk.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Download the private R3D SDK tarball for local/CI builds.
+
+Expects a GitHub Release on a **private** repo (default: derek-rein/r3d-sdk-private)
+with asset ``R3DSDKv9_2_1-full.tar.gz`` (or override via env).
+
+Auth (first match wins):
+  * ``R3D_SDK_READ_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN``
+  * ``gh auth token`` (local developer machines)
+
+Usage:
+  python3 scripts/fetch_r3d_sdk.py
+  python3 scripts/fetch_r3d_sdk.py --out /tmp/r3d-sdk
+
+Prints the unpacked SDK root path on stdout (last line) and sets nothing else;
+export yourself::
+
+  export R3D_SDK_ROOT="$(python3 scripts/fetch_r3d_sdk.py)"
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_REPO = "derek-rein/r3d-sdk-private"
+DEFAULT_TAG = "sdk-9.2.1"
+DEFAULT_ASSET = "R3DSDKv9_2_1-full.tar.gz"
+# Prefer repo-local cache (gitignored) then XDG-ish home cache.
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _token() -> str:
+    for key in ("R3D_SDK_READ_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            return val
+    try:
+        out = subprocess.check_output(
+            ["gh", "auth", "token"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return ""
+
+
+def _api_download(repo: str, tag: str, asset: str, dest: Path, token: str) -> None:
+    """Download a release asset via the GitHub API (private-repo friendly)."""
+    # Resolve asset id via release metadata.
+    api = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
+    req = urllib.request.Request(
+        api,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "exr-converter-fetch-r3d-sdk",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            import json
+
+            data = json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")[:500]
+        raise SystemExit(f"Failed to fetch release {repo}@{tag}: HTTP {e.code}\n{body}") from e
+
+    asset_id = None
+    for a in data.get("assets") or []:
+        if a.get("name") == asset:
+            asset_id = a.get("id")
+            break
+    if not asset_id:
+        names = [a.get("name") for a in (data.get("assets") or [])]
+        raise SystemExit(f"Asset {asset!r} not found on {repo}@{tag}. Available: {names}")
+
+    url = f"https://api.github.com/repos/{repo}/releases/assets/{asset_id}"
+    req2 = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "exr-converter-fetch-r3d-sdk",
+        },
+    )
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urllib.request.urlopen(req2, timeout=600) as resp, dest.open("wb") as f:
+            shutil.copyfileobj(resp, f)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")[:500]
+        raise SystemExit(f"Failed to download asset {asset}: HTTP {e.code}\n{body}") from e
+
+
+def _find_sdk_root(extract_dir: Path) -> Path:
+    direct = extract_dir / "Include" / "R3DSDK.h"
+    if direct.is_file():
+        return extract_dir
+    for child in sorted(extract_dir.iterdir()):
+        if child.is_dir() and (child / "Include" / "R3DSDK.h").is_file():
+            return child
+    raise SystemExit(f"No R3DSDK.h under {extract_dir} after extract")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--repo",
+        default=os.environ.get("R3D_SDK_GITHUB_REPO", DEFAULT_REPO),
+        help=f"owner/name of private SDK repo (default {DEFAULT_REPO})",
+    )
+    ap.add_argument(
+        "--tag",
+        default=os.environ.get("R3D_SDK_RELEASE_TAG", DEFAULT_TAG),
+        help=f"release tag (default {DEFAULT_TAG})",
+    )
+    ap.add_argument(
+        "--asset",
+        default=os.environ.get("R3D_SDK_ASSET", DEFAULT_ASSET),
+        help=f"asset filename (default {DEFAULT_ASSET})",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="unpack directory (default: .r3d-sdk/ under repo or $R3D_SDK_CACHE)",
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="re-download even if SDK already present",
+    )
+    args = ap.parse_args()
+
+    cache = args.out
+    if cache is None:
+        env_cache = os.environ.get("R3D_SDK_CACHE", "").strip()
+        cache = Path(env_cache) if env_cache else (ROOT / ".r3d-sdk")
+    cache = cache.expanduser().resolve()
+
+    # Already unpacked?
+    existing = None
+    if (cache / "Include" / "R3DSDK.h").is_file():
+        existing = cache
+    else:
+        for child in cache.glob("R3DSDK*") if cache.is_dir() else []:
+            if (child / "Include" / "R3DSDK.h").is_file():
+                existing = child
+                break
+    if existing is not None and not args.force:
+        print(f"Using existing SDK at {existing}", file=sys.stderr)
+        print(existing)
+        return
+
+    token = _token()
+    if not token:
+        raise SystemExit(
+            "No GitHub token. Set R3D_SDK_READ_TOKEN (or GH_TOKEN), or run `gh auth login`."
+        )
+
+    cache.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="r3d-sdk-") as tmp:
+        tarball = Path(tmp) / args.asset
+        print(f"Downloading {args.repo}@{args.tag} / {args.asset} …", file=sys.stderr)
+        _api_download(args.repo, args.tag, args.asset, tarball, token)
+        print(f"Extracting → {cache}", file=sys.stderr)
+        # Clean previous extract of same layout.
+        for child in list(cache.iterdir()) if cache.is_dir() else []:
+            if child.name.startswith("R3DSDK") or child.name == "Include":
+                if child.is_dir():
+                    shutil.rmtree(child)
+                else:
+                    child.unlink()
+        with tarfile.open(tarball, "r:gz") as tf:
+            tf.extractall(cache, filter="data")
+
+    sdk_root = _find_sdk_root(cache)
+    print(f"R3D SDK ready: {sdk_root}", file=sys.stderr)
+    print(sdk_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_r3d_into_bundle.py
+++ b/scripts/install_r3d_into_bundle.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Copy optional R3D bridge + RED Redistributable libs into a Nuitka dist.
+
+Layout written (private app directory — RED license)::
+
+  <bundle>/r3d/libr3d_bridge.{dylib,so,dll}
+  <bundle>/r3d/REDR3D.* …
+  <bundle>/r3d/… (other redistributables)
+
+On macOS app bundles, *bundle* is ``Contents/MacOS`` (next to the executable).
+
+Usage::
+
+  python3 scripts/install_r3d_into_bundle.py "dist/EXR Converter.app"
+  python3 scripts/install_r3d_into_bundle.py dist/main.dist
+
+If ``build/r3d/libr3d_bridge.*`` is missing, exits 0 with a skip message
+(optional feature).
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD = ROOT / "build" / "r3d"
+
+
+def _bridge_name() -> str:
+    system = platform.system()
+    if system == "Darwin":
+        return "libr3d_bridge.dylib"
+    if system == "Windows":
+        return "libr3d_bridge.dll"
+    return "libr3d_bridge.so"
+
+
+def _macos_exec_dir(app: Path) -> Path:
+    mac_os = app / "Contents" / "MacOS"
+    if mac_os.is_dir():
+        return mac_os
+    return app
+
+
+def resolve_install_root(target: Path) -> Path:
+    target = target.resolve()
+    if target.suffix == ".app" or target.name.endswith(".app"):
+        return _macos_exec_dir(target)
+    return target
+
+
+def install(target: Path, build_dir: Path = BUILD) -> Path | None:
+    bridge = build_dir / _bridge_name()
+    # Windows may also produce r3d_bridge.dll
+    if not bridge.is_file():
+        alt = build_dir / "r3d_bridge.dll"
+        if alt.is_file():
+            bridge = alt
+    if not bridge.is_file():
+        print(f"skip: no bridge at {bridge} (R3D optional)", file=sys.stderr)
+        return None
+
+    redist = build_dir / "redistributable"
+    if not redist.is_dir():
+        print(f"ERROR: missing redistributable dir {redist}", file=sys.stderr)
+        raise SystemExit(2)
+
+    root = resolve_install_root(target)
+    dest = root / "r3d"
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True)
+
+    shutil.copy2(bridge, dest / bridge.name)
+    for item in redist.iterdir():
+        if item.is_file():
+            shutil.copy2(item, dest / item.name)
+        elif item.is_dir():
+            shutil.copytree(item, dest / item.name)
+
+    print(f"Installed R3D runtime → {dest}")
+    return dest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("bundle", type=Path, help="App bundle, main.dist, or install root")
+    ap.add_argument(
+        "--build-dir",
+        type=Path,
+        default=BUILD,
+        help=f"bridge build output (default {BUILD})",
+    )
+    args = ap.parse_args()
+    if not args.bundle.exists():
+        raise SystemExit(f"bundle path not found: {args.bundle}")
+    install(args.bundle, args.build_dir.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.8.2"
+APP_VERSION = "0.9.0"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/core/convert.py
+++ b/src/core/convert.py
@@ -264,7 +264,40 @@ def run_video_to_exr(
     Files are always written as ``{output_name}.{frame:0N}.ext`` (dot pad only).
     *output_name* defaults to the video stem when empty. Slate / burn-in /
     watermark are **never** applied on this path.
+
+    RED R3D / Nikon N-RAW (``.r3d`` / ``.nev``) use the optional R3D SDK bridge
+    when available (see ``docs/r3d.md``); other formats use PyAV.
     """
+    from .r3d import R3DUnavailableError, is_r3d_path
+    from .r3d import is_available as r3d_available
+
+    if is_r3d_path(video_path):
+        if not r3d_available():
+            from .r3d import unavailable_reason
+
+            raise R3DUnavailableError(unavailable_reason())
+        _run_r3d_to_exr(
+            video_path,
+            output_dir,
+            ocio_cfg,
+            src_space,
+            dst_space,
+            progress=progress,
+            cancel_check=cancel_check,
+            log=log,
+            compression=compression,
+            workers=workers,
+            config_source=config_source,
+            config_path=config_path,
+            scale=scale,
+            padding=padding,
+            start_frame=start_frame,
+            frame_set=frame_set,
+            exr_opts=exr_opts,
+            output_name=output_name,
+        )
+        return
+
     ocio_cfg = _ensure_ocio(ocio_cfg, config_source, config_path)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -466,6 +499,217 @@ def _v2e_serial(
     if log:
         nuke_pat = "#" * padding
         log(f"Wrote {written} EXR frames \u2192 {output_dir / f'{stem}.{nuke_pat}.exr'}")
+
+
+# ---- r3d / n-raw -> exr ----------------------------------------------------
+
+
+def _run_r3d_to_exr(
+    video_path: str,
+    output_dir: Path,
+    ocio_cfg: OCIO.Config | None,
+    src_space: str,
+    dst_space: str,
+    progress: ProgressCallback | None = None,
+    cancel_check: Callable[[], bool] | None = None,
+    log: LogCallback | None = None,
+    compression: str = "dwaa",
+    workers: int = 0,
+    config_source: str = "",
+    config_path: str = "",
+    scale: float = 1.0,
+    padding: int = 4,
+    start_frame: int = 1001,
+    frame_set: set[int] | None = None,
+    exr_opts: dict[str, str] | None = None,
+    output_name: str = "",
+) -> None:
+    """Decode RED R3D / Nikon N-RAW via the R3D SDK bridge → OCIO → EXR."""
+    from .r3d import R3DClip, decode_mode_for_scale, sdk_version
+
+    ocio_cfg = _ensure_ocio(ocio_cfg, config_source, config_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = (output_name or Path(video_path).stem).strip()
+    stem = Path(stem).name
+    if not stem:
+        stem = Path(video_path).stem
+
+    mode = decode_mode_for_scale(scale)
+    # When using native half/quarter decode, skip a second software resize unless
+    # the requested scale does not match a decode ladder step exactly.
+    ladder_scale = {
+        0: 1.0,
+        1: 0.5,
+        2: 0.5,
+        3: 0.25,
+        4: 0.125,
+        5: 0.0625,
+    }.get(mode, 1.0)
+    extra_scale = scale / ladder_scale if ladder_scale > 0 else scale
+    need_extra_resize = abs(extra_scale - 1.0) > 0.02
+
+    n_workers = workers if workers > 0 else _DEFAULT_WORKERS
+    fmt = f"0{padding}d"
+
+    with R3DClip(video_path) as clip:
+        info = clip.info
+        full_w, full_h = info.width, info.height
+        total = max(1, info.frame_count)
+        ow, oh = _scaled_dims(full_w, full_h, scale)
+        render_total = len(frame_set) if frame_set else total
+
+        # Clip-level R3D metadata once; per-frame timecode added below.
+        base_attrs: dict[str, str] = {
+            f"exrconverter:r3d:{k}": v for k, v in clip.clip_metadata_dict().items() if v
+        }
+
+        if log:
+            res_info = f"{full_w}x{full_h}" if scale >= 1.0 else f"{full_w}x{full_h} → {ow}x{oh}"
+            range_info = f", range trimmed to {render_total}" if frame_set else ""
+            log(f"Input: {video_path}  ({res_info}, {total} frames{range_info})")
+            log(f"R3D SDK: {sdk_version() or info.sdk_version}")
+            log(f"R3D decode: mode={mode} pipeline=IPP2 primary Log3G10/RWG")
+            if base_attrs.get("exrconverter:r3d:camera_model"):
+                log(f"R3D camera: {base_attrs['exrconverter:r3d:camera_model']}")
+            nuke_pat = "#" * max(1, int(padding))
+            log(f"Output sequence: {output_dir / f'{stem}.{nuke_pat}.exr'}")
+
+        use_pool = n_workers > 1 and bool(config_source or config_path)
+        if log:
+            thr = f"{n_workers} workers" if use_pool else "single-threaded"
+            log(f"OCIO: {src_space} → {dst_space}  ({thr})")
+
+        max_idx = max(frame_set) if frame_set else 0
+        written = 0
+        finished = 0
+
+        def _frame_attrs(idx_0: int) -> dict[str, str]:
+            attrs = dict(base_attrs)
+            tc = clip.absolute_timecode(idx_0)
+            if tc:
+                attrs["exrconverter:r3d:absolute_timecode"] = tc
+            etc = clip.edge_timecode(idx_0)
+            if etc:
+                attrs["exrconverter:r3d:edge_timecode"] = etc
+            attrs["exrconverter:r3d:source_frame"] = str(idx_0)
+            return attrs
+
+        def _indices() -> list[int]:
+            if frame_set:
+                return sorted(i for i in frame_set if 1 <= i <= total)
+            return list(range(1, total + 1))
+
+        indices = _indices()
+        if not indices:
+            raise RuntimeError("No frames selected for R3D decode.")
+
+        if not use_pool:
+            cpu = make_cpu_processor(ocio_cfg, src_space, dst_space)
+            for idx_1based in indices:
+                if cancel_check and cancel_check():
+                    raise RuntimeError("Cancelled")
+                if frame_set and max_idx and idx_1based > max_idx:
+                    break
+                idx_0 = idx_1based - 1
+                rgb = clip.decode_frame(idx_0, mode=mode)
+                if need_extra_resize and (rgb.shape[1], rgb.shape[0]) != (ow, oh):
+                    # Simple box resize via numpy (rare path; prefer ladder modes).
+                    rgb = _resize_rgb_f32(rgb, ow, oh)
+                elif not need_extra_resize and ladder_scale < 1.0:
+                    # Ensure even dims for EXR path consistency.
+                    pass
+                h, w = rgb.shape[:2]
+                buf = np.ascontiguousarray(rgb, dtype=np.float32)
+                desc = OCIO.PackedImageDesc(buf, w, h, 3)
+                cpu.apply(desc)
+                frame_num = start_frame + idx_1based - 1
+                out_path = output_dir / f"{stem}.{frame_num:{fmt}}.exr"
+                write_exr(
+                    str(out_path),
+                    buf,
+                    compression=compression,
+                    src_space=src_space,
+                    dst_space=dst_space,
+                    exr_opts=exr_opts,
+                    extra_attrs=_frame_attrs(idx_0),
+                )
+                written += 1
+                if progress:
+                    progress(written, render_total)
+        else:
+            max_inflight = n_workers * 2
+            with _process_pool(n_workers) as pool:
+                pending: dict = {}
+                it = iter(indices)
+                all_submitted = False
+
+                def _submit_batch() -> None:
+                    nonlocal all_submitted
+                    if all_submitted:
+                        return
+                    while len(pending) < max_inflight:
+                        try:
+                            idx_1based = next(it)
+                        except StopIteration:
+                            all_submitted = True
+                            return
+                        if cancel_check and cancel_check():
+                            _cancel_pool(pool, pending)
+                            raise RuntimeError("Cancelled")
+                        idx_0 = idx_1based - 1
+                        rgb = clip.decode_frame(idx_0, mode=mode)
+                        if need_extra_resize and (rgb.shape[1], rgb.shape[0]) != (ow, oh):
+                            rgb = _resize_rgb_f32(rgb, ow, oh)
+                        frame_num = start_frame + idx_1based - 1
+                        out_path = str(output_dir / f"{stem}.{frame_num:{fmt}}.exr")
+                        fut = pool.submit(
+                            process_frame_v2e,
+                            idx_1based,
+                            rgb,
+                            out_path,
+                            compression,
+                            config_source,
+                            config_path,
+                            src_space,
+                            dst_space,
+                            exr_opts,
+                            _frame_attrs(idx_0),
+                        )
+                        pending[fut] = idx_1based
+
+                _submit_batch()
+                while pending:
+                    if cancel_check and cancel_check():
+                        _cancel_pool(pool, pending)
+                        raise RuntimeError("Cancelled")
+                    done_set, _ = wait(pending, return_when=FIRST_COMPLETED)
+                    for done in done_set:
+                        done.result()
+                        del pending[done]
+                        finished += 1
+                        if progress:
+                            progress(finished, render_total)
+                    _submit_batch()
+            written = finished
+
+    if written == 0:
+        raise RuntimeError("No frames decoded from the R3D/N-RAW file.")
+    if log:
+        nuke_pat = "#" * padding
+        log(f"Wrote {written} EXR frames → {output_dir / f'{stem}.{nuke_pat}.exr'}")
+
+
+def _resize_rgb_f32(rgb: np.ndarray, out_w: int, out_h: int) -> np.ndarray:
+    """Nearest-neighbor resize for float32 RGB (rare path when scale ≠ R3D ladder)."""
+    h, w = rgb.shape[:2]
+    if w == out_w and h == out_h:
+        return rgb
+    ys = np.linspace(0, h - 1, out_h)
+    xs = np.linspace(0, w - 1, out_w)
+    yi = np.clip(np.rint(ys).astype(np.intp), 0, h - 1)
+    xi = np.clip(np.rint(xs).astype(np.intp), 0, w - 1)
+    return np.ascontiguousarray(rgb[np.ix_(yi, xi)], dtype=np.float32)
 
 
 # ---- exr -> video ----------------------------------------------------------

--- a/src/core/exr_io.py
+++ b/src/core/exr_io.py
@@ -121,6 +121,7 @@ def write_exr(
     src_space: str = "",
     dst_space: str = "",
     exr_opts: dict[str, str] | None = None,
+    extra_attrs: dict[str, str] | None = None,
 ) -> None:
     """Write a float32 (H, W, 3) array as half-float EXR.
 
@@ -131,6 +132,9 @@ def write_exr(
     to a generic ``lin_rec709`` ``oiio:ColorSpace`` tag without changing
     pixels. Trust **``exrconverter:dstColorSpace``** for the true OCIO space
     of the samples; ``oiio:ColorSpace`` is only a coarse “scene-linear” hint.
+
+    *extra_attrs* are optional string attributes (e.g. R3D camera metadata
+    under ``exrconverter:r3d:*``).
 
     Raises
     ------
@@ -154,6 +158,18 @@ def write_exr(
             spec.attribute("oiio:ColorSpace", str(dst_space))
         except Exception:
             pass
+    if extra_attrs:
+        for key, val in extra_attrs.items():
+            if key is None or val is None:
+                continue
+            k = str(key).strip()
+            v = str(val).strip()
+            if not k or not v:
+                continue
+            try:
+                spec.attribute(k, v)
+            except Exception:
+                pass
     buf = oiio.ImageBuf(spec)
     # set_pixels + write must not run OIIO colorconvert (pixels already OCIO'd).
     buf.set_pixels(

--- a/src/core/pool.py
+++ b/src/core/pool.py
@@ -55,6 +55,7 @@ def process_frame_v2e(
     src_space: str,
     dst_space: str,
     exr_opts: dict[str, str] | None = None,
+    extra_attrs: dict[str, str] | None = None,
 ) -> int:
     """OCIO transform + write one EXR frame. Returns frame index."""
     cpu = _ensure_cpu(config_source, config_path, src_space, dst_space)
@@ -69,6 +70,7 @@ def process_frame_v2e(
         src_space=src_space,
         dst_space=dst_space,
         exr_opts=exr_opts,
+        extra_attrs=extra_attrs,
     )
     return idx
 

--- a/src/core/r3d.py
+++ b/src/core/r3d.py
@@ -1,0 +1,645 @@
+"""Optional RED R3D / N-RAW decode via the local R3D SDK bridge.
+
+The proprietary RED R3D SDK is **not** bundled in source form. When a developer
+(or release packager) builds ``libr3d_bridge`` with ``scripts/build_r3d_bridge.py``
+and places the RED Redistributable dynamic libraries next to it, this module
+loads them and exposes probe/decode helpers for video→EXR.
+
+Without the bridge, :func:`is_available` is False and R3D paths raise a clear
+error. See ``docs/r3d.md`` for license, EULA, and packaging constraints.
+"""
+
+from __future__ import annotations
+
+import atexit
+import ctypes
+import logging
+import os
+import platform
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# Extensions handled by the R3D SDK (not PyAV).
+R3D_SUFFIXES: frozenset[str] = frozenset({".r3d", ".nev"})
+
+# OCIO source-space candidates when decoding IPP2 primary development.
+R3D_SRC_COLORSPACE_CANDIDATES: tuple[str, ...] = (
+    "Log3G10 REDWideGamutRGB",
+    "Input - RED - Log3G10",
+    "RED Log3G10",
+    "Log3G10",
+    "REDWideGamutRGB",
+)
+
+# Decode ladder (matches native/r3d/r3d_bridge.h).
+DECODE_FULL_PREMIUM = 0
+DECODE_HALF_PREMIUM = 1
+DECODE_HALF_GOOD = 2
+DECODE_QUARTER_GOOD = 3
+DECODE_EIGHTH_GOOD = 4
+DECODE_SIXTEENTH_GOOD = 5
+
+PIPELINE_PRIMARY_LOG3G10 = 0
+PIPELINE_CLIP_DEFAULT = 1
+
+# Preview / thumbnail defaults (convert uses full premium via decode_mode_for_scale).
+DECODE_PREVIEW = DECODE_HALF_GOOD
+DECODE_THUMBNAIL = DECODE_SIXTEENTH_GOOD
+
+# Clip-level RMD keys we copy into EXR attributes (when present).
+_CLIP_META_KEYS: tuple[str, ...] = (
+    "camera_model",
+    "camera_id",
+    "camera_pin",
+    "camera_firmware_version",
+    "clip_id",
+    "clip_uuid",
+    "iso",
+    "exposure_time",
+    "exposure_compensation",
+    "exposure_adjust",
+    "framerate",
+    "framerate_numerator",
+    "framerate_denominator",
+    "image_width",
+    "image_height",
+    "lens_name",
+    "lens_brand",
+    "lens_focal_length",
+    "lens_aperture_label",
+    "lens_mount",
+    "gmt_date",
+    "gmt_time",
+    "hdr_mode",
+    "sensor_name",
+    "reel_id",
+    "reel_no",
+    "camera_network_name",
+)
+
+_lib: ctypes.CDLL | None = None
+_init_attempted = False
+_init_ok = False
+_init_error = ""
+
+
+class R3DUnavailableError(RuntimeError):
+    """Raised when R3D support is requested but the bridge/SDK is missing."""
+
+
+class R3DError(RuntimeError):
+    """R3D SDK / bridge operation failed."""
+
+
+@dataclass(frozen=True)
+class R3DClipInfo:
+    width: int
+    height: int
+    frame_count: int
+    fps: float
+    colorspace_hint: str
+    sdk_version: str
+
+
+class _ClipInfoStruct(ctypes.Structure):
+    _fields_ = [
+        ("width", ctypes.c_uint32),
+        ("height", ctypes.c_uint32),
+        ("frame_count", ctypes.c_uint32),
+        ("fps", ctypes.c_float),
+        ("file_id", ctypes.c_int),
+        ("sdk_version", ctypes.c_char * 256),
+        ("colorspace_hint", ctypes.c_char * 64),
+    ]
+
+
+def is_r3d_path(path: str | Path) -> bool:
+    """True if *path* looks like an R3D / N-RAW file by extension."""
+    return Path(path).suffix.lower() in R3D_SUFFIXES
+
+
+def _bridge_names() -> tuple[str, ...]:
+    system = platform.system()
+    if system == "Darwin":
+        return ("libr3d_bridge.dylib",)
+    if system == "Windows":
+        return ("libr3d_bridge.dll", "r3d_bridge.dll")
+    return ("libr3d_bridge.so",)
+
+
+def _bridge_candidates() -> list[Path]:
+    """Search paths for libr3d_bridge.*"""
+    names = _bridge_names()
+    dirs: list[Path] = []
+    files: list[Path] = []
+
+    env = os.environ.get("EXR_CONVERTER_R3D_BRIDGE", "").strip()
+    if env:
+        p = Path(env).expanduser()
+        if p.suffix.lower() in {".dylib", ".so", ".dll"}:
+            files.append(p)
+        else:
+            dirs.append(p)
+
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        dirs.append(exe_dir / "r3d")
+        dirs.append(exe_dir)
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            dirs.append(Path(meipass) / "r3d")
+            dirs.append(Path(meipass))
+
+    pkg_root = Path(__file__).resolve().parents[2]
+    dirs.extend(
+        [
+            pkg_root / "build" / "r3d",
+            pkg_root / "native" / "r3d",
+            pkg_root / "resources" / "r3d",
+        ]
+    )
+
+    out: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(p: Path) -> None:
+        try:
+            key = str(p.resolve()) if p.exists() else str(p)
+        except OSError:
+            key = str(p)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(p)
+
+    for f in files:
+        _add(f)
+    for d in dirs:
+        for name in names:
+            _add(d / name)
+    return out
+
+
+def _redistributable_candidates(bridge_path: Path | None) -> list[Path]:
+    """Folders that may contain REDR3D.dylib / .so / .dll."""
+    system = platform.system()
+    if system == "Darwin":
+        sub = "mac"
+        marker = "REDR3D.dylib"
+    elif system == "Windows":
+        sub = "win"
+        marker = "REDR3D-x64.dll"
+    else:
+        sub = "linux"
+        marker = "REDR3D-x64.so"
+
+    roots: list[Path] = []
+    env = os.environ.get("EXR_CONVERTER_R3D_LIBS", "").strip()
+    if env:
+        roots.append(Path(env).expanduser().resolve())
+    env2 = os.environ.get("R3D_SDK_LIBS", "").strip()
+    if env2:
+        roots.append(Path(env2).expanduser().resolve())
+    sdk = os.environ.get("R3D_SDK_ROOT", "").strip()
+    if sdk:
+        roots.append(Path(sdk).expanduser().resolve() / "Redistributable" / sub)
+
+    if bridge_path is not None:
+        roots.append(bridge_path.parent)
+        roots.append(bridge_path.parent / "redistributable")
+
+    pkg_root = Path(__file__).resolve().parents[2]
+    roots.append(pkg_root / "build" / "r3d" / "redistributable")
+    roots.append(pkg_root / "resources" / "r3d")
+    # Local SDK drop (developer machine only; gitignored).
+    for name in ("R3DSDKv9_2_1", "R3DSDK"):
+        roots.append(pkg_root / name / "Redistributable" / sub)
+
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        roots.append(exe_dir / "r3d")
+        roots.append(exe_dir)
+
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for r in roots:
+        try:
+            rp = r.resolve()
+        except OSError:
+            continue
+        if rp in seen:
+            continue
+        seen.add(rp)
+        if (rp / marker).is_file() or rp.is_dir():
+            out.append(rp)
+    return out
+
+
+def _load_library() -> ctypes.CDLL | None:
+    global _lib
+    if _lib is not None:
+        return _lib
+    for path in _bridge_candidates():
+        if not path.is_file():
+            continue
+        try:
+            lib = ctypes.CDLL(str(path))
+        except OSError as e:
+            log.debug("Failed to load R3D bridge %s: %s", path, e)
+            continue
+        _bind(lib)
+        lib._bridge_path = path  # type: ignore[attr-defined]
+        _lib = lib
+        log.info("Loaded R3D bridge: %s", path)
+        return _lib
+    return None
+
+
+def _bind(lib: ctypes.CDLL) -> None:
+    lib.r3d_bridge_available.restype = ctypes.c_int
+    lib.r3d_bridge_available.argtypes = []
+
+    lib.r3d_bridge_initialize.restype = ctypes.c_int
+    lib.r3d_bridge_initialize.argtypes = [ctypes.c_char_p]
+
+    lib.r3d_bridge_finalize.restype = None
+    lib.r3d_bridge_finalize.argtypes = []
+
+    lib.r3d_bridge_is_initialized.restype = ctypes.c_int
+    lib.r3d_bridge_is_initialized.argtypes = []
+
+    lib.r3d_bridge_sdk_version.restype = None
+    lib.r3d_bridge_sdk_version.argtypes = [ctypes.c_char_p, ctypes.c_size_t]
+
+    lib.r3d_bridge_identify.restype = ctypes.c_int
+    lib.r3d_bridge_identify.argtypes = [ctypes.c_char_p]
+
+    lib.r3d_bridge_open.restype = ctypes.c_void_p
+    lib.r3d_bridge_open.argtypes = [ctypes.c_char_p]
+
+    lib.r3d_bridge_close.restype = None
+    lib.r3d_bridge_close.argtypes = [ctypes.c_void_p]
+
+    lib.r3d_bridge_clip_info.restype = ctypes.c_int
+    lib.r3d_bridge_clip_info.argtypes = [ctypes.c_void_p, ctypes.POINTER(_ClipInfoStruct)]
+
+    lib.r3d_bridge_decode_frame.restype = ctypes.c_int
+    lib.r3d_bridge_decode_frame.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+
+    lib.r3d_bridge_decode_buffer_bytes.restype = ctypes.c_size_t
+    lib.r3d_bridge_decode_buffer_bytes.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+
+    lib.r3d_bridge_last_error.restype = ctypes.c_char_p
+    lib.r3d_bridge_last_error.argtypes = []
+
+    lib.r3d_bridge_metadata_string.restype = ctypes.c_int
+    lib.r3d_bridge_metadata_string.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+
+    lib.r3d_bridge_absolute_timecode.restype = ctypes.c_int
+    lib.r3d_bridge_absolute_timecode.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+
+    lib.r3d_bridge_edge_timecode.restype = ctypes.c_int
+    lib.r3d_bridge_edge_timecode.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+
+
+def _last_error(lib: ctypes.CDLL) -> str:
+    try:
+        raw = lib.r3d_bridge_last_error()
+        if raw:
+            return raw.decode("utf-8", errors="replace")
+    except Exception:
+        pass
+    return ""
+
+
+def ensure_initialized() -> bool:
+    """Load bridge + InitializeSdk if possible. Idempotent."""
+    global _init_attempted, _init_ok, _init_error
+    if _init_attempted:
+        return _init_ok
+    _init_attempted = True
+
+    lib = _load_library()
+    if lib is None:
+        _init_error = (
+            "R3D bridge library not found. Build with "
+            "`python3 scripts/build_r3d_bridge.py` after installing the RED R3D SDK "
+            "(see docs/r3d.md)."
+        )
+        log.debug(_init_error)
+        return False
+
+    bridge_path = getattr(lib, "_bridge_path", None)
+    libs_path: Path | None = None
+    for cand in _redistributable_candidates(bridge_path):
+        # Prefer a directory that actually contains the main RED library.
+        system = platform.system()
+        markers = {
+            "Darwin": "REDR3D.dylib",
+            "Windows": "REDR3D-x64.dll",
+            "Linux": "REDR3D-x64.so",
+        }
+        marker = markers.get(system, "REDR3D.dylib")
+        if (cand / marker).is_file():
+            libs_path = cand
+            break
+        # On Windows ARM, name differs — accept any REDR3D*
+        if any(cand.glob("REDR3D*")):
+            libs_path = cand
+            break
+
+    if libs_path is None:
+        _init_error = (
+            "RED Redistributable libraries not found (REDR3D.*). "
+            "Set EXR_CONVERTER_R3D_LIBS to the Redistributable/{mac,linux,win} folder."
+        )
+        log.debug(_init_error)
+        return False
+
+    rc = lib.r3d_bridge_initialize(str(libs_path).encode("utf-8"))
+    if rc != 0:
+        _init_error = _last_error(lib) or f"InitializeSdk failed ({rc})"
+        log.warning("R3D SDK init failed: %s", _init_error)
+        return False
+
+    _init_ok = True
+    atexit.register(_finalize_safe)
+    ver = sdk_version()
+    log.info("R3D SDK initialized (%s) libs=%s", ver, libs_path)
+    return True
+
+
+def _finalize_safe() -> None:
+    global _init_ok
+    lib = _lib
+    if lib is None or not _init_ok:
+        return
+    try:
+        lib.r3d_bridge_finalize()
+    except Exception:
+        pass
+    _init_ok = False
+
+
+def is_available() -> bool:
+    """True if the bridge loads and the R3D SDK initializes successfully."""
+    return ensure_initialized()
+
+
+def unavailable_reason() -> str:
+    """Human-readable reason when :func:`is_available` is False."""
+    if ensure_initialized():
+        return ""
+    return _init_error or "R3D support unavailable"
+
+
+def sdk_version() -> str:
+    if not ensure_initialized() or _lib is None:
+        return ""
+    buf = ctypes.create_string_buffer(256)
+    _lib.r3d_bridge_sdk_version(buf, 256)
+    return buf.value.decode("utf-8", errors="replace")
+
+
+def decode_mode_for_scale(scale: float) -> int:
+    """Map a convert *scale* factor to a native R3D decode mode."""
+    if scale >= 0.99:
+        return DECODE_FULL_PREMIUM
+    if scale >= 0.49:
+        return DECODE_HALF_PREMIUM
+    if scale >= 0.24:
+        return DECODE_QUARTER_GOOD
+    if scale >= 0.12:
+        return DECODE_EIGHTH_GOOD
+    return DECODE_SIXTEENTH_GOOD
+
+
+class R3DClip:
+    """Open R3D / N-RAW clip (context manager).
+
+    Decode is safe from one worker at a time (player prefetch holds a lock).
+    Do not share one instance across concurrent decoders without external locking.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        if not ensure_initialized() or _lib is None:
+            raise R3DUnavailableError(unavailable_reason())
+        self.path = str(Path(path).resolve())
+        self._lib = _lib
+        handle = self._lib.r3d_bridge_open(self.path.encode("utf-8"))
+        if not handle:
+            raise R3DError(_last_error(self._lib) or f"Failed to open {self.path}")
+        self._handle: Any = handle
+        self._info = self._read_info()
+
+    def _read_info(self) -> R3DClipInfo:
+        info = _ClipInfoStruct()
+        rc = self._lib.r3d_bridge_clip_info(self._handle, ctypes.byref(info))
+        if rc != 0:
+            raise R3DError(_last_error(self._lib) or "clip_info failed")
+        hint = info.colorspace_hint.decode("utf-8", errors="replace").strip()
+        ver = info.sdk_version.decode("utf-8", errors="replace").strip()
+        return R3DClipInfo(
+            width=int(info.width),
+            height=int(info.height),
+            frame_count=int(info.frame_count),
+            fps=float(info.fps) if info.fps > 0 else 24.0,
+            colorspace_hint=hint or R3D_SRC_COLORSPACE_CANDIDATES[0],
+            sdk_version=ver,
+        )
+
+    @property
+    def info(self) -> R3DClipInfo:
+        return self._info
+
+    def close(self) -> None:
+        if self._handle and self._lib is not None:
+            self._lib.r3d_bridge_close(self._handle)
+            self._handle = None
+
+    def __enter__(self) -> R3DClip:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def decode_frame(
+        self,
+        frame_index: int,
+        *,
+        mode: int = DECODE_FULL_PREMIUM,
+        pipeline: int = PIPELINE_PRIMARY_LOG3G10,
+    ) -> np.ndarray:
+        """Decode 0-based *frame_index* → float32 RGB ``(H, W, 3)`` in 0–1."""
+        if not self._handle:
+            raise R3DError("Clip is closed")
+        w = ctypes.c_uint32(0)
+        h = ctypes.c_uint32(0)
+        nbytes = self._lib.r3d_bridge_decode_buffer_bytes(
+            self._handle, int(mode), ctypes.byref(w), ctypes.byref(h)
+        )
+        if nbytes == 0 or w.value == 0 or h.value == 0:
+            raise R3DError(_last_error(self._lib) or "invalid decode buffer size")
+
+        # float32 RGB output
+        arr = np.empty((int(h.value), int(w.value), 3), dtype=np.float32)
+        flat = arr.reshape(-1)
+        rc = self._lib.r3d_bridge_decode_frame(
+            self._handle,
+            ctypes.c_uint32(frame_index),
+            int(mode),
+            int(pipeline),
+            flat.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            flat.nbytes,
+            ctypes.byref(w),
+            ctypes.byref(h),
+        )
+        if rc != 0:
+            raise R3DError(_last_error(self._lib) or f"decode failed frame={frame_index} rc={rc}")
+        # If decoder returned different dims, reshape (should match).
+        if int(w.value) != arr.shape[1] or int(h.value) != arr.shape[0]:
+            arr = flat[: int(h.value) * int(w.value) * 3].reshape((int(h.value), int(w.value), 3))
+        return arr
+
+    def metadata_string(self, key: str) -> str:
+        """Return clip-level metadata *key* as string, or empty if missing."""
+        if not self._handle:
+            return ""
+        buf = ctypes.create_string_buffer(1024)
+        rc = self._lib.r3d_bridge_metadata_string(self._handle, key.encode("utf-8"), buf, 1024)
+        if rc != 1:
+            return ""
+        return buf.value.decode("utf-8", errors="replace").strip()
+
+    def absolute_timecode(self, frame_index: int = 0) -> str:
+        if not self._handle:
+            return ""
+        buf = ctypes.create_string_buffer(64)
+        rc = self._lib.r3d_bridge_absolute_timecode(
+            self._handle, ctypes.c_uint32(frame_index), buf, 64
+        )
+        if rc != 1:
+            return ""
+        return buf.value.decode("utf-8", errors="replace").strip()
+
+    def edge_timecode(self, frame_index: int = 0) -> str:
+        if not self._handle:
+            return ""
+        buf = ctypes.create_string_buffer(64)
+        rc = self._lib.r3d_bridge_edge_timecode(self._handle, ctypes.c_uint32(frame_index), buf, 64)
+        if rc != 1:
+            return ""
+        return buf.value.decode("utf-8", errors="replace").strip()
+
+    def clip_metadata_dict(self) -> dict[str, str]:
+        """Stable clip-level attributes for EXR headers / inspect."""
+        out: dict[str, str] = {}
+        for key in _CLIP_META_KEYS:
+            val = self.metadata_string(key)
+            if val:
+                out[key] = val
+        info = self._info
+        out.setdefault("image_width", str(info.width))
+        out.setdefault("image_height", str(info.height))
+        out.setdefault("framerate", f"{info.fps:.6f}".rstrip("0").rstrip("."))
+        if info.sdk_version:
+            out["sdk_version"] = info.sdk_version
+        tc = self.absolute_timecode(0)
+        if tc:
+            out["start_absolute_timecode"] = tc
+        etc = self.edge_timecode(0)
+        if etc:
+            out["start_edge_timecode"] = etc
+        return out
+
+
+def probe_r3d(path: str | Path) -> tuple[int, int, float, int]:
+    """Return ``(width, height, fps, frame_count)`` for an R3D/N-RAW path."""
+    with R3DClip(path) as clip:
+        i = clip.info
+        return i.width, i.height, i.fps, max(1, i.frame_count)
+
+
+def r3d_exr_attributes(path: str | Path, *, frame_index: int = 0) -> dict[str, str]:
+    """Build EXR attribute map from an R3D/N-RAW clip.
+
+    Keys are prefixed ``exrconverter:r3d:``. Includes per-frame timecode when
+    *frame_index* (0-based) is available.
+    """
+    with R3DClip(path) as clip:
+        meta = clip.clip_metadata_dict()
+        tc = clip.absolute_timecode(frame_index)
+        if tc:
+            meta["absolute_timecode"] = tc
+        etc = clip.edge_timecode(frame_index)
+        if etc:
+            meta["edge_timecode"] = etc
+    return {f"exrconverter:r3d:{k}": v for k, v in meta.items() if v}
+
+
+def r3d_src_colorspace_candidates(path: str | Path = "") -> list[str]:
+    """OCIO source-space candidates for R3D primary Log3G10 decode."""
+    # path reserved for future per-clip metadata; always primary log for now.
+    _ = path
+    return list(R3D_SRC_COLORSPACE_CANDIDATES)
+
+
+# Required end-user notice when RED Redistributable libraries ship with the app
+# (summary; full terms are in the official R3D SDK License Agreement).
+RED_REDISTRIBUTABLE_NOTICE = """\
+RED R3D / N-RAW decoding uses proprietary software from RED.COM, LLC / Nikon
+(the “R3D SDK”). When this application includes RED Redistributable dynamic
+libraries, those libraries remain the property of RED and are licensed to you
+only under the R3D SDK License Agreement and the following conditions:
+
+• You may use the R3D functionality solely as integrated in this application
+  to decode R3D / N-RAW media for your own projects.
+• You may not reverse engineer, decompile, disassemble, or otherwise attempt
+  to derive the source code or file formats of the RED libraries or SDK.
+• You may not redistribute the RED libraries separately, modify them, or
+  place them in a shared system location for use by other software.
+• You may not claim that this product is certified by RED or use RED
+  trademarks without written permission from RED.
+• THE RED LIBRARIES AND RELATED MATERIALS ARE PROVIDED “AS IS” WITHOUT
+  WARRANTY OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY LAW, RED AND ITS
+  LICENSORS DISCLAIM ALL WARRANTIES AND LIMIT LIABILITY AS SET OUT IN THE
+  R3D SDK LICENSE AGREEMENT (INCLUDING AN AGGREGATE LIABILITY CAP).
+
+Obtain the current license from the official R3D SDK package. For questions:
+RED-r3dsdk@nikon.com
+"""

--- a/src/core/video.py
+++ b/src/core/video.py
@@ -80,13 +80,23 @@ def _stream_basics(stream) -> tuple[int, int, float, int, str, str]:
 
 
 def probe_video(path: str) -> tuple[int, int, float, int]:
-    """Return (width, height, fps, frame_count) using PyAV.
+    """Return (width, height, fps, frame_count) using PyAV or the R3D SDK.
 
-    Falls back through codec_context, a deep libavformat probe, and a
-    single-frame decode when the default probe doesn't surface stream
-    attributes (e.g. Sony Venice MXFs whose vendor-tagged codec parameters
-    live past the default 5 MB / 5 s probe window).
+    RED R3D / N-RAW (``.r3d`` / ``.nev``) use the optional R3D bridge when
+    available. Other formats use PyAV, falling back through codec_context, a
+    deep libavformat probe, and a single-frame decode when the default probe
+    doesn't surface stream attributes (e.g. Sony Venice MXFs).
     """
+    from .r3d import is_available as r3d_available
+    from .r3d import is_r3d_path, probe_r3d
+
+    if is_r3d_path(path):
+        if not r3d_available():
+            from .r3d import unavailable_reason
+
+            raise RuntimeError(unavailable_reason())
+        return probe_r3d(path)
+
     import av
 
     duration = time_base = None
@@ -240,6 +250,11 @@ def guess_video_colorspace_candidates(path: str) -> list[str]:
     characteristics. The caller should try each candidate through alias
     resolution until one matches the active OCIO config.
     """
+    from .r3d import is_r3d_path, r3d_src_colorspace_candidates
+
+    if is_r3d_path(path):
+        return r3d_src_colorspace_candidates(path)
+
     import av
 
     try:
@@ -354,6 +369,8 @@ _VIDEO_SUFFIXES = {
     ".webm",
     ".m4v",
     ".ts",
+    ".r3d",
+    ".nev",
 }
 
 
@@ -378,6 +395,35 @@ def scan_video_files(directory: str) -> list[dict[str, str]]:
         if entry.suffix.lower() not in _VIDEO_SUFFIXES:
             continue
         row: dict[str, str] = {"name": entry.name, "path": str(entry)}
+        # R3D / N-RAW — PyAV cannot probe these; use the optional SDK bridge.
+        from .r3d import is_available as r3d_available
+        from .r3d import is_r3d_path, probe_r3d
+
+        if is_r3d_path(entry):
+            try:
+                if r3d_available():
+                    vw, vh, fps, nframes = probe_r3d(entry)
+                    row["resolution"] = f"{vw}x{vh}" if vw and vh else ""
+                    row["codec"] = "R3D" if entry.suffix.lower() == ".r3d" else "N-RAW"
+                    row["fps"] = f"{fps:.3f}".rstrip("0").rstrip(".") if fps else ""
+                    if nframes and fps:
+                        dur = nframes / fps
+                        row["duration"] = f"{dur:.2f}s"
+                    else:
+                        row["duration"] = ""
+                else:
+                    row["resolution"] = ""
+                    row["codec"] = "R3D (SDK missing)"
+                    row["fps"] = ""
+                    row["duration"] = ""
+            except Exception:
+                row.setdefault("resolution", "")
+                row.setdefault("codec", "R3D")
+                row.setdefault("fps", "")
+                row.setdefault("duration", "")
+            results.append(row)
+            continue
+
         try:
             container = av.open(str(entry))
             vs = container.streams.video[0] if container.streams.video else None

--- a/src/gui/browser_thumbs.py
+++ b/src/gui/browser_thumbs.py
@@ -52,6 +52,28 @@ def load_video_thumbnail_rgb(
     """Return uint8 RGB thumbnail from the first video frame, or ``None``."""
     if not path or not Path(path).is_file():
         return None
+
+    # R3D / N-RAW: sixteenth-res SDK decode (fast ID thumbs; not full premium).
+    try:
+        from ..core.r3d import (
+            DECODE_THUMBNAIL,
+            R3DClip,
+            is_r3d_path,
+        )
+        from ..core.r3d import (
+            is_available as r3d_available,
+        )
+
+        if is_r3d_path(path) and r3d_available():
+            with R3DClip(path) as clip:
+                rgb = clip.decode_frame(0, mode=DECODE_THUMBNAIL)
+            # Log3G10 is not linear display; cheap OETF so thumbs aren't crushed.
+            disp = np.clip(np.asarray(rgb, dtype=np.float32), 0.0, 1.0)
+            disp = np.power(disp, 1.0 / 2.2)
+            return _downscale_uint8_rgb(disp, max_edge)
+    except Exception:
+        pass
+
     try:
         import av
 

--- a/src/gui/player/sequence_player.py
+++ b/src/gui/player/sequence_player.py
@@ -385,6 +385,7 @@ class SequencePlayer(QWidget):
             return False
 
         try:
+            from ...core.r3d import is_r3d_path
             from ...core.video import probe_video, resolve_video_src_colorspace
 
             w, h, probed_fps, n_frames = probe_video(path)
@@ -400,8 +401,12 @@ class SequencePlayer(QWidget):
             use_fps = 24.0
         self.set_fps(use_fps)
         # Probe size when caller did not pass a positive resolution.
+        # R3D player path uses half-res decode (DECODE_PREVIEW) for scrub speed.
         if w > 0 and h > 0 and (resolution is None or resolution[0] <= 0 or resolution[1] <= 0):
-            self.set_resolution(int(w), int(h))
+            if is_r3d_path(path):
+                self.set_resolution(max(1, int(w) // 2), max(1, int(h) // 2))
+            else:
+                self.set_resolution(int(w), int(h))
 
         self._video_path = path
         self._shot_frames = list(range(1, n_frames + 1))

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -1267,6 +1267,7 @@ _VIDEO_EXTS = frozenset(
         ".asf",
         ".dv",
         ".r3d",
+        ".nev",
         ".braw",
         ".ari",
         ".arx",

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -157,6 +157,10 @@ class ColorSpaceButton(QToolButton):
     When the active OCIO config changes, :meth:`populate` may leave the
     control in an **invalid** state if the previous space has no equivalent —
     :meth:`current_space` then returns ``""`` so Convert stays disabled.
+
+    Auto-detect (media probe) uses :meth:`try_select` with ``auto=True`` for a
+    brief amber flash; manual picks, presets, and ``populate`` never leave that
+    flash stuck on.
     """
 
     space_changed = Signal(str)
@@ -165,6 +169,13 @@ class ColorSpaceButton(QToolButton):
     _INVALID_STYLE = (
         "QToolButton { color: #e07070; border: 1px solid #a04040; background-color: #3a2020; }"
     )
+    # Brief cue when the space was chosen by media auto-detect (not sticky).
+    _AUTO_STYLE = (
+        "QToolButton { color: #e8dcc0; border: 1px solid #8a6a30; "
+        "background-color: #3a3020; border-radius: 3px; padding: 4px 8px; "
+        "text-align: left; font-size: 13px; }"
+    )
+    _AUTO_FLASH_MS = 1200
 
     def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
@@ -175,7 +186,11 @@ class ColorSpaceButton(QToolButton):
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self._current = ""
         self._valid = False
+        self._auto_flash = False
         self._menu = QMenu(self)
+        self._auto_timer = QTimer(self)
+        self._auto_timer.setSingleShot(True)
+        self._auto_timer.timeout.connect(self._end_auto_flash)
         self._set_display("(none)")
         self._apply_valid_style()
 
@@ -190,8 +205,13 @@ class ColorSpaceButton(QToolButton):
     def is_valid(self) -> bool:
         return self._valid and bool(self._current)
 
+    def is_auto_flash(self) -> bool:
+        """True while the auto-detect highlight is showing."""
+        return self._auto_flash
+
     def set_current_space(self, name: str) -> None:
         """Set the selection; marks invalid if *name* is empty."""
+        self._stop_auto_flash()
         self._current = name or ""
         self._valid = bool(name)
         self._set_display(name or "(none)")
@@ -199,6 +219,7 @@ class ColorSpaceButton(QToolButton):
 
     def set_invalid(self, wanted: str) -> None:
         """Show *wanted* as missing from the active config (Convert disabled)."""
+        self._stop_auto_flash()
         self._current = wanted or ""
         self._valid = False
         label = wanted if wanted else "(none)"
@@ -217,6 +238,7 @@ class ColorSpaceButton(QToolButton):
         (or empty). Callers should run :func:`~src.core.ocio_utils.find_equivalent_space`
         first; use :meth:`set_invalid` when no match exists.
         """
+        self._stop_auto_flash()
         old_menu = self._menu
         self._menu = QMenu(self)
         old_menu.deleteLater()
@@ -246,14 +268,15 @@ class ColorSpaceButton(QToolButton):
             for cs_name in names:
                 all_names.add(cs_name)
                 action = target_menu.addAction(cs_name)
-                action.triggered.connect(lambda checked, n=cs_name: self._pick(n))
+                # Menu pick is always manual — clears any auto-detect flash.
+                action.triggered.connect(lambda checked, n=cs_name: self._pick(n, auto=False))
                 if cs_name == select:
                     found = True
 
         if select and found:
-            self._pick(select)
+            self._pick(select, auto=False)
         elif select and select in all_names:
-            self._pick(select)
+            self._pick(select, auto=False)
         elif select:
             # Name not in menu — invalid until the user picks.
             self.set_invalid(select)
@@ -296,29 +319,61 @@ class ColorSpaceButton(QToolButton):
         global_pos = self.mapToGlobal(QPoint(x, self.height()))
         self._menu.popup(global_pos)
 
-    def _pick(self, name: str) -> None:
+    def _pick(self, name: str, *, auto: bool = False) -> None:
         self._current = name
         self._valid = True
         self._set_display(name)
-        self._apply_valid_style()
+        if auto:
+            self._begin_auto_flash()
+        else:
+            self._stop_auto_flash()
+            self._apply_valid_style()
+            self.setToolTip(name)
         self.space_changed.emit(name)
 
-    def try_select(self, name: str) -> bool:
-        """Select *name* if it exists in the menu. Returns True on match."""
+    def try_select(self, name: str, *, auto: bool = False) -> bool:
+        """Select *name* if it exists in the menu. Returns True on match.
+
+        Pass ``auto=True`` when the value comes from media auto-detect so the
+        button briefly highlights, then returns to the normal style.
+        """
         if not name:
             return False
         if self._find_action(self._menu, name):
-            self._pick(name)
+            self._pick(name, auto=auto)
             return True
         # Case-insensitive fallback: scan all actions for a match
         found = self._find_action_ci(self._menu, name.lower())
         if found:
-            self._pick(found)
+            self._pick(found, auto=auto)
             return True
         return False
 
+    def _begin_auto_flash(self) -> None:
+        """Show the auto-detect highlight; timer clears it (never sticky)."""
+        self._auto_flash = True
+        self.setStyleSheet(self._AUTO_STYLE)
+        self.setToolTip(f"{self._current} — auto-detected from media")
+        self._auto_timer.start(self._AUTO_FLASH_MS)
+
+    def _end_auto_flash(self) -> None:
+        """Timer callback: drop auto-detect highlight, keep selection."""
+        self._auto_flash = False
+        self._apply_valid_style()
+        if self._valid and self._current:
+            self.setToolTip(self._current)
+
+    def _stop_auto_flash(self) -> None:
+        """Cancel any in-flight auto flash without waiting for the timer."""
+        if self._auto_timer.isActive():
+            self._auto_timer.stop()
+        self._auto_flash = False
+
     def _apply_valid_style(self) -> None:
-        if self._valid:
+        if self._auto_flash:
+            self.setStyleSheet(self._AUTO_STYLE)
+        elif self._valid:
+            # Empty stylesheet → inherit app QSS (normal input chrome).
             self.setStyleSheet("")
         else:
             self.setStyleSheet(self._INVALID_STYLE)
@@ -705,6 +760,51 @@ _OS_PLACES: list[tuple[str, str, QStandardPaths.StandardLocation]] = [
 def _copy_to_clipboard(text: str) -> None:
     if text:
         QGuiApplication.clipboard().setText(text)
+
+
+def _folder_path_for_copy(text: str) -> str:
+    """Directory to copy for a file, folder, or ``name.####.ext`` path string.
+
+    Shared by path-field and file-browser context menus (same semantics as the
+    Input/Output line-edit **Copy Folder Path** action).
+    """
+    raw = (text or "").strip()
+    if not raw:
+        return ""
+    p = Path(raw).expanduser()
+    # Sequence pattern → containing directory
+    if "#" in p.name:
+        return str(p.parent)
+    try:
+        if p.is_dir():
+            return str(p)
+        if p.is_file():
+            return str(p.parent)
+    except OSError:
+        pass
+    # Non-existent file-like path → parent; bare path → as-is
+    if p.suffix or "." in p.name:
+        return str(p.parent) if str(p.parent) not in ("", ".") else str(p)
+    return str(p)
+
+
+def _add_copy_path_actions(menu: QMenu, *, file_path: str = "", folder_path: str = "") -> None:
+    """Append **Copy File Path** / **Copy Folder Path** (disabled when empty)."""
+    # QAction.triggered(bool) — never bind the bool as the path string.
+    file_path = (file_path or "").strip()
+    folder_path = (folder_path or "").strip()
+    if not folder_path and file_path:
+        folder_path = _folder_path_for_copy(file_path)
+
+    copy_file = QAction("Copy File Path", menu)
+    copy_file.setEnabled(bool(file_path))
+    copy_file.triggered.connect(lambda _=False, p=file_path: _copy_to_clipboard(p))
+    menu.addAction(copy_file)
+
+    copy_folder = QAction("Copy Folder Path", menu)
+    copy_folder.setEnabled(bool(folder_path))
+    copy_folder.triggered.connect(lambda _=False, p=folder_path: _copy_to_clipboard(p))
+    menu.addAction(copy_folder)
 
 
 # SizeGrip lives in :mod:`src.gui.size_grip` (imported by window / slate_widgets)
@@ -2349,6 +2449,13 @@ class SequenceBrowserDialog(QDialog):
         open_act.setEnabled(self._ok_btn.isEnabled())
         open_act.triggered.connect(self.accept)
         menu.addAction(open_act)
+        menu.addSeparator()
+        # File = first frame of the selected sequence (what Open commits).
+        _add_copy_path_actions(
+            menu,
+            file_path=self._selected_frame_path,
+            folder_path=self._selected_dir,
+        )
         menu.exec(global_pos)
 
     def _ensure_player(self):
@@ -2496,9 +2603,8 @@ class SequenceBrowserDialog(QDialog):
         super().accept()
 
     def reject(self) -> None:
-        if self._view_seg.currentData() == _SEQ_BROWSER_VIEW_PREVIEW:
-            self._view_seg.setCurrentData(self._last_browse_mode)
-            return
+        # Always close the dialog. Escape already leaves Preview via keyPressEvent /
+        # eventFilter; window chrome (X) and Cancel must not be trapped in Preview.
         self._shutdown_browser_workers()
         self._save_browser_layout()
         super().reject()
@@ -2697,6 +2803,7 @@ class VideoBrowserDialog(QDialog):
         self._table.setMinimumWidth(200)
         self._table.setTextElideMode(Qt.TextElideMode.ElideMiddle)
         self._table.setWordWrap(False)
+        self._table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         th = self._table.horizontalHeader()
         th.setStretchLastSection(False)
         th.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
@@ -2725,6 +2832,7 @@ class VideoBrowserDialog(QDialog):
         self._grid.setWordWrap(True)
         self._grid.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self._grid.setTextElideMode(Qt.TextElideMode.ElideMiddle)
+        self._grid.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self._grid.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self._grid.setMinimumWidth(200)
 
@@ -2821,8 +2929,10 @@ class VideoBrowserDialog(QDialog):
         self._tree.clicked.connect(self._on_tree_clicked)
         self._table.itemSelectionChanged.connect(self._on_table_selection)
         self._table.cellDoubleClicked.connect(lambda _r, _c: self.accept())
+        self._table.customContextMenuRequested.connect(self._on_table_context_menu)
         self._grid.itemSelectionChanged.connect(self._on_grid_selection)
         self._grid.itemDoubleClicked.connect(self._on_grid_double_clicked)
+        self._grid.customContextMenuRequested.connect(self._on_grid_context_menu)
         self._path_edit.returnPressed.connect(self._on_path_entered)
         self._table.installEventFilter(self)
         self._table.viewport().installEventFilter(self)
@@ -3106,9 +3216,8 @@ class VideoBrowserDialog(QDialog):
         super().accept()
 
     def reject(self) -> None:
-        if self._view_seg.currentData() == _VID_BROWSER_VIEW_PREVIEW:
-            self._view_seg.setCurrentData(self._last_browse_mode)
-            return
+        # Always close the dialog. Escape already leaves Preview via eventFilter;
+        # window chrome (X) and Cancel must not be trapped in Preview.
         self._shutdown_player()
         self._save_browser_layout()
         super().reject()
@@ -3328,6 +3437,49 @@ class VideoBrowserDialog(QDialog):
             self._selected_path = str(self._file_data[row].get("path") or "")
             if self._selected_path:
                 self.accept()
+
+    def _select_video_row(self, row: int) -> None:
+        """Commit video index *row* into selection (table + grid stay in sync)."""
+        if row < 0 or row >= len(self._file_data):
+            self._selected_path = ""
+            self._ok_btn.setEnabled(False)
+            return
+        self._selected_path = str(self._file_data[row].get("path") or "")
+        self._ok_btn.setEnabled(bool(self._selected_path))
+        self._table.selectRow(row)
+        if 0 <= row < self._grid.count():
+            self._grid.setCurrentRow(row)
+        if self._meta_panel.isVisible():
+            self._show_metadata(row)
+
+    def _on_table_context_menu(self, pos: QPoint) -> None:
+        index = self._table.indexAt(pos)
+        if index.isValid():
+            self._select_video_row(index.row())
+        self._show_video_context_menu(self._table.viewport().mapToGlobal(pos))
+
+    def _on_grid_context_menu(self, pos: QPoint) -> None:
+        item = self._grid.itemAt(pos)
+        if item is not None:
+            row = int(item.data(Qt.ItemDataRole.UserRole) or self._grid.row(item))
+            self._select_video_row(row)
+        self._show_video_context_menu(self._grid.viewport().mapToGlobal(pos))
+
+    def _show_video_context_menu(self, global_pos: QPoint) -> None:
+        menu = QMenu(self)
+        preview_act = QAction("Preview", self)
+        preview_act.setShortcut(Qt.Key.Key_Space)
+        preview_act.triggered.connect(
+            lambda: self._view_seg.setCurrentData(_VID_BROWSER_VIEW_PREVIEW)
+        )
+        menu.addAction(preview_act)
+        open_act = QAction("Open", self)
+        open_act.setEnabled(self._ok_btn.isEnabled())
+        open_act.triggered.connect(self.accept)
+        menu.addAction(open_act)
+        menu.addSeparator()
+        _add_copy_path_actions(menu, file_path=self._selected_path)
+        menu.exec(global_pos)
 
     def _on_table_selection(self) -> None:
         rows = self._table.selectionModel().selectedRows()
@@ -4569,24 +4721,7 @@ class ConvertTab(QWidget):
     @staticmethod
     def _folder_path_from_field(text: str) -> str:
         """Directory to copy/open for a path field value (file, folder, or name.####.ext)."""
-        raw = (text or "").strip()
-        if not raw:
-            return ""
-        p = Path(raw).expanduser()
-        # Sequence pattern → containing directory
-        if "#" in p.name:
-            return str(p.parent)
-        try:
-            if p.is_dir():
-                return str(p)
-            if p.is_file():
-                return str(p.parent)
-        except OSError:
-            pass
-        # Non-existent file-like path → parent; bare path → as-is
-        if p.suffix or "." in p.name:
-            return str(p.parent) if str(p.parent) not in ("", ".") else str(p)
-        return str(p)
+        return _folder_path_for_copy(text)
 
     def _show_path_context_menu(self, edit: QLineEdit, pos: QPoint) -> None:
         """Standard cut/copy/paste plus path helpers (replaces stock QLineEdit menu).
@@ -4634,20 +4769,8 @@ class ConvertTab(QWidget):
 
         menu.addSeparator()
 
-        # --- Path-specific helpers ---
-        # QAction.triggered(bool) — never bind the bool as the path string.
-        def _clip(s: str) -> None:
-            QGuiApplication.clipboard().setText(s)
-
-        copy_file = QAction("Copy File Path", menu)
-        copy_file.setEnabled(bool(text))
-        copy_file.triggered.connect(lambda _=False, t=text: _clip(t))
-        menu.addAction(copy_file)
-
-        copy_folder = QAction("Copy Folder Path", menu)
-        copy_folder.setEnabled(bool(folder))
-        copy_folder.triggered.connect(lambda _=False, f=folder: _clip(f))
-        menu.addAction(copy_folder)
+        # --- Path-specific helpers (same actions as file-browser row menus) ---
+        _add_copy_path_actions(menu, file_path=text, folder_path=folder)
 
         open_act = QAction(file_manager_label(), menu)
         open_act.setEnabled(bool(folder) and path_is_revealable(folder))
@@ -4819,10 +4942,14 @@ class ConvertTab(QWidget):
         from ..core.video import resolve_video_src_colorspace
 
         preferred = resolve_video_src_colorspace(video_path, getattr(self, "_ocio_cfg", None))
-        if preferred and self.src_btn.try_select(preferred):
+        if preferred and self.src_btn.try_select(preferred, auto=True):
             self.log_message.emit(f"Auto-detected source color space: {preferred}")
-            self.src_btn.setStyleSheet("background-color: #3a3020;")
-            QTimer.singleShot(500, self, lambda: self.src_btn.setStyleSheet(""))
+
+    def _flash_field(self, widget: QWidget) -> None:
+        """Brief amber flash on a path field / button after an auto-edit."""
+        widget.setStyleSheet("background-color: #3a3020;")
+        # Context = *widget* so the clear always runs on that object (never sticky).
+        QTimer.singleShot(500, widget, lambda w=widget: w.setStyleSheet(""))
 
     def _update_output_placeholder(self) -> None:
         """Update the output placeholder and current pattern to reflect padding."""
@@ -4837,8 +4964,7 @@ class ConvertTab(QWidget):
             updated = re.sub(r"#+\.exr$", f"{pat}.exr", current)
             if updated != current:
                 self.output_path.setText(updated)
-                self.output_path.setStyleSheet("background-color: #3a3020;")
-                QTimer.singleShot(500, self, lambda: self.output_path.setStyleSheet(""))
+                self._flash_field(self.output_path)
 
     def _update_output_ext(self) -> None:
         """Update the output path extension to match the current codec."""
@@ -4851,8 +4977,7 @@ class ConvertTab(QWidget):
         new_ext = self._codec_ext()
         if p.suffix.lower() != new_ext:
             self.output_path.setText(str(p.with_suffix(new_ext)))
-            self.output_path.setStyleSheet("background-color: #3a3020;")
-            QTimer.singleShot(500, self, lambda: self.output_path.setStyleSheet(""))
+            self._flash_field(self.output_path)
 
     def _update_dst_for_codec(self) -> None:
         """Suggest a sensible destination colorspace for the selected codec."""
@@ -4876,9 +5001,8 @@ class ConvertTab(QWidget):
                 if resolved:
                     preferred = resolved
                     break
-        if self.dst_btn.try_select(preferred):
-            self.dst_btn.setStyleSheet("background-color: #3a3020;")
-            QTimer.singleShot(500, self, lambda: self.dst_btn.setStyleSheet(""))
+        if self.dst_btn.try_select(preferred, auto=True):
+            pass  # amber flash owned by ColorSpaceButton
 
     def _auto_detect_colorspace(self, path_or_dir: str) -> None:
         """Probe or infer source colorspace for the loaded image sequence.
@@ -4925,10 +5049,8 @@ class ConvertTab(QWidget):
                     if resolved:
                         preferred = resolved
                         break
-            if self.src_btn.try_select(preferred):
+            if self.src_btn.try_select(preferred, auto=True):
                 self.log_message.emit(f"Display still sequence — source color space: {preferred}")
-                self.src_btn.setStyleSheet("background-color: #3a3020;")
-                QTimer.singleShot(500, self, lambda: self.src_btn.setStyleSheet(""))
             return
 
         canonical = cs
@@ -4939,10 +5061,8 @@ class ConvertTab(QWidget):
             resolved = resolve_alias(ocio_cfg, cs)
             if resolved:
                 canonical = resolved
-        if self.src_btn.try_select(canonical):
+        if self.src_btn.try_select(canonical, auto=True):
             self.log_message.emit(f"Auto-detected source color space: {canonical}")
-            self.src_btn.setStyleSheet("background-color: #3a3020;")
-            QTimer.singleShot(500, self, lambda: self.src_btn.setStyleSheet(""))
         else:
             self.log_message.emit(f'Image color space "{cs}" not found in current OCIO config')
 

--- a/src/gui/window.py
+++ b/src/gui/window.py
@@ -60,7 +60,8 @@ class AboutDialog(QDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("About EXR Converter")
-        self.setFixedSize(480, 440)
+        self.setMinimumSize(480, 480)
+        self.resize(520, 560)
 
         layout = QVBoxLayout(self)
         layout.setSpacing(12)
@@ -77,11 +78,25 @@ class AboutDialog(QDialog):
         except Exception:
             oiio_ver = "?"
 
+        r3d_line = ""
+        try:
+            from ..core.r3d import is_available as r3d_available
+            from ..core.r3d import sdk_version
+
+            if r3d_available():
+                ver = sdk_version() or "loaded"
+                r3d_line = f"<br>RED R3D SDK: {ver}"
+            else:
+                r3d_line = "<br>RED R3D: not available (optional)"
+        except Exception:
+            r3d_line = ""
+
         deps = (
             f"Python {sys.version.split()[0]} · "
             f"PySide6 {__import__('PySide6').__version__}<br>"
             f"OpenColorIO {OCIO_mod.GetVersion()} · "
             f"OpenImageIO {oiio_ver}"
+            f"{r3d_line}"
         )
 
         body = QTextBrowser()
@@ -106,13 +121,37 @@ class AboutDialog(QDialog):
             "rights to use, copy, modify, merge, publish, distribute, sublicense, "
             "and/or sell copies of the Software, subject to the above copyright "
             "notice and this permission notice being included in all copies.</p>"
+            "<p style='font-size:10px;'>Application source is MIT-licensed. "
+            "Optional RED Redistributable libraries (when present) remain under "
+            "the proprietary R3D SDK License Agreement — use the button below.</p>"
         )
         body.setReadOnly(True)
         layout.addWidget(body, 1)
 
+        red_btn = QPushButton("RED redistributable notice…")
+        red_btn.setToolTip("End-user terms for optional RED R3D / N-RAW libraries")
+        red_btn.clicked.connect(self._show_red_notice)
+        layout.addWidget(red_btn)
+
         buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
         buttons.accepted.connect(self.accept)
         layout.addWidget(buttons)
+
+    def _show_red_notice(self) -> None:
+        from ..core.r3d import RED_REDISTRIBUTABLE_NOTICE
+
+        dlg = QDialog(self)
+        dlg.setWindowTitle("RED R3D redistributable notice")
+        dlg.setMinimumSize(480, 360)
+        lay = QVBoxLayout(dlg)
+        text = QPlainTextEdit()
+        text.setReadOnly(True)
+        text.setPlainText(RED_REDISTRIBUTABLE_NOTICE.strip())
+        lay.addWidget(text, 1)
+        bb = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+        bb.accepted.connect(dlg.accept)
+        lay.addWidget(bb)
+        dlg.exec()
 
 
 class MainWindow(QMainWindow):
@@ -1215,6 +1254,8 @@ class MainWindow(QMainWindow):
         ".webm",
         ".m4v",
         ".ts",
+        ".r3d",
+        ".nev",
     }
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:

--- a/src/services/video_prefetch.py
+++ b/src/services/video_prefetch.py
@@ -290,6 +290,39 @@ class _VideoDecoder:
         return None
 
 
+class _R3DDecoder:
+    """R3D / N-RAW decoder for player scrub (half-res good by default)."""
+
+    def __init__(self, path: str, *, fps: float = 0.0, mode: int | None = None) -> None:
+        from ..core.r3d import DECODE_PREVIEW, R3DClip
+
+        self.path = path
+        self._clip = R3DClip(path)
+        self.fps = float(fps) if fps and fps > 0 else float(self._clip.info.fps or 24.0)
+        self._mode = int(mode) if mode is not None else DECODE_PREVIEW
+        self._last_idx: int | None = None
+        self._last_rgb: np.ndarray | None = None
+
+    def close(self) -> None:
+        try:
+            self._clip.close()
+        except Exception:
+            pass
+
+    def get_frame(self, idx_1based: int) -> np.ndarray | None:
+        idx = max(1, int(idx_1based))
+        if self._last_idx == idx and self._last_rgb is not None:
+            return self._last_rgb
+        try:
+            rgb = self._clip.decode_frame(idx - 1, mode=self._mode)
+        except Exception:
+            log.debug("R3D get_frame failed frame=%s", idx, exc_info=True)
+            return None
+        self._last_idx = idx
+        self._last_rgb = rgb
+        return rgb
+
+
 def _decode_one(
     path: str,
     frame: int,
@@ -299,13 +332,18 @@ def _decode_one(
     fps: float = 0.0,
 ) -> np.ndarray | None:
     """Worker entry: decode one frame via a shared locked decoder."""
+    from ..core.r3d import is_r3d_path
+
     with lock:
-        dec: _VideoDecoder | None = decoder_holder.get("dec")
-        if dec is None or dec.path != path:
+        dec = decoder_holder.get("dec")
+        if dec is None or getattr(dec, "path", None) != path:
             if dec is not None:
                 dec.close()
             try:
-                dec = _VideoDecoder(path, fps=fps)
+                if is_r3d_path(path):
+                    dec = _R3DDecoder(path, fps=fps)
+                else:
+                    dec = _VideoDecoder(path, fps=fps)
             except Exception:
                 log.exception("Failed to open video for prefetch: %s", path)
                 decoder_holder["dec"] = None

--- a/tests/test_browser_dialogs.py
+++ b/tests/test_browser_dialogs.py
@@ -1,0 +1,228 @@
+"""File-browser dialog behavior (close / reject / context menus)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QGuiApplication, QKeyEvent
+from PySide6.QtWidgets import QDialog, QMenu
+
+from src.gui.browser_state import VIEW_LIST, VIEW_PREVIEW
+from src.gui.widgets import (
+    SequenceBrowserDialog,
+    VideoBrowserDialog,
+    _add_copy_path_actions,
+    _folder_path_for_copy,
+)
+
+
+@pytest.fixture
+def empty_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "browse"
+    d.mkdir()
+    return d
+
+
+class TestBrowserRejectWhilePreviewing:
+    """Window chrome / Cancel must close even when Preview is active.
+
+    Escape leaves Preview via key handlers; ``reject()`` used to intercept and
+    only switch back to List/Grid, so the first X/Cancel left the dialog open.
+    """
+
+    def test_sequence_reject_closes_from_preview(
+        self, qapp, empty_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            SequenceBrowserDialog,
+            "_load_preview_sequence",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            SequenceBrowserDialog,
+            "_shutdown_browser_workers",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            SequenceBrowserDialog,
+            "_save_browser_layout",
+            lambda self: None,
+        )
+        dlg = SequenceBrowserDialog(start_dir=str(empty_dir))
+        try:
+            dlg._view_seg.blockSignals(True)
+            dlg._view_seg.setCurrentData(VIEW_PREVIEW)
+            dlg._view_seg.blockSignals(False)
+            dlg._previewing = True
+            assert dlg._view_seg.currentData() == VIEW_PREVIEW
+
+            dlg.reject()
+
+            assert dlg.result() == QDialog.DialogCode.Rejected
+            # Must not have been demoted to list/grid while still "open".
+            assert dlg.result() != QDialog.DialogCode.Accepted
+        finally:
+            dlg.close()
+            dlg.deleteLater()
+            qapp.processEvents()
+
+    def test_video_reject_closes_from_preview(
+        self, qapp, empty_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            VideoBrowserDialog,
+            "_load_preview_video",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            VideoBrowserDialog,
+            "_shutdown_player",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            VideoBrowserDialog,
+            "_save_browser_layout",
+            lambda self: None,
+        )
+        # Avoid filesystem scan noise during construct/navigate.
+        monkeypatch.setattr(
+            VideoBrowserDialog,
+            "_scan_directory",
+            lambda self, directory: None,
+        )
+        dlg = VideoBrowserDialog(start_dir=str(empty_dir))
+        try:
+            dlg._view_seg.blockSignals(True)
+            dlg._view_seg.setCurrentData(VIEW_PREVIEW)
+            dlg._view_seg.blockSignals(False)
+            dlg._previewing = True
+            assert dlg._view_seg.currentData() == VIEW_PREVIEW
+
+            dlg.reject()
+
+            assert dlg.result() == QDialog.DialogCode.Rejected
+        finally:
+            dlg.close()
+            dlg.deleteLater()
+            qapp.processEvents()
+
+    def test_sequence_escape_still_leaves_preview(
+        self, qapp, empty_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Escape should return to the last browse mode, not close."""
+        monkeypatch.setattr(
+            SequenceBrowserDialog,
+            "_load_preview_sequence",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            SequenceBrowserDialog,
+            "_stop_preview_playback",
+            lambda self, **kw: None,
+        )
+        monkeypatch.setattr(
+            SequenceBrowserDialog,
+            "_save_browser_layout",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            SequenceBrowserDialog,
+            "_scan_directory",
+            lambda self, directory: None,
+        )
+        dlg = SequenceBrowserDialog(start_dir=str(empty_dir))
+        try:
+            dlg._last_browse_mode = VIEW_LIST
+            dlg._view_seg.setCurrentData(VIEW_PREVIEW)
+            assert dlg._view_seg.currentData() == VIEW_PREVIEW
+
+            ev = QKeyEvent(
+                QKeyEvent.Type.KeyPress,
+                Qt.Key.Key_Escape,
+                Qt.KeyboardModifier.NoModifier,
+            )
+            dlg.keyPressEvent(ev)
+
+            assert dlg.result() == 0  # not finished
+            assert dlg._view_seg.currentData() == VIEW_LIST
+        finally:
+            dlg.close()
+            dlg.deleteLater()
+            qapp.processEvents()
+
+
+class TestCopyPathHelpers:
+    def test_folder_path_for_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "shot.mov"
+        f.write_bytes(b"x")
+        assert _folder_path_for_copy(str(f)) == str(tmp_path)
+
+    def test_folder_path_for_sequence_pattern(self, tmp_path: Path) -> None:
+        pat = str(tmp_path / "plate.####.exr")
+        assert _folder_path_for_copy(pat) == str(tmp_path)
+
+    def test_folder_path_for_directory(self, tmp_path: Path) -> None:
+        assert _folder_path_for_copy(str(tmp_path)) == str(tmp_path)
+
+
+class TestBrowserCopyPathMenu:
+    def test_sequence_menu_has_copy_actions(
+        self, qapp, empty_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(SequenceBrowserDialog, "_scan_directory", lambda self, d: None)
+        monkeypatch.setattr(SequenceBrowserDialog, "_save_browser_layout", lambda self: None)
+        monkeypatch.setattr(SequenceBrowserDialog, "_shutdown_browser_workers", lambda self: None)
+        dlg = SequenceBrowserDialog(start_dir=str(empty_dir))
+        try:
+            frame = str(empty_dir / "shot.1001.exr")
+            dlg._selected_frame_path = frame
+            dlg._selected_dir = str(empty_dir)
+            # Build the same actions the context menu would; avoid QMenu.exec.
+            menu = QMenu(dlg)
+            _add_copy_path_actions(
+                menu,
+                file_path=dlg._selected_frame_path,
+                folder_path=dlg._selected_dir,
+            )
+            labels = [a.text() for a in menu.actions()]
+            assert "Copy File Path" in labels
+            assert "Copy Folder Path" in labels
+            by_text = {a.text(): a for a in menu.actions()}
+            assert by_text["Copy File Path"].isEnabled()
+            assert by_text["Copy Folder Path"].isEnabled()
+
+            clip = QGuiApplication.clipboard()
+            by_text["Copy File Path"].trigger()
+            assert clip.text() == frame
+            by_text["Copy Folder Path"].trigger()
+            assert clip.text() == str(empty_dir)
+        finally:
+            dlg.close()
+            dlg.deleteLater()
+            qapp.processEvents()
+
+    def test_video_menu_has_copy_actions(
+        self, qapp, empty_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(VideoBrowserDialog, "_scan_directory", lambda self, d: None)
+        monkeypatch.setattr(VideoBrowserDialog, "_save_browser_layout", lambda self: None)
+        monkeypatch.setattr(VideoBrowserDialog, "_shutdown_player", lambda self: None)
+        dlg = VideoBrowserDialog(start_dir=str(empty_dir))
+        try:
+            vid = str(empty_dir / "clip.mov")
+            dlg._selected_path = vid
+            menu = QMenu(dlg)
+            _add_copy_path_actions(menu, file_path=dlg._selected_path)
+            by_text = {a.text(): a for a in menu.actions()}
+            assert by_text["Copy File Path"].isEnabled()
+            assert by_text["Copy Folder Path"].isEnabled()
+            by_text["Copy File Path"].trigger()
+            assert QGuiApplication.clipboard().text() == vid
+            by_text["Copy Folder Path"].trigger()
+            assert QGuiApplication.clipboard().text() == str(empty_dir)
+        finally:
+            dlg.close()
+            dlg.deleteLater()
+            qapp.processEvents()

--- a/tests/test_color_space_button.py
+++ b/tests/test_color_space_button.py
@@ -1,0 +1,79 @@
+"""ColorSpaceButton auto-detect flash vs normal selection styling."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication
+
+from src.gui.widgets import ColorSpaceButton
+
+
+def _app() -> QApplication:
+    existing = QApplication.instance()
+    if existing is not None:
+        return existing  # type: ignore[return-value]
+    return QApplication([])
+
+
+def _populate_simple(btn: ColorSpaceButton, *names: str, select: str = "") -> None:
+    families = {"Utility": list(names)}
+    btn.populate(families, select=select)
+
+
+class TestColorSpaceAutoFlash:
+    def test_manual_select_has_no_auto_style(self) -> None:
+        _app()
+        btn = ColorSpaceButton()
+        _populate_simple(btn, "ACEScg", "sRGB", select="ACEScg")
+        assert btn.is_valid()
+        assert not btn.is_auto_flash()
+        assert btn.styleSheet() == ""
+
+    def test_auto_select_flashes_then_clears(self) -> None:
+        app = _app()
+        btn = ColorSpaceButton()
+        # Short flash for a fast test.
+        btn._AUTO_FLASH_MS = 50  # type: ignore[misc]
+        _populate_simple(btn, "ACEScg", "sRGB")
+        assert btn.try_select("sRGB", auto=True)
+        assert btn.current_space() == "sRGB"
+        assert btn.is_auto_flash()
+        assert "3a3020" in btn.styleSheet()
+
+        # Drive the single-shot timer to completion.
+        deadline = 500
+        elapsed = 0
+        while btn.is_auto_flash() and elapsed < deadline:
+            app.processEvents()
+            QTimer.singleShot(20, app.quit)
+            app.exec()
+            elapsed += 20
+
+        assert not btn.is_auto_flash()
+        assert btn.styleSheet() == ""
+        assert btn.is_valid()
+        assert btn.current_space() == "sRGB"
+
+    def test_manual_pick_clears_auto_flash(self) -> None:
+        _app()
+        btn = ColorSpaceButton()
+        btn._AUTO_FLASH_MS = 60_000  # type: ignore[misc]  # would stick if not cleared
+        _populate_simple(btn, "ACEScg", "sRGB")
+        assert btn.try_select("ACEScg", auto=True)
+        assert btn.is_auto_flash()
+
+        assert btn.try_select("sRGB", auto=False)
+        assert not btn.is_auto_flash()
+        assert btn.styleSheet() == ""
+        assert btn.current_space() == "sRGB"
+
+    def test_set_current_space_clears_auto_flash(self) -> None:
+        _app()
+        btn = ColorSpaceButton()
+        btn._AUTO_FLASH_MS = 60_000  # type: ignore[misc]
+        _populate_simple(btn, "ACEScg", "sRGB")
+        btn.try_select("ACEScg", auto=True)
+        assert btn.is_auto_flash()
+        btn.set_current_space("sRGB")
+        assert not btn.is_auto_flash()
+        assert btn.styleSheet() == ""

--- a/tests/test_r3d.py
+++ b/tests/test_r3d.py
@@ -1,0 +1,120 @@
+"""Unit tests for optional R3D / N-RAW support (no proprietary SDK required)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.core.r3d import (
+    DECODE_FULL_PREMIUM,
+    DECODE_HALF_PREMIUM,
+    DECODE_QUARTER_GOOD,
+    R3D_SUFFIXES,
+    decode_mode_for_scale,
+    is_r3d_path,
+    r3d_src_colorspace_candidates,
+)
+
+
+def test_is_r3d_path_extensions() -> None:
+    assert is_r3d_path("clip.R3D")
+    assert is_r3d_path("clip.r3d")
+    assert is_r3d_path(Path("/tmp/DSC_0001.NEV"))
+    assert is_r3d_path("shot.nev")
+    assert not is_r3d_path("plate.mov")
+    assert not is_r3d_path("seq.####.exr")
+
+
+def test_r3d_suffixes_set() -> None:
+    assert ".r3d" in R3D_SUFFIXES
+    assert ".nev" in R3D_SUFFIXES
+
+
+def test_decode_mode_for_scale() -> None:
+    assert decode_mode_for_scale(1.0) == DECODE_FULL_PREMIUM
+    assert decode_mode_for_scale(0.5) == DECODE_HALF_PREMIUM
+    assert decode_mode_for_scale(0.25) == DECODE_QUARTER_GOOD
+
+
+def test_src_colorspace_candidates_include_log3g10() -> None:
+    cands = r3d_src_colorspace_candidates("x.R3D")
+    assert any("Log3G10" in c or "log3g10" in c.lower() for c in cands)
+    assert cands[0]
+
+
+def test_red_notice_is_nonempty() -> None:
+    from src.core.r3d import RED_REDISTRIBUTABLE_NOTICE
+
+    assert "RED" in RED_REDISTRIBUTABLE_NOTICE
+    assert "reverse engineer" in RED_REDISTRIBUTABLE_NOTICE.lower()
+
+
+def _force_r3d_unavailable() -> tuple:
+    """Return previous r3d module state after forcing unavailable."""
+    from src.core import r3d as r3d_mod
+
+    prev = (
+        r3d_mod._init_attempted,
+        r3d_mod._init_ok,
+        r3d_mod._init_error,
+        r3d_mod._lib,
+    )
+    r3d_mod._init_attempted = True
+    r3d_mod._init_ok = False
+    r3d_mod._init_error = "test: bridge missing"
+    r3d_mod._lib = None
+    return prev
+
+
+def _restore_r3d_state(prev: tuple) -> None:
+    from src.core import r3d as r3d_mod
+
+    (
+        r3d_mod._init_attempted,
+        r3d_mod._init_ok,
+        r3d_mod._init_error,
+        r3d_mod._lib,
+    ) = prev
+
+
+def test_probe_r3d_without_bridge_raises() -> None:
+    """When the bridge is missing, probe must not silently return bogus dims."""
+    prev = _force_r3d_unavailable()
+    try:
+        from src.core.video import probe_video
+
+        with pytest.raises(RuntimeError):
+            probe_video("/tmp/nonexistent_clip_for_test.R3D")
+    finally:
+        _restore_r3d_state(prev)
+
+
+def test_video_suffixes_include_r3d() -> None:
+    from src.core.video import _VIDEO_SUFFIXES
+
+    assert ".r3d" in _VIDEO_SUFFIXES
+    assert ".nev" in _VIDEO_SUFFIXES
+
+
+def test_run_video_to_exr_r3d_missing_sdk(tmp_path: Path) -> None:
+    from src.core.convert import run_video_to_exr
+    from src.core.r3d import R3DUnavailableError
+
+    prev = _force_r3d_unavailable()
+    try:
+        fake = tmp_path / "clip.R3D"
+        fake.write_bytes(b"not a real r3d")
+
+        with pytest.raises(R3DUnavailableError):
+            run_video_to_exr(
+                str(fake),
+                tmp_path / "out",
+                ocio_cfg=None,
+                src_space="ACEScg",
+                dst_space="ACEScg",
+                config_source="",
+                config_path="",
+            )
+    finally:
+        _restore_r3d_state(prev)

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.8.2"
+version = "0.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

Ship **0.9.0** with optional **RED R3D / N-RAW** support for Video → EXR:

- License-safe R3D SDK bridge (CPU, IPP2 primary Log3G10 / RWG)
- Private CI feed (`R3D_SDK_READ_TOKEN` → `r3d-sdk-private`) so Release binaries can ship Redistributable libs only
- Browser thumbnails + sequence-player preview (low-res decode)
- Camera / timecode metadata on EXRs (`exrconverter:r3d:*`)
- About dialog RED redistributable notice
- Docs: `docs/r3d.md`, CLI/GUI/README/AGENTS

Also includes browser context-menu path copy, preview-close fix, and input color-space highlight fix.

## Version

- Bump **0.8.2 → 0.9.0** (minor — new user-facing capability per AGENTS.md)
- CHANGELOG section `## [0.9.0]` + compare link

## Test plan

- [x] `make lint` + unit tests green locally
- [x] Live smoke on Gemini R3D (probe, thumb, preview decode, convert + metadata)
- [ ] PR CI `ci-ok`
- [ ] After merge: Auto-tag `v0.9.0` + Release workflow; confirm artifacts include private `r3d/` when secret is set (no headers/static libs)

## Notes

- Do **not** push the local `v0.9.0` tag unless Auto-tag fails
- Full SDK stays private (`~/code/r3d-sdk-private` / private GH release); not in this repo