### PR TITLE
release: 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.9.3] — 2026-08-10
+
+### Added
+
+- **Nuke-style path paste:** Pasting ``name.####.exr`` (or ``%04d``) into the
+  EXR → Video input field resolves the sequence, frame range, and source color
+  space the same way as Browse. In the sequence/video browser Folder field,
+  paste navigates to the parent folder, selects the matching item, and switches
+  to Preview so **Open** is ready.
+
+### Fixed
+
+- **R3D redistributable packaging:** skip macOS AppleDouble (``._*``) junk when
+  copying RED Redistributable libraries so Linux `strip` does not fail in CI.
+
+---
+
 ## [0.9.2] — 2026-08-10
 
 ### Fixed
@@ -571,7 +588,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/derek-rein/exr-converter/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/derek-rein/exr-converter/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/derek-rein/exr-converter/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/derek-rein/exr-converter/compare/v0.8.2...v0.9.0

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -46,6 +46,13 @@ Right-click the **Input** or **Output** path field for:
 field, **⌘-click** (macOS) or **Ctrl-click** (Windows/Linux) on **Browse…**
 reveals that path in the OS file manager instead.
 
+**Paste paths:** You can paste a Nuke-style sequence path
+(``/show/shot.####.exr`` or ``%04d``) into the convert Input field — the app
+resolves the sequence on disk, fills the frame range, and auto-detects source
+color space. Pasting a folder, frame file, video, or ``####`` pattern into a
+browser’s **Folder** field navigates there, highlights the matching item, and
+opens **Preview** so you can hit **Open** immediately.
+
 **Sequence browser** lists every supported still sequence in a folder
 (``name.####.ext`` or ``name_####.ext``). Mixed folders prefer EXR, then DPX.
 Display-encoded stills (PNG/JPEG/WebP) auto-suggest an **sRGB** source color

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.2"
+version = "0.9.3"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/scripts/build_r3d_bridge.py
+++ b/scripts/build_r3d_bridge.py
@@ -187,10 +187,20 @@ def build(sdk: Path, out_dir: Path, verbose: bool) -> Path:
     subprocess.check_call(cmd)
 
     # Copy only Redistributable dynamic libraries (allowed by RED license).
+    # Skip macOS AppleDouble (._*) / .DS_Store junk that can ride along in tarballs
+    # and break Linux `strip` in packaging.
     dest_redist = out_dir / "redistributable"
     if dest_redist.exists():
         shutil.rmtree(dest_redist)
-    shutil.copytree(redistrib_src, dest_redist)
+
+    def _ignore_junk(_dir: str, names: list[str]) -> set[str]:
+        return {n for n in names if n.startswith("._") or n in {".DS_Store", "Thumbs.db"}}
+
+    shutil.copytree(redistrib_src, dest_redist, ignore=_ignore_junk)
+    # Also drop any junk already nested if ignore missed something.
+    for p in dest_redist.rglob("*"):
+        if p.name.startswith("._") or p.name in {".DS_Store", "Thumbs.db"}:
+            p.unlink(missing_ok=True)
 
     # ASCII-only logs: Windows CI runners often use cp1252 and choke on arrows.
     print(f"Built {out_lib}")

--- a/scripts/install_r3d_into_bundle.py
+++ b/scripts/install_r3d_into_bundle.py
@@ -77,10 +77,18 @@ def install(target: Path, build_dir: Path = BUILD) -> Path | None:
 
     shutil.copy2(bridge, dest / bridge.name)
     for item in redist.iterdir():
+        if item.name.startswith("._") or item.name in {".DS_Store", "Thumbs.db"}:
+            continue
         if item.is_file():
             shutil.copy2(item, dest / item.name)
         elif item.is_dir():
-            shutil.copytree(item, dest / item.name)
+            shutil.copytree(
+                item,
+                dest / item.name,
+                ignore=lambda _d, names: {
+                    n for n in names if n.startswith("._") or n in {".DS_Store", "Thumbs.db"}
+                },
+            )
 
     print(f"Installed R3D runtime → {dest}")
     return dest

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.9.2"
+APP_VERSION = "0.9.3"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/core/sequence.py
+++ b/src/core/sequence.py
@@ -23,6 +23,15 @@ _DOT_FRAME_PATTERN = re.compile(
     r"^(?P<name>.+)\.(?P<frame>\d+)\.(?P<ext>[A-Za-z0-9]+)$",
     re.IGNORECASE,
 )
+# Nuke / CLI paste: ``name.####.exr``, ``name_####.exr``, ``name.%04d.exr``.
+_SEQ_HASH_PAD = re.compile(
+    r"^(?P<head>.+?)(?P<sep>[._])(?P<pad>#+)\.(?P<ext>[A-Za-z0-9]+)$",
+    re.IGNORECASE,
+)
+_SEQ_PRINTF_PAD = re.compile(
+    r"^(?P<head>.+?)(?P<sep>[._])%0?(?P<width>\d*)d\.(?P<ext>[A-Za-z0-9]+)$",
+    re.IGNORECASE,
+)
 
 
 def is_dot_frame_sequence(seq: fileseq.FileSequence) -> bool:
@@ -154,6 +163,52 @@ def _pick_default_sequence(
 
 # Back-compat alias used by older call sites / tests.
 _find_exr_seqs = _find_image_seqs
+
+
+def sequence_pattern_stem(filename: str) -> str | None:
+    """Return the sequence stem for a Nuke-style pattern filename, or ``None``.
+
+    Examples::
+
+        ``chs_010.####.exr`` → ``chs_010``
+        ``chs_010_####.exr`` → ``chs_010``
+        ``plate.%04d.exr`` → ``plate``
+        ``plate.1001.exr`` → ``plate`` (numeric frame token)
+    """
+    name = Path(filename).name
+    m = _SEQ_HASH_PAD.match(name)
+    if m:
+        return m.group("head")
+    m = _SEQ_PRINTF_PAD.match(name)
+    if m:
+        return m.group("head")
+    m = _DOT_FRAME_PATTERN.match(name)
+    if m and not Path(filename).is_file():
+        # Only treat as a pattern when the path is not a real single frame.
+        return m.group("name")
+    return None
+
+
+def looks_like_sequence_pattern(path: str) -> bool:
+    """True when *path* looks like ``name.####.ext`` (may not exist on disk)."""
+    raw = (path or "").strip()
+    if not raw:
+        return False
+    return sequence_pattern_stem(Path(raw).name) is not None
+
+
+def _match_seq_by_stem(
+    seqs: list[fileseq.FileSequence],
+    stem: str,
+) -> fileseq.FileSequence | None:
+    """Pick the sequence whose basename (sans trailing ``.``/``_``) equals *stem*."""
+    stem = (stem or "").strip()
+    if not stem:
+        return None
+    exact = [s for s in seqs if s.basename().rstrip("._") == stem]
+    if exact:
+        return exact[0]
+    return None
 
 
 def probe_pixel_colorspace(filepath: str) -> str:
@@ -337,23 +392,44 @@ def scan_exr_sequences(directory: str) -> list[dict]:
     return results
 
 
+def _scan_dir_and_pattern(
+    input_path: str,
+) -> tuple[Path, str, str | None]:
+    """Return ``(path_obj, scan_dir, pattern_stem_or_None)`` for open resolution.
+
+    Accepts real files/dirs and non-existent Nuke patterns like
+    ``/show/shot.####.exr`` (parent must exist).
+    """
+    raw = (input_path or "").strip()
+    if not raw:
+        raise RuntimeError("Empty sequence path")
+    p = Path(raw).expanduser()
+    if p.is_file() or p.is_dir():
+        scan_dir = str(p.parent) if p.is_file() else str(p)
+        return p, scan_dir, None
+    # Non-existent path: may be a #### / %04d pattern whose parent exists.
+    parent = p.parent
+    if parent.is_dir():
+        stem = sequence_pattern_stem(p.name)
+        if stem is not None:
+            return p, str(parent), stem
+        # Parent exists but name is not a pattern (typo / missing file).
+        raise RuntimeError(f"Path does not exist: {input_path}")
+    raise RuntimeError(f"Path does not exist: {input_path}")
+
+
 def find_exr_sequence(input_path: str) -> tuple[list[str], str]:
     """Resolve *input_path* to an ordered list of image file paths + a basename.
 
     *input_path* may be:
     - a directory  → scan for supported image sequences, pick preferred (EXR first)
     - a single frame file → scan its parent dir, find the sequence it belongs to
+    - a Nuke-style pattern (``name.####.ext`` / ``name_%04d.ext``) → match by stem
 
     Supported extensions: see :data:`IMAGE_SEQUENCE_EXTS` (``.exr``, ``.dpx``,
     ``.png``, ``.jpg`` / ``.jpeg``, ``.webp``).
     """
-    p = Path(input_path)
-    if p.is_file():
-        scan_dir = str(p.parent)
-    elif p.is_dir():
-        scan_dir = str(p)
-    else:
-        raise RuntimeError(f"Path does not exist: {input_path}")
+    p, scan_dir, pattern_stem = _scan_dir_and_pattern(input_path)
 
     seqs = _find_image_seqs(scan_dir)
     if not seqs:
@@ -374,7 +450,15 @@ def find_exr_sequence(input_path: str) -> tuple[list[str], str]:
             return [str(p)], p.stem
         raise RuntimeError(f"Not a supported image sequence frame: {p.name}")
 
-    seq = _pick_default_sequence(seqs, scan_dir)
+    if pattern_stem is not None:
+        matched = _match_seq_by_stem(seqs, pattern_stem)
+        if matched is None:
+            raise RuntimeError(
+                f"No sequence matching {p.name!r} in {scan_dir} (looked for stem {pattern_stem!r})"
+            )
+        seq = matched
+    else:
+        seq = _pick_default_sequence(seqs, scan_dir)
     fs = seq.frameSet()
     if not fs:
         raise RuntimeError(f"Image sequence has no frames in {scan_dir}")
@@ -388,14 +472,11 @@ def find_exr_sequence_info(
     """Like find_exr_sequence but also returns frame numbers, padding, and the FileSequence.
 
     Returns (paths, basename, sorted_frame_nums, pad_width, file_sequence).
+
+    Accepts directories, real frame files, and Nuke-style ``####`` / ``%04d``
+    patterns whose parent directory exists.
     """
-    p = Path(input_path)
-    if p.is_file():
-        scan_dir = str(p.parent)
-    elif p.is_dir():
-        scan_dir = str(p)
-    else:
-        raise RuntimeError(f"Path does not exist: {input_path}")
+    p, scan_dir, pattern_stem = _scan_dir_and_pattern(input_path)
 
     seqs = _find_image_seqs(scan_dir)
     if not seqs:
@@ -417,6 +498,12 @@ def find_exr_sequence_info(
         if seq is None and is_image_sequence_ext(p.suffix):
             # Build a one-frame sequence for an isolated still.
             seq = fileseq.FileSequence(str(p))
+    elif pattern_stem is not None:
+        seq = _match_seq_by_stem(seqs, pattern_stem)
+        if seq is None:
+            raise RuntimeError(
+                f"No sequence matching {p.name!r} in {scan_dir} (looked for stem {pattern_stem!r})"
+            )
     if seq is None:
         seq = _pick_default_sequence(seqs, scan_dir)
 

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 import threading
 from pathlib import Path
@@ -1882,6 +1883,7 @@ class SequenceBrowserDialog(QDialog):
         self._grid.itemDoubleClicked.connect(self._on_grid_double_clicked)
         self._grid.customContextMenuRequested.connect(self._on_grid_context_menu)
         self._path_edit.returnPressed.connect(self._on_path_entered)
+        self._path_edit.installEventFilter(self)
         # Space → preview (table/grid eat key presses; filter their viewports).
         self._table.installEventFilter(self)
         self._table.viewport().installEventFilter(self)
@@ -1941,11 +1943,26 @@ class SequenceBrowserDialog(QDialog):
 
         start_folder = ""
         if start_dir:
+            from ..core.sequence import looks_like_sequence_pattern, sequence_pattern_stem
+
             d = Path(start_dir)
             if d.is_file():
                 # First-frame path from convert tab — open its parent folder.
                 if not self._auto_select_name:
-                    self._auto_select_name = d.name.split(".")[0] if "." in d.name else d.stem
+                    stem = sequence_pattern_stem(d.name)
+                    if stem is None:
+                        m = re.match(
+                            r"^(?P<head>.+)\.(?P<frame>\d+)\.(?P<ext>[A-Za-z0-9]+)$",
+                            d.name,
+                            re.I,
+                        )
+                        self._auto_select_name = m.group("head") if m else d.stem
+                    else:
+                        self._auto_select_name = stem
+                d = d.parent
+            elif looks_like_sequence_pattern(start_dir):
+                if not self._auto_select_name:
+                    self._auto_select_name = sequence_pattern_stem(d.name) or ""
                 d = d.parent
             if d.is_dir():
                 start_folder = str(d)
@@ -2124,9 +2141,56 @@ class SequenceBrowserDialog(QDialog):
         self._scan_directory(path)
 
     def _on_path_entered(self) -> None:
-        path = self._path_edit.text().strip()
-        if path and Path(path).is_dir():
-            self._navigate_to(path)
+        """Navigate to a pasted/typed path (folder, frame file, or Nuke #### pattern)."""
+        raw = self._path_edit.text().strip()
+        if not raw:
+            return
+        self._navigate_to_path_string(raw)
+
+    def _navigate_to_path_string(self, raw: str, *, prefer_preview: bool = True) -> None:
+        """Resolve *raw* to a folder + optional sequence selection and open it."""
+        from ..core.sequence import looks_like_sequence_pattern, sequence_pattern_stem
+
+        p = Path(raw).expanduser()
+        directory = ""
+        select_name = ""
+        if p.is_dir():
+            directory = str(p)
+        elif p.is_file() and is_image_sequence_ext(p.suffix):
+            directory = str(p.parent)
+            # Match the sequence that owns this frame by stem (strip frame token).
+            stem = sequence_pattern_stem(p.name)
+            if stem is None:
+                # Real frame ``name.1001.exr`` → stem before last numeric token.
+                m = re.match(
+                    r"^(?P<head>.+)\.(?P<frame>\d+)\.(?P<ext>[A-Za-z0-9]+)$",
+                    p.name,
+                    re.I,
+                )
+                select_name = m.group("head") if m else p.stem
+            else:
+                select_name = stem
+        elif looks_like_sequence_pattern(raw):
+            directory = str(p.parent)
+            select_name = sequence_pattern_stem(p.name) or ""
+        else:
+            # Parent dir still useful when the leaf is mistyped.
+            if p.parent.is_dir():
+                directory = str(p.parent)
+            else:
+                return
+
+        if not directory or not Path(directory).is_dir():
+            return
+
+        self._auto_select_name = select_name
+        if prefer_preview:
+            # Paste from Nuke should land in Preview with the sequence selected.
+            self._pending_preview = True
+            self._view_seg.blockSignals(True)
+            self._view_seg.setCurrentData(_SEQ_BROWSER_VIEW_PREVIEW)
+            self._view_seg.blockSignals(False)
+        self._navigate_to(directory)
 
     def _on_view_changed(self, _index: int) -> None:
         mode = self._view_seg.currentData()
@@ -2240,6 +2304,15 @@ class SequenceBrowserDialog(QDialog):
             select_row = 0
         if select_row >= 0:
             self._apply_selection(select_row)
+            self._table.scrollToItem(
+                self._table.item(select_row, 0),
+                QAbstractItemView.ScrollHint.PositionAtCenter,
+            )
+            if 0 <= select_row < self._grid.count():
+                self._grid.scrollToItem(
+                    self._grid.item(select_row),
+                    QAbstractItemView.ScrollHint.PositionAtCenter,
+                )
 
         n = len(seqs)
         if n > 1:
@@ -2383,10 +2456,20 @@ class SequenceBrowserDialog(QDialog):
         self._apply_selection(row)
 
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # noqa: N802
+        # Paste into Folder path: navigate + select + preview after text updates.
+        if obj is self._path_edit and event.type() == QEvent.Type.KeyPress:
+            from PySide6.QtGui import QKeyEvent
+
+            if isinstance(event, QKeyEvent) and event.matches(QKeySequence.StandardKey.Paste):
+                QTimer.singleShot(0, self._on_path_entered)
+                return False  # let the paste apply, then navigate
         if event.type() == QEvent.Type.KeyPress:
             from PySide6.QtGui import QKeyEvent
 
             if isinstance(event, QKeyEvent) and not event.isAutoRepeat():
+                # Don't steal Space while typing in the path field.
+                if obj is self._path_edit:
+                    return super().eventFilter(obj, event)
                 if event.key() == Qt.Key.Key_Space:
                     # Toggle Preview segment
                     if self._view_seg.currentData() == _SEQ_BROWSER_VIEW_PREVIEW:
@@ -2935,6 +3018,7 @@ class VideoBrowserDialog(QDialog):
         self._grid.itemDoubleClicked.connect(self._on_grid_double_clicked)
         self._grid.customContextMenuRequested.connect(self._on_grid_context_menu)
         self._path_edit.returnPressed.connect(self._on_path_entered)
+        self._path_edit.installEventFilter(self)
         self._table.installEventFilter(self)
         self._table.viewport().installEventFilter(self)
         self._grid.installEventFilter(self)
@@ -3230,8 +3314,16 @@ class VideoBrowserDialog(QDialog):
         super().closeEvent(event)
 
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # noqa: N802
+        if obj is self._path_edit and event.type() == QEvent.Type.KeyPress:
+            from PySide6.QtGui import QKeyEvent
+
+            if isinstance(event, QKeyEvent) and event.matches(QKeySequence.StandardKey.Paste):
+                QTimer.singleShot(0, self._on_path_entered)
+                return False
         if event.type() == QEvent.Type.KeyPress:
             key = event.key()  # type: ignore[attr-defined]
+            if obj is self._path_edit:
+                return super().eventFilter(obj, event)
             if key == Qt.Key.Key_Space and not event.isAutoRepeat():  # type: ignore[attr-defined]
                 if self._view_seg.currentData() == _VID_BROWSER_VIEW_PREVIEW:
                     # Let the player handle Space for play/pause when focused.
@@ -3284,9 +3376,34 @@ class VideoBrowserDialog(QDialog):
         self._scan_directory(path)
 
     def _on_path_entered(self) -> None:
-        path = self._path_edit.text().strip()
-        if path and Path(path).is_dir():
-            self._navigate_to(path)
+        """Navigate to a pasted/typed folder or video file path."""
+        raw = self._path_edit.text().strip()
+        if not raw:
+            return
+        self._navigate_to_path_string(raw)
+
+    def _navigate_to_path_string(self, raw: str, *, prefer_preview: bool = True) -> None:
+        p = Path(raw).expanduser()
+        directory = ""
+        select_path = ""
+        if p.is_dir():
+            directory = str(p)
+        elif p.is_file() and p.suffix.lower() in _VIDEO_EXTS:
+            directory = str(p.parent)
+            select_path = str(p)
+        elif p.parent.is_dir():
+            directory = str(p.parent)
+        else:
+            return
+        if not directory:
+            return
+        self._auto_select_path = select_path
+        if prefer_preview and select_path:
+            self._pending_preview = True
+            self._view_seg.blockSignals(True)
+            self._view_seg.setCurrentData(_VID_BROWSER_VIEW_PREVIEW)
+            self._view_seg.blockSignals(False)
+        self._navigate_to(directory)
 
     def _scan_directory(self, directory: str) -> None:
         was_preview = self._view_seg.currentData() == _VID_BROWSER_VIEW_PREVIEW
@@ -3347,17 +3464,28 @@ class VideoBrowserDialog(QDialog):
             self._grid.addItem(gitem)
 
         selected = False
+        select_row = -1
         if self._auto_select_path:
             for row in range(self._table.rowCount()):
                 item = self._table.item(row, 0)
                 if item and item.data(Qt.ItemDataRole.UserRole) == self._auto_select_path:
-                    self._table.selectRow(row)
-                    self._grid.setCurrentRow(row)
+                    select_row = row
                     selected = True
                     break
         if not selected and files:
-            self._table.selectRow(0)
-            self._grid.setCurrentRow(0)
+            select_row = 0
+        if select_row >= 0:
+            self._table.selectRow(select_row)
+            self._grid.setCurrentRow(select_row)
+            self._table.scrollToItem(
+                self._table.item(select_row, 0),
+                QAbstractItemView.ScrollHint.PositionAtCenter,
+            )
+            if 0 <= select_row < self._grid.count():
+                self._grid.scrollToItem(
+                    self._grid.item(select_row),
+                    QAbstractItemView.ScrollHint.PositionAtCenter,
+                )
 
         self._status.setText(f"{len(files)} video file(s) found")
         mode = self._view_seg.currentData()
@@ -4348,7 +4476,15 @@ class ConvertTab(QWidget):
                 self.set_input(text)
                 return
         else:
-            if p.is_dir() or (p.is_file() and is_image_sequence_ext(p.suffix)):
+            from ..core.sequence import looks_like_sequence_pattern
+
+            if (
+                p.is_dir()
+                or (p.is_file() and is_image_sequence_ext(p.suffix))
+                or looks_like_sequence_pattern(text)
+            ):
+                # Nuke-style ``name.####.exr`` paste: resolve range + color space
+                # the same way as Browse / Open.
                 self.set_input(text)
                 return
 

--- a/tests/test_image_sequence.py
+++ b/tests/test_image_sequence.py
@@ -13,9 +13,11 @@ from src.core.exr_io import read_image, write_exr
 from src.core.sequence import (
     find_exr_sequence,
     find_exr_sequence_info,
+    looks_like_sequence_pattern,
     parse_dot_sequence_output,
     scan_exr_sequences,
     sequence_looks_scene_referred,
+    sequence_pattern_stem,
 )
 
 
@@ -210,3 +212,39 @@ class TestSequenceDiscovery:
         assert pad2 is None
         with pytest.raises(ValueError, match="dot-separated"):
             parse_dot_sequence_output("/tmp/out/shot_####.exr")
+
+
+class TestNukeStylePatterns:
+    def test_pattern_stem_hash_and_printf(self) -> None:
+        assert sequence_pattern_stem("chs_010_010_v0001.####.exr") == "chs_010_010_v0001"
+        assert sequence_pattern_stem("plate_####.exr") == "plate"
+        assert sequence_pattern_stem("plate.%04d.exr") == "plate"
+        assert looks_like_sequence_pattern("/show/shot/chs_010_010_v0001.####.exr")
+        assert not looks_like_sequence_pattern("/show/shot/readme.txt")
+
+    def test_resolve_hash_pattern_to_sequence(self, tmp_path: Path) -> None:
+        d = tmp_path / "footage"
+        d.mkdir()
+        for f in (1001, 1002, 1003):
+            write_exr(
+                str(d / f"chs_010_010_v0001.{f:04d}.exr"),
+                np.zeros((4, 4, 3), dtype=np.float32),
+                compression="none",
+            )
+        # Unrelated sequence in same folder
+        write_exr(
+            str(d / "other.0001.exr"),
+            np.zeros((4, 4, 3), dtype=np.float32),
+            compression="none",
+        )
+        pattern = str(d / "chs_010_010_v0001.####.exr")
+        paths, name, frames, pad, _seq = find_exr_sequence_info(pattern)
+        assert name == "chs_010_010_v0001"
+        assert frames == [1001, 1002, 1003]
+        assert pad == 4
+        assert len(paths) == 3
+        assert paths[0].endswith("chs_010_010_v0001.1001.exr")
+
+        paths2, name2 = find_exr_sequence(pattern)
+        assert name2 == "chs_010_010_v0001"
+        assert len(paths2) == 3

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.2"
+version = "0.9.3"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

**0.9.3** — Nuke-style path paste + Linux R3D packaging fix.

### Added
- Paste ``name.####.exr`` / ``%04d`` into EXR→Video input → full resolve (range + color space)
- Browser Folder paste → navigate, highlight match, open Preview, ready for **Open**

### Fixed
- Skip macOS AppleDouble (``._*``) when bundling RED Redistributables (Linux ``strip`` failure)
- Private SDK feed tarball refreshed without ``._*`` junk

## Test plan
- [x] Unit tests for Nuke patterns
- [x] Live resolve of motorcycle chase ``chs_010_010_v0001.####.exr``
- [ ] PR CI green
- [ ] Release: Linux build passes R3D install/strip; Windows R3D still green