### PR TITLE
release: 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.9.7] — 2026-08-11
+
+### Fixed
+
+- **Video browser:** hide macOS AppleDouble metadata sidecars (``._clip.R3D``
+  and similar) that share a media extension but are not real clips. The same
+  filter applies to drag/drop, paste, R3D path detection, CLI probe, and
+  convert ingest; forced sidecar paths fail with a clear error.
+
+---
+
 ## [0.9.6] — 2026-08-11
 
 ### Changed
@@ -626,7 +637,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.6...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.7...HEAD
+[0.9.7]: https://github.com/derek-rein/exr-converter/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/derek-rein/exr-converter/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/derek-rein/exr-converter/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/derek-rein/exr-converter/compare/v0.9.3...v0.9.4

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -74,6 +74,13 @@ directory still resolves a default sequence on disk (EXR first, then DPX;
 prefers a basename matching the folder name when several sequences share the
 folder). The slate editor reuses the player with live burn-in/watermark overlays.
 
+**Video browser filters:** only real media extensions are listed (``.r3d``,
+``.nev``, ``.mov``, ``.mp4``, …). macOS **AppleDouble** Finder sidecars
+(``._clip.R3D``) that appear next to clips on network shares or non-HFS
+volumes are hidden — they share the media extension but are resource-fork
+metadata, not video. RED **`.RMD`** metadata files are never listed (not a
+video extension).
+
 Right-click a row in **List** or a tile in **Grid** (sequence and video
 browsers) for:
 

--- a/docs/r3d.md
+++ b/docs/r3d.md
@@ -156,6 +156,8 @@ Windows:<dist>/r3d/
 | CI skips R3D | Secret `R3D_SDK_READ_TOKEN` not set or cannot read private release |
 | Wrong colors | Use Log3G10 / RWG source (auto-detect) — primary pipeline is not display Rec.709 |
 | Multi-part classic R3D | Point at any part (e.g. `…_001.R3D`); the SDK loads siblings |
+| `._….R3D` in browser | macOS AppleDouble metadata next to the real clip — hidden from the video browser (not media) |
+| `.RMD` next to clip | RED metadata recipe sidecar — not listed as video (open the `.R3D`) |
 
 Sample clips (from RED / Nikon, not this repo):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.6"
+version = "0.9.7"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.9.6"
+APP_VERSION = "0.9.7"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/core/frame_source.py
+++ b/src/core/frame_source.py
@@ -108,9 +108,7 @@ def open_ingest_source(
 
     path_s = str(path)
     if is_ignored_media_filename(path_s):
-        raise RuntimeError(
-            f"Not a media file (OS metadata sidecar): {Path(path_s).name}"
-        )
+        raise RuntimeError(f"Not a media file (OS metadata sidecar): {Path(path_s).name}")
     if is_r3d_path(path_s):
         if not is_available():
             raise R3DUnavailableError(unavailable_reason())

--- a/src/core/frame_source.py
+++ b/src/core/frame_source.py
@@ -104,8 +104,13 @@ def open_ingest_source(
 ) -> IngestSource:
     """Factory for video→EXR decode (R3D SDK or PyAV)."""
     from .r3d import R3DUnavailableError, is_available, is_r3d_path, unavailable_reason
+    from .video import is_ignored_media_filename
 
     path_s = str(path)
+    if is_ignored_media_filename(path_s):
+        raise RuntimeError(
+            f"Not a media file (OS metadata sidecar): {Path(path_s).name}"
+        )
     if is_r3d_path(path_s):
         if not is_available():
             raise R3DUnavailableError(unavailable_reason())

--- a/src/core/r3d/__init__.py
+++ b/src/core/r3d/__init__.py
@@ -43,8 +43,15 @@ _bridge_names = bridge_names
 
 
 def is_r3d_path(path: str | Path) -> bool:
-    """True if *path* looks like an R3D / N-RAW file by extension."""
-    return Path(path).suffix.lower() in R3D_SUFFIXES
+    """True if *path* looks like an R3D / N-RAW file by extension.
+
+    Rejects macOS AppleDouble sidecars (``._clip.R3D``) that share the media
+    extension but are Finder/resource-fork metadata, not decodable clips.
+    """
+    p = Path(path)
+    if p.name.startswith("._"):
+        return False
+    return p.suffix.lower() in R3D_SUFFIXES
 
 
 def r3d_src_colorspace_candidates(path: str | Path = "") -> list[str]:

--- a/src/core/video.py
+++ b/src/core/video.py
@@ -87,8 +87,14 @@ def probe_video(path: str) -> tuple[int, int, float, int]:
     deep libavformat probe, and a single-frame decode when the default probe
     doesn't surface stream attributes (e.g. Sony Venice MXFs).
     """
+    from pathlib import Path
+
     from .r3d import is_available as r3d_available
     from .r3d import is_r3d_path, probe_r3d
+
+    # Reject OS metadata sidecars early (CLI / forced paths), not only in the browser.
+    if is_ignored_media_filename(path):
+        raise RuntimeError(f"Not a media file (OS metadata sidecar): {Path(path).name}")
 
     if is_r3d_path(path):
         if not r3d_available():
@@ -373,11 +379,35 @@ _VIDEO_SUFFIXES = {
     ".nev",
 }
 
+# OS / desktop metadata that often sits next to media and can share an extension
+# (notably macOS AppleDouble ``._clip.R3D`` on non-HFS volumes and network shares).
+_IGNORED_MEDIA_BASENAMES = frozenset({".DS_Store", "Thumbs.db", "desktop.ini"})
+
+
+def is_ignored_media_filename(name: str) -> bool:
+    """True for OS metadata sidecars that must not be treated as video media.
+
+    macOS AppleDouble resource-fork files (``._clip.R3D``) store Finder metadata
+    next to the real clip. They end with the same extension as the media and
+    would otherwise appear in the video browser as empty R3D/MOV rows.
+
+    *name* may be a basename or a full path; only the final path component is
+    inspected.
+    """
+    from pathlib import Path
+
+    base = Path(name).name
+    if base.startswith("._"):
+        return True
+    return base in _IGNORED_MEDIA_BASENAMES
+
 
 def scan_video_files(directory: str) -> list[dict[str, str]]:
     """Return summary dicts for every video file in *directory*.
 
     Each dict: name, resolution, codec, fps, duration, path (full).
+
+    Skips OS metadata sidecars (macOS AppleDouble ``._*``, ``.DS_Store``, etc.).
     """
     from pathlib import Path
 
@@ -391,6 +421,8 @@ def scan_video_files(directory: str) -> list[dict[str, str]]:
 
     for entry in entries:
         if not entry.is_file():
+            continue
+        if is_ignored_media_filename(entry.name):
             continue
         if entry.suffix.lower() not in _VIDEO_SUFFIXES:
             continue

--- a/src/gui/browser_path.py
+++ b/src/gui/browser_path.py
@@ -137,11 +137,7 @@ def resolve_video_browser_path(
     select_path = ""
     if p.is_dir():
         directory = str(p)
-    elif (
-        p.is_file()
-        and p.suffix.lower() in video_exts
-        and not is_ignored_media_filename(p.name)
-    ):
+    elif p.is_file() and p.suffix.lower() in video_exts and not is_ignored_media_filename(p.name):
         directory = str(p.parent)
         select_path = str(p)
     elif p.parent.is_dir():

--- a/src/gui/browser_path.py
+++ b/src/gui/browser_path.py
@@ -127,6 +127,8 @@ def resolve_video_browser_path(
     Returns ``(directory, select_path)`` or ``None``. *select_path* is the full
     path of a video file to select (empty when navigating a folder only).
     """
+    from ..core.video import is_ignored_media_filename
+
     text = clean_path_string(raw)
     if not text:
         return None
@@ -135,7 +137,11 @@ def resolve_video_browser_path(
     select_path = ""
     if p.is_dir():
         directory = str(p)
-    elif p.is_file() and p.suffix.lower() in video_exts:
+    elif (
+        p.is_file()
+        and p.suffix.lower() in video_exts
+        and not is_ignored_media_filename(p.name)
+    ):
         directory = str(p.parent)
         select_path = str(p)
     elif p.parent.is_dir():

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -102,7 +102,7 @@ from ..core.ocio_utils import (
     resolve_ocio_config,
 )
 from ..core.sequence import probe_exr_colorspace, probe_exr_metadata, scan_exr_sequences
-from ..core.video import probe_video_metadata, scan_video_files
+from ..core.video import is_ignored_media_filename, probe_video_metadata, scan_video_files
 from .browser_state import (
     SEQ_BROWSER_KEYS,
     VID_BROWSER_KEYS,
@@ -1326,6 +1326,7 @@ class _DirSearchWorker(QObject):
                     if not is_dir and (
                         self._dirs_only
                         or name in _SEARCH_SKIP_FILES
+                        or name.startswith("._")
                         or ext_lower in _SEARCH_SKIP_SUFFIXES
                         or (self._ext_filter is not None and ext_lower not in self._ext_filter)
                     ):
@@ -4428,7 +4429,11 @@ class ConvertTab(QWidget):
 
         p = Path(text).expanduser()
         if self._mode == "video2exr":
-            if p.is_file() and p.suffix.lower() in _VIDEO_EXTS:
+            if (
+                p.is_file()
+                and p.suffix.lower() in _VIDEO_EXTS
+                and not is_ignored_media_filename(p.name)
+            ):
                 self.set_input(str(p))
                 return
         else:
@@ -4436,7 +4441,11 @@ class ConvertTab(QWidget):
 
             if (
                 p.is_dir()
-                or (p.is_file() and is_image_sequence_ext(p.suffix))
+                or (
+                    p.is_file()
+                    and is_image_sequence_ext(p.suffix)
+                    and not is_ignored_media_filename(p.name)
+                )
                 or looks_like_sequence_pattern(text)
             ):
                 # Nuke-style ``name.####.exr`` paste: resolve range + color space
@@ -4986,10 +4995,18 @@ class ConvertTab(QWidget):
         """Accept a dropped path if valid for this tab's mode. Returns True if accepted."""
         p = Path(path)
         if self._mode == "video2exr":
-            if p.is_file() and p.suffix.lower() in _VIDEO_EXTS:
+            if (
+                p.is_file()
+                and p.suffix.lower() in _VIDEO_EXTS
+                and not is_ignored_media_filename(p.name)
+            ):
                 return self.set_input(str(p))
         else:
-            if p.is_dir() or (p.is_file() and is_image_sequence_ext(p.suffix)):
+            if p.is_dir() or (
+                p.is_file()
+                and is_image_sequence_ext(p.suffix)
+                and not is_ignored_media_filename(p.name)
+            ):
                 return self.set_input(str(p))
         return False
 

--- a/src/gui/window.py
+++ b/src/gui/window.py
@@ -353,9 +353,7 @@ class MainWindow(QMainWindow):
         if open_path:
             open_name = Path(open_path.split()[0]).name
             if is_ignored_media_filename(open_name):
-                self._append_log(
-                    f"Ignored OS metadata path on launch (not media): {open_name}"
-                )
+                self._append_log(f"Ignored OS metadata path on launch (not media): {open_name}")
             else:
                 # Prevent deferred QSettings restore from overwriting --open / Nuke.
                 self._v2e_tab.suppress_saved_input_restore()

--- a/src/gui/window.py
+++ b/src/gui/window.py
@@ -43,6 +43,7 @@ from ..core.constants import (
     is_image_sequence_ext,
 )
 from ..core.ocio_utils import color_space_families, config_source_info
+from ..core.video import is_ignored_media_filename
 from ..services.presets import delete_preset, list_presets, load_preset, save_preset
 from ..services.worker import ConvertWorker
 from .preferences import (
@@ -340,8 +341,9 @@ class MainWindow(QMainWindow):
             # that are not yet fully visible, or sequence tokens).
             p = Path(open_path.split()[0] if open_path else "")
             name = p.name.lower()
-            if p.suffix.lower() in self._VIDEO_EXTS or any(
-                name.endswith(ext) for ext in self._VIDEO_EXTS
+            if not is_ignored_media_filename(p.name) and (
+                p.suffix.lower() in self._VIDEO_EXTS
+                or any(name.endswith(ext) for ext in self._VIDEO_EXTS)
             ):
                 self._tabs.setCurrentIndex(0)
             else:
@@ -349,13 +351,19 @@ class MainWindow(QMainWindow):
                 self._tabs.setCurrentIndex(1)
 
         if open_path:
-            # Prevent deferred QSettings restore from overwriting --open / Nuke.
-            self._v2e_tab.suppress_saved_input_restore()
-            self._e2v_tab.suppress_saved_input_restore()
-            tab = self._active_tab()
-            # Async probe so large MXFs / sequences don't freeze launch.
-            tab.set_input_async(open_path)
-            self._append_log(f"Opened (launch): {open_path}")
+            open_name = Path(open_path.split()[0]).name
+            if is_ignored_media_filename(open_name):
+                self._append_log(
+                    f"Ignored OS metadata path on launch (not media): {open_name}"
+                )
+            else:
+                # Prevent deferred QSettings restore from overwriting --open / Nuke.
+                self._v2e_tab.suppress_saved_input_restore()
+                self._e2v_tab.suppress_saved_input_restore()
+                tab = self._active_tab()
+                # Async probe so large MXFs / sequences don't freeze launch.
+                tab.set_input_async(open_path)
+                self._append_log(f"Opened (launch): {open_path}")
 
     # -- Menu bar --
 
@@ -1264,7 +1272,12 @@ class MainWindow(QMainWindow):
             for url in mime.urls():
                 if url.isLocalFile():
                     p = Path(url.toLocalFile())
-                    if p.is_dir() or p.suffix.lower() in (self._VIDEO_EXTS | IMAGE_SEQUENCE_EXTS):
+                    if p.is_dir():
+                        event.acceptProposedAction()
+                        return
+                    if is_ignored_media_filename(p.name):
+                        continue
+                    if p.suffix.lower() in (self._VIDEO_EXTS | IMAGE_SEQUENCE_EXTS):
                         event.acceptProposedAction()
                         return
         event.ignore()
@@ -1277,13 +1290,21 @@ class MainWindow(QMainWindow):
             if not url.isLocalFile():
                 continue
             p = Path(url.toLocalFile())
-            if p.is_file() and p.suffix.lower() in self._VIDEO_EXTS:
+            if (
+                p.is_file()
+                and p.suffix.lower() in self._VIDEO_EXTS
+                and not is_ignored_media_filename(p.name)
+            ):
                 self._tabs.setCurrentIndex(0)
                 self._v2e_tab.handle_dropped_path(str(p))
                 self._append_log(f"Dropped video: {p.name}")
                 event.acceptProposedAction()
                 return
-            if p.is_dir() or (p.is_file() and is_image_sequence_ext(p.suffix)):
+            if p.is_dir() or (
+                p.is_file()
+                and is_image_sequence_ext(p.suffix)
+                and not is_ignored_media_filename(p.name)
+            ):
                 self._tabs.setCurrentIndex(1)
                 self._e2v_tab.handle_dropped_path(str(p))
                 self._append_log(f"Dropped: {p.name}")

--- a/tests/test_browser_path.py
+++ b/tests/test_browser_path.py
@@ -46,3 +46,14 @@ def test_resolve_video_browser_path_file(tmp_path: Path) -> None:
     directory, select_path = got
     assert Path(directory) == tmp_path
     assert Path(select_path) == clip
+
+
+def test_resolve_video_browser_path_skips_appledouble(tmp_path: Path) -> None:
+    """macOS ``._*.R3D`` sidecars must not auto-select as video."""
+    junk = tmp_path / "._cam.R3D"
+    junk.write_bytes(b"x")
+    got = resolve_video_browser_path(str(junk), _VIDEO)
+    assert got is not None
+    directory, select_path = got
+    assert Path(directory) == tmp_path
+    assert select_path == ""

--- a/tests/test_r3d.py
+++ b/tests/test_r3d.py
@@ -25,6 +25,9 @@ def test_is_r3d_path_extensions() -> None:
     assert is_r3d_path("shot.nev")
     assert not is_r3d_path("plate.mov")
     assert not is_r3d_path("seq.####.exr")
+    # macOS AppleDouble resource-fork sidecars share the .R3D extension.
+    assert not is_r3d_path("._clip.R3D")
+    assert not is_r3d_path(Path("/tmp/._A004_C010_0920DA_001.R3D"))
 
 
 def test_r3d_suffixes_set() -> None:
@@ -120,6 +123,39 @@ def test_video_suffixes_include_r3d() -> None:
 
     assert ".r3d" in _VIDEO_SUFFIXES
     assert ".nev" in _VIDEO_SUFFIXES
+
+
+def test_is_ignored_media_filename_appledouble() -> None:
+    from src.core.video import is_ignored_media_filename
+
+    assert is_ignored_media_filename("._A004_C010_0920DA_001.R3D")
+    assert is_ignored_media_filename("._clip.mov")
+    assert is_ignored_media_filename(".DS_Store")
+    assert is_ignored_media_filename("Thumbs.db")
+    assert not is_ignored_media_filename("A004_C010_0920DA_001.R3D")
+    assert not is_ignored_media_filename("clip.mov")
+
+
+def test_scan_video_files_skips_appledouble(tmp_path: Path) -> None:
+    """Browser listing must hide macOS AppleDouble ``._*.R3D`` sidecars."""
+    from src.core.video import scan_video_files
+
+    real = tmp_path / "A004_C010_0920DA_001.R3D"
+    junk = tmp_path / "._A004_C010_0920DA_001.R3D"
+    # Fake bytes are fine: scan is extension-based; SDK probe may fail gracefully.
+    real.write_bytes(b"not-real-r3d")
+    junk.write_bytes(b"appledouble")
+    rows = scan_video_files(str(tmp_path))
+    names = [r["name"] for r in rows]
+    assert "A004_C010_0920DA_001.R3D" in names
+    assert "._A004_C010_0920DA_001.R3D" not in names
+
+
+def test_probe_video_rejects_appledouble() -> None:
+    from src.core.video import probe_video
+
+    with pytest.raises(RuntimeError, match="OS metadata sidecar"):
+        probe_video("/tmp/._clip.R3D")
 
 
 def test_run_video_to_exr_r3d_missing_sdk(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.6"
+version = "0.9.7"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

- **Patch 0.9.7:** hide macOS AppleDouble metadata sidecars (`._clip.R3D` and similar) from the video browser and related entry points so Finder resource-fork files are not treated as media.
- Filter applies to browser listing, paste/drop, R3D path detection, launch `--open`, CLI probe, and convert ingest (clear error on forced sidecar paths).
- Docs + changelog + unit tests included.

## Review notes

Verification (check-work + code review subagents): **PASS** — no blocking issues. Small hardening added for CLI/ingest/`--open` after review suggestions.

## Test plan

- [x] `make lint`
- [x] `pytest tests/test_r3d.py tests/test_browser_path.py tests/test_frame_source.py`
- [ ] CI green on PR
- [ ] After merge: Auto-tag creates `v0.9.7` and dispatches Release (do **not** also push local tag unless Auto-tag fails)