### PR TITLE
release: 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.9.5] — 2026-08-11
+
+### Fixed
+
+- **R3D in packaged apps:** find ``libr3d_bridge`` / RED redistributables next to
+  the binary even when Nuitka does not set ``sys.frozen`` (v0.9.4 shipped the
+  ``r3d/`` folder but runtime discovery missed it).
+
+---
+
 ## [0.9.4] — 2026-08-10
 
 ### Fixed
@@ -598,7 +608,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/derek-rein/exr-converter/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/derek-rein/exr-converter/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/derek-rein/exr-converter/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/derek-rein/exr-converter/compare/v0.9.1...v0.9.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.4"
+version = "0.9.5"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.9.4"
+APP_VERSION = "0.9.5"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/core/r3d.py
+++ b/src/core/r3d.py
@@ -133,6 +133,46 @@ def _bridge_names() -> tuple[str, ...]:
     return ("libr3d_bridge.so",)
 
 
+def _is_frozen_app() -> bool:
+    """True inside a Nuitka / PyInstaller-style binary (not a source checkout)."""
+    if getattr(sys, "frozen", False) or hasattr(sys, "_MEIPASS"):
+        return True
+    # Nuitka marks compiled modules with ``__compiled__``.
+    return globals().get("__compiled__") is not None
+
+
+def _runtime_exe_dirs() -> list[Path]:
+    """Directories that may sit next to the real application binary.
+
+    Always consider ``sys.executable`` / ``argv[0]`` — Nuitka standalone often
+    does **not** set ``sys.frozen``, so relying only on that misses the
+    private ``r3d/`` folder we install next to the launcher.
+    """
+    dirs: list[Path] = []
+    for raw in (sys.executable, sys.argv[0] if sys.argv else ""):
+        if not raw:
+            continue
+        try:
+            p = Path(raw).resolve()
+        except OSError:
+            continue
+        if p.is_file():
+            dirs.append(p.parent)
+        elif p.is_dir():
+            dirs.append(p)
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        dirs.append(Path(meipass))
+    # macOS .app: private redistributables live under Contents/MacOS/r3d/.
+    for d in list(dirs):
+        if d.name == "MacOS" and d.parent.name == "Contents":
+            dirs.append(d.parent / "Resources")
+        elif (d / "MacOS").is_dir():
+            dirs.append(d / "MacOS")
+            dirs.append(d / "Resources")
+    return dirs
+
+
 def _bridge_candidates() -> list[Path]:
     """Search paths for libr3d_bridge.*"""
     names = _bridge_names()
@@ -147,16 +187,16 @@ def _bridge_candidates() -> list[Path]:
         else:
             dirs.append(p)
 
-    if getattr(sys, "frozen", False):
-        exe_dir = Path(sys.executable).resolve().parent
+    # Prefer private app folder next to the binary (packaged + frozen).
+    for exe_dir in _runtime_exe_dirs():
         dirs.append(exe_dir / "r3d")
         dirs.append(exe_dir)
-        meipass = getattr(sys, "_MEIPASS", None)
-        if meipass:
-            dirs.append(Path(meipass) / "r3d")
-            dirs.append(Path(meipass))
 
-    pkg_root = Path(__file__).resolve().parents[2]
+    # Dev / source checkout layouts.
+    try:
+        pkg_root = Path(__file__).resolve().parents[2]
+    except Exception:
+        pkg_root = Path.cwd()
     dirs.extend(
         [
             pkg_root / "build" / "r3d",
@@ -214,17 +254,19 @@ def _redistributable_candidates(bridge_path: Path | None) -> list[Path]:
         roots.append(bridge_path.parent)
         roots.append(bridge_path.parent / "redistributable")
 
-    pkg_root = Path(__file__).resolve().parents[2]
+    for exe_dir in _runtime_exe_dirs():
+        roots.append(exe_dir / "r3d")
+        roots.append(exe_dir)
+
+    try:
+        pkg_root = Path(__file__).resolve().parents[2]
+    except Exception:
+        pkg_root = Path.cwd()
     roots.append(pkg_root / "build" / "r3d" / "redistributable")
     roots.append(pkg_root / "resources" / "r3d")
     # Local SDK drop (developer machine only; gitignored).
     for name in ("R3DSDKv9_2_1", "R3DSDK"):
         roots.append(pkg_root / name / "Redistributable" / sub)
-
-    if getattr(sys, "frozen", False):
-        exe_dir = Path(sys.executable).resolve().parent
-        roots.append(exe_dir / "r3d")
-        roots.append(exe_dir)
 
     out: list[Path] = []
     seen: set[Path] = set()
@@ -356,12 +398,13 @@ def ensure_initialized() -> bool:
 
     lib = _load_library()
     if lib is None:
+        tried = ", ".join(str(p) for p in _bridge_candidates()[:12])
         _init_error = (
             "R3D bridge library not found. Build with "
             "`python3 scripts/build_r3d_bridge.py` after installing the RED R3D SDK "
-            "(see docs/r3d.md)."
+            f"(see docs/r3d.md). Tried: {tried}"
         )
-        log.debug(_init_error)
+        log.warning("%s (frozen=%s exe=%s)", _init_error, _is_frozen_app(), sys.executable)
         return False
 
     bridge_path = getattr(lib, "_bridge_path", None)

--- a/tests/test_r3d.py
+++ b/tests/test_r3d.py
@@ -58,7 +58,9 @@ def test_bridge_candidates_include_exe_r3d_dir(monkeypatch, tmp_path: Path) -> N
     fake_exe = tmp_path / "MacOS" / "exr_converter"
     fake_exe.parent.mkdir(parents=True)
     fake_exe.write_bytes(b"")
-    bridge = tmp_path / "MacOS" / "r3d" / "libr3d_bridge.dylib"
+    # Use the platform-native bridge filename (Linux CI looks for .so, not .dylib).
+    bridge_name = r3d_mod._bridge_names()[0]
+    bridge = tmp_path / "MacOS" / "r3d" / bridge_name
     bridge.parent.mkdir(parents=True)
     bridge.write_bytes(b"")
 
@@ -69,9 +71,8 @@ def test_bridge_candidates_include_exe_r3d_dir(monkeypatch, tmp_path: Path) -> N
         monkeypatch.delattr(sys, "frozen", raising=False)
 
     cands = r3d_mod._bridge_candidates()
-    assert any(p.name.startswith("libr3d_bridge") and "r3d" in p.parts for p in cands)
-    assert bridge in {p.resolve() for p in cands if p.exists()}
-
+    assert any(p.name == bridge_name and "r3d" in p.parts for p in cands)
+    assert bridge.resolve() in {p.resolve() for p in cands if p.exists()}
 
 def _force_r3d_unavailable() -> tuple:
     """Return previous r3d module state after forcing unavailable."""

--- a/tests/test_r3d.py
+++ b/tests/test_r3d.py
@@ -74,6 +74,7 @@ def test_bridge_candidates_include_exe_r3d_dir(monkeypatch, tmp_path: Path) -> N
     assert any(p.name == bridge_name and "r3d" in p.parts for p in cands)
     assert bridge.resolve() in {p.resolve() for p in cands if p.exists()}
 
+
 def _force_r3d_unavailable() -> tuple:
     """Return previous r3d module state after forcing unavailable."""
     from src.core import r3d as r3d_mod

--- a/tests/test_r3d.py
+++ b/tests/test_r3d.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -48,6 +49,28 @@ def test_red_notice_is_nonempty() -> None:
 
     assert "RED" in RED_REDISTRIBUTABLE_NOTICE
     assert "reverse engineer" in RED_REDISTRIBUTABLE_NOTICE.lower()
+
+
+def test_bridge_candidates_include_exe_r3d_dir(monkeypatch, tmp_path: Path) -> None:
+    """Packaged apps place libr3d_bridge next to the binary under r3d/."""
+    from src.core import r3d as r3d_mod
+
+    fake_exe = tmp_path / "MacOS" / "exr_converter"
+    fake_exe.parent.mkdir(parents=True)
+    fake_exe.write_bytes(b"")
+    bridge = tmp_path / "MacOS" / "r3d" / "libr3d_bridge.dylib"
+    bridge.parent.mkdir(parents=True)
+    bridge.write_bytes(b"")
+
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(sys, "argv", [str(fake_exe)])
+    # Simulate Nuitka not setting sys.frozen.
+    if hasattr(sys, "frozen"):
+        monkeypatch.delattr(sys, "frozen", raising=False)
+
+    cands = r3d_mod._bridge_candidates()
+    assert any(p.name.startswith("libr3d_bridge") and "r3d" in p.parts for p in cands)
+    assert bridge in {p.resolve() for p in cands if p.exists()}
 
 
 def _force_r3d_unavailable() -> tuple:

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.4"
+version = "0.9.5"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

**0.9.5** — R3D **was** packaged in v0.9.4 (confirmed in DMG: `Contents/MacOS/r3d/`), but runtime discovery only looked next to the binary when ``sys.frozen`` was set. Nuitka standalone often does not set that flag, so About/convert reported R3D missing.

### Fix
Always search ``sys.executable`` / ``argv[0]`` parent (and ``r3d/`` under it), matching how OCIO finds bundled configs.

## Test plan
- [x] Unit test: bridge candidates include exe_dir/r3d without frozen
- [ ] PR CI green
- [ ] Release artifact: open About → RED R3D SDK version shown
- [ ] Convert a small .R3D in the packaged app