### PR TITLE
release: 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.9.4] — 2026-08-10
+
+### Fixed
+
+- **Windows Release scripts:** ASCII-only console logs in R3D install/fetch and
+  OCIO helper scripts (no more `UnicodeEncodeError` on cp1252 after a successful
+  R3D bundle install).
+
+---
+
 ## [0.9.3] — 2026-08-10
 
 ### Added
@@ -588,7 +598,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.3...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/derek-rein/exr-converter/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/derek-rein/exr-converter/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/derek-rein/exr-converter/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/derek-rein/exr-converter/compare/v0.9.0...v0.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.3"
+version = "0.9.4"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/scripts/ensure_ocio.py
+++ b/scripts/ensure_ocio.py
@@ -113,14 +113,14 @@ def _reinstall() -> int:
 def main() -> int:
     broken, ver = _is_broken()
     if not broken:
-        print(f"ensure_ocio: OK — OpenColorIO {ver}")
+        print(f"ensure_ocio: OK - OpenColorIO {ver}")
         _preserve_oiio_ocio24_dll()
         return 0
 
     print(
         f"ensure_ocio: OpenColorIO runtime is {ver!r}, need >= {'.'.join(map(str, REQUIRED))}.\n"
         "  (oiio-python often rewires PyOpenColorIO to its vendored 2.4 library.)\n"
-        f"  Reinstalling {PACKAGE} …",
+        f"  Reinstalling {PACKAGE} ...",
         file=sys.stderr,
     )
     rc = _reinstall()
@@ -132,7 +132,7 @@ def main() -> int:
         print(f"ensure_ocio: still broken after reinstall ({ver})", file=sys.stderr)
         return 2
 
-    print(f"ensure_ocio: repaired — OpenColorIO {ver}")
+    print(f"ensure_ocio: repaired - OpenColorIO {ver}")
     _preserve_oiio_ocio24_dll()
 
     try:
@@ -143,7 +143,7 @@ def main() -> int:
             out = subprocess.check_output(["otool", "-L", str(so)], text=True)
             first = next((ln.strip() for ln in out.splitlines()[1:] if ln.strip()), "")
             if first:
-                print(f"ensure_ocio: link → {first.split()[0]}")
+                print(f"ensure_ocio: link -> {first.split()[0]}")
     except Exception:
         pass
     return 0

--- a/scripts/fetch_r3d_sdk.py
+++ b/scripts/fetch_r3d_sdk.py
@@ -173,9 +173,9 @@ def main() -> None:
     cache.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="r3d-sdk-") as tmp:
         tarball = Path(tmp) / args.asset
-        print(f"Downloading {args.repo}@{args.tag} / {args.asset} …", file=sys.stderr)
+        print(f"Downloading {args.repo}@{args.tag} / {args.asset} ...", file=sys.stderr)
         _api_download(args.repo, args.tag, args.asset, tarball, token)
-        print(f"Extracting → {cache}", file=sys.stderr)
+        print(f"Extracting -> {cache}", file=sys.stderr)
         # Clean previous extract of same layout.
         for child in list(cache.iterdir()) if cache.is_dir() else []:
             if child.name.startswith("R3DSDK") or child.name == "Include":

--- a/scripts/fix_bundle_ocio.py
+++ b/scripts/fix_bundle_ocio.py
@@ -162,7 +162,7 @@ def _macos_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
             f"{ext} still has only OpenColorIO_v2_4 undefined symbols — "
             f"build-env extension was not restored correctly"
         )
-    print(f"fix_bundle_ocio: macOS — {ext.name} → @loader_path/libOpenColorIO.dylib")
+    print(f"fix_bundle_ocio: macOS - {ext.name} -> @loader_path/libOpenColorIO.dylib")
     print(f"fix_bundle_ocio: copied {dest_lib} ({dest_lib.stat().st_size} bytes)")
 
 

--- a/scripts/fix_bundle_ocio.py
+++ b/scripts/fix_bundle_ocio.py
@@ -199,7 +199,7 @@ def _linux_fix(ext: Path, src_ext: Path, src_lib: Path) -> None:
     except (FileNotFoundError, subprocess.CalledProcessError):
         pass
 
-    print(f"fix_bundle_ocio: Linux — ensured {plain}")
+    print(f"fix_bundle_ocio: Linux - ensured {plain}")
 
 
 def _windows_copy_dll(src: Path, dests: list[Path]) -> None:
@@ -211,7 +211,7 @@ def _windows_copy_dll(src: Path, dests: list[Path]) -> None:
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dest)
         written.add(dest)
-        print(f"fix_bundle_ocio: Windows — copied {dest}")
+        print(f"fix_bundle_ocio: Windows - copied {dest}")
 
 
 def _windows_materialize_ocio24(work_dir: Path) -> Path:

--- a/scripts/install_r3d_into_bundle.py
+++ b/scripts/install_r3d_into_bundle.py
@@ -90,7 +90,8 @@ def install(target: Path, build_dir: Path = BUILD) -> Path | None:
                 },
             )
 
-    print(f"Installed R3D runtime → {dest}")
+    # ASCII-only: Windows CI consoles are often cp1252.
+    print(f"Installed R3D runtime -> {dest}")
     return dest
 
 

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.9.3"
+APP_VERSION = "0.9.4"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.3"
+version = "0.9.4"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

**0.9.4** — Windows Release was still dying on unicode console output:

`Installed R3D runtime → …` → `UnicodeEncodeError` on cp1252 after a successful R3D install.

ASCII-only prints in `install_r3d_into_bundle`, `fetch_r3d_sdk`, `ensure_ocio`, `fix_bundle_ocio`.

## Test plan
- [ ] PR CI green
- [ ] Release Windows job passes “Install R3D runtime into bundle”