### PR TITLE
release: 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.9.1] — 2026-08-10
+
+### Fixed
+
+- **Windows R3D bridge build:** compile/link the RED bridge with `/MD` so it
+  matches `R3DSDK-*-MD.lib` (fixes LNK2038 RuntimeLibrary mismatch and unresolved
+  CRT imports on GitHub Actions Release).
+
+---
+
 ## [0.9.0] — 2026-08-10
 
 ### Added
@@ -552,7 +562,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/derek-rein/exr-converter/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/derek-rein/exr-converter/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/derek-rein/exr-converter/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/derek-rein/exr-converter/compare/v0.8.0...v0.8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.0"
+version = "0.9.1"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/scripts/build_r3d_bridge.py
+++ b/scripts/build_r3d_bridge.py
@@ -132,11 +132,16 @@ def build(sdk: Path, out_dir: Path, verbose: bool) -> Path:
 
     system = platform.system()
     if system == "Windows":
-        # Expect cl.exe on PATH (Developer Command Prompt).
+        # Expect cl.exe on PATH (Developer Command Prompt / msvc-dev-cmd).
+        # Must match the RED static lib CRT: R3DSDK-*-MD.lib → /MD (DLL runtime).
+        # Without explicit /MD, some CI images default to /MT and LNK2038.
+        # Prefer /Fo + /Fe into out_dir so intermediates stay out of the source tree.
+        obj = out_dir / "r3d_bridge.obj"
         cmd = [
             "cl.exe",
             "/nologo",
             "/O2",
+            "/MD",
             "/EHsc",
             "/std:c++17",
             f"/I{include}",
@@ -145,7 +150,8 @@ def build(sdk: Path, out_dir: Path, verbose: bool) -> Path:
             "/LD",
             str(SRC),
             str(static),
-            f"/Fe:{out_lib}",
+            f"/Fo{obj}",
+            f"/Fe{out_lib}",
         ]
     else:
         cxx = os.environ.get("CXX", "c++")

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.9.0"
+APP_VERSION = "0.9.1"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.0"
+version = "0.9.1"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

**Patch 0.9.1** — fix Windows Release R3D bridge link failure.

`cl.exe` was building `r3d_bridge` as `/MT` while linking `R3DSDK-2017MD.lib` (`/MD`), causing LNK2038 RuntimeLibrary mismatch and unresolved CRT symbols (`__imp_getenv`).

### Fix
- Explicit `/MD` on the Windows bridge compile (matches RED `*-MD.lib`)
- Object/output paths under `build/r3d/`

## Test plan
- [ ] PR CI green
- [ ] After merge: Release workflow Windows “Build R3D bridge” succeeds
- [ ] Windows artifact contains `r3d/libr3d_bridge.dll` + redistributables (no headers/static libs)