### PR TITLE
release: 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.9.2] — 2026-08-10
+
+### Fixed
+
+- **Windows R3D bridge CI log:** use ASCII arrows in build script output so
+  cp1252 consoles do not raise UnicodeEncodeError after a successful link.
+
+---
+
 ## [0.9.1] — 2026-08-10
 
 ### Fixed
@@ -562,7 +571,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/derek-rein/exr-converter/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/derek-rein/exr-converter/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/derek-rein/exr-converter/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/derek-rein/exr-converter/compare/v0.8.1...v0.8.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.1"
+version = "0.9.2"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/scripts/build_r3d_bridge.py
+++ b/scripts/build_r3d_bridge.py
@@ -192,8 +192,9 @@ def build(sdk: Path, out_dir: Path, verbose: bool) -> Path:
         shutil.rmtree(dest_redist)
     shutil.copytree(redistrib_src, dest_redist)
 
+    # ASCII-only logs: Windows CI runners often use cp1252 and choke on arrows.
     print(f"Built {out_lib}")
-    print(f"Redistributables → {dest_redist}")
+    print(f"Redistributables -> {dest_redist}")
     print(f"SDK version root: {sdk}")
     return out_lib
 

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.9.1"
+APP_VERSION = "0.9.2"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.1"
+version = "0.9.2"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

**0.9.2** — Windows R3D bridge CI failure after successful link:

- `/MD` fix in 0.9.1 **did** build `libr3d_bridge.dll`
- Script then printed `→` and crashed with `UnicodeEncodeError` on cp1252

This patch uses ASCII `->` in build logs only.

## Test plan
- [ ] PR CI green
- [ ] Release Windows “Build R3D bridge” succeeds and continues packaging