### PR TITLE
release: 0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+### Changed
+
+- **EXR → Video codec picker:** codecs are grouped in the dropdown (ProRes
+  software / VideoToolbox / oxideav, CineForm, DNxHR, H.264/HEVC, FFV1).
+
 ### Added
 
 - **Experimental true 12-bit ProRes** (`prores_ox_4444` / `prores_ox_xq`):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,9 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
-### Changed
+---
 
-- **EXR → Video codec picker:** codecs are grouped in the dropdown (ProRes
-  software / VideoToolbox / oxideav, CineForm, DNxHR, H.264/HEVC, FFV1).
+## [0.9.8] — 2026-08-24
 
 ### Added
 
@@ -25,6 +24,11 @@ rolling the `[Unreleased]` section into a versioned heading.
   **oxideav-prores** PyO3 bindings (``exr_prores``), packaged with Nuitka.
   Not Apple-certified; hidden when the extension is not built
   (`make oxideav-prores`). Software FFmpeg ProRes remains honest 10-bit.
+
+### Changed
+
+- **EXR → Video codec picker:** codecs are grouped in the dropdown (ProRes
+  software / VideoToolbox / oxideav, CineForm, DNxHR, H.264/HEVC, FFV1).
 
 ---
 
@@ -650,7 +654,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.7...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.8...HEAD
+[0.9.8]: https://github.com/derek-rein/exr-converter/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/derek-rein/exr-converter/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/derek-rein/exr-converter/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/derek-rein/exr-converter/compare/v0.9.4...v0.9.5

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then open it normally (double-click, or right-click → **Open**). If macOS stil
 | **Language & tooling** | Python 3.13, [uv](https://docs.astral.sh/uv/) for deps and runs, [Ruff](https://docs.astral.sh/ruff/) in CI, [Nuitka](https://nuitka.net/) for standalone bundles |
 | **UI** | [PySide6](https://doc.qt.io/qtforpython/) (Qt 6.8), Nuke-inspired dark theme |
 | **Imaging & color** | [OpenImageIO](https://openimageio.org/) (`oiio-python`), [OpenColorIO 2.5](https://opencolorio.org/) display/render transforms with a wide-gamut scene-linear **compositing space** for all overlay (slate / burn-in / watermark) compositing — prefers **ACES2065-1 (AP0)** via the `aces_interchange` role so sRGB-authored overlays are linearised and alpha-over'd without ever clipping or shifting the user's footage; falls back to the `scene_linear` role (e.g. ACEScg) on non-ACES configs.<br>Bundles the official **ACES Studio Config v4** (from [ASWF OpenColorIO-Config-ACES](https://github.com/AcademySoftwareFoundation/OpenColorIO-Config-ACES), BSD-3-Clause) which includes dozens of camera IDTs including **Apple Log** (iPhone 15/16 Pro cinematic / ProRes Log), ARRI LogC3/4, RED Log3G10, Sony S-Log/Venice, Canon, DJI, and many more. |
-| **Video & sequences** | [PyAV](https://github.com/PyAV-Org/PyAV) (FFmpeg bindings) for video I/O, [fileseq](https://github.com/justinfx/fileseq) for frame sequences & ranges; optional **RED R3D SDK** bridge for `.r3d` / `.nev` |
+| **Video & sequences** | [PyAV](https://github.com/PyAV-Org/PyAV) (FFmpeg bindings) for video I/O, [fileseq](https://github.com/justinfx/fileseq) for frame sequences & ranges; optional **RED R3D SDK** bridge for `.r3d` / `.nev`; optional **oxideav-prores** PyO3 extension (`exr_prores`) for experimental cross-platform **12-bit** ProRes-compatible encode in release builds |
 | **Slate / burn-in / watermark** | Native **QPainter** preview and offscreen capture (no embedded browser); burn-in and watermark are linearised into the working space and alpha-composited per-frame, then OCIO-transformed to display before encode |
 
 CI runs on **GitHub Actions**; releases publish binaries for Linux, macOS (Apple Silicon + Intel), and Windows.
@@ -70,8 +70,9 @@ built with Hugo from [`site/`](site/) and published to GitHub Pages:
 | Guide | |
 |-------|--|
 | [CLI](docs/cli.md) | `video2exr` / `exr2video` / GUI launch flags |
-| [GUI](docs/gui.md) | Tabs, overlays, preferences, post-convert |
+| [GUI](docs/gui.md) | Tabs, overlays, preferences, post-convert, codec picker |
 | [R3D / N-RAW](docs/r3d.md) | Optional RED SDK (license, build, CI, preview) |
+| [12-bit ProRes (oxideav)](docs/plan-12bit-prores-oxideav.md) | Experimental RDD-36 12-bit ProRes via PyO3 |
 | [Nuke](docs/nuke.md) | Menu: open selected Read + session OCIO |
 
 ```bash
@@ -118,7 +119,19 @@ Common convert options:
 | `--workers N` | both | `0` = auto, `1` = single-threaded |
 | `--scale FACTOR` | both | e.g. `0.5` for half resolution |
 | `--exr-compression NAME` | `video2exr` | e.g. `dwaa`, `zip`, `none` (see `--help`) |
-| `--codec KEY` | `exr2video` | ProRes / DNxHR / CineForm / HEVC / H.264 / FFV1 — see [docs/cli.md](docs/cli.md) for bit-depth notes |
+| `--codec KEY` | `exr2video` | ProRes / DNxHR / CineForm / HEVC / H.264 / FFV1 — see [docs/cli.md](docs/cli.md) for bit-depth notes and codec keys |
+
+### EXR → video codecs (summary)
+
+Default **`prores`** is software **ProRes 422 HQ** (FFmpeg `prores_ks`, **10-bit** encode). The GUI codec menu groups presets by family (ProRes software, VideoToolbox on macOS, experimental oxideav, CineForm, DNxHR, H.264/HEVC, FFV1).
+
+| Path | When to use |
+|------|-------------|
+| **`prores_*` (software)** | Cross-platform ProRes; all profiles encode at **10-bit** |
+| **`prores_vt_*` (macOS)** | Apple **VideoToolbox** — faster, official HW encoder; 4444/XQ ~12-bit class |
+| **`prores_ox_*` (oxideav)** | Experimental **true 12-bit** RDD-36 ProRes-compatible MOV in **release builds**; not Apple-certified. Dev from source: `make oxideav-prores` |
+
+Software ProRes 4444/XQ must not be treated as true 12-bit. On macOS, prefer VideoToolbox for speed and Apple’s encoder. Full ladder: [docs/cli.md](docs/cli.md#codecs-honest-bit-depths).
 
 ```bash
 uv run python main.py --help
@@ -171,6 +184,7 @@ Nuitka will auto-download `ccache` on first run. See the `Makefile` for the full
 | `make test-unit` | Unit tests only (skip integration) |
 | `make resources` | Regenerate `src/rc_resources.py` from `resources.qrc` (needed after icon changes) |
 | `make bundle` | Nuitka standalone bundle under `dist/` |
+| `make oxideav-prores` | Build optional PyO3 12-bit ProRes extension (needs Rust + maturin) |
 | `make clean` | Remove all build artifacts |
 
 All static assets live under `resources/`: icons in `resources/icons/` (`icon.icns` / `icon.ico` / `icon.png`), UI images in `resources/images/`, the Qt stylesheet at `resources/style.qss`, the bundled OCIO config in `resources/ocio/`, and docs imagery in `resources/screenshots/`.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -20,4 +20,4 @@ as the code (and [CHANGELOG.md](../CHANGELOG.md)). See
 | [Nuke](./nuke.md) | Nuke menu integration |
 | [R3D / N-RAW](./r3d.md) | Optional RED R3D SDK (proprietary; build + license) |
 | [Releasing](./releasing.md) | Pointer to maintainer release process |
-| [12-bit ProRes (oxideav)](./plan-12bit-prores-oxideav.md) | Experimental RDD-36 12-bit ProRes via PyO3 |
+| [12-bit ProRes (oxideav)](./plan-12bit-prores-oxideav.md) | Experimental RDD-36 12-bit ProRes (release builds) |

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -183,7 +183,9 @@ sequence. Extraction uses the known EXR frame list (not a video seek).
 ## Codecs
 
 Same honest bit-depth ladder as the CLI. Default is software **ProRes 422 HQ**
-(`prores`, **10-bit**). macOS-only VideoToolbox ProRes keys appear only on
+(`prores`, **10-bit**). The EXR → Video **Codec** dropdown groups presets by
+family (ProRes software, VideoToolbox on macOS, experimental oxideav, CineForm,
+DNxHR, H.264/HEVC, FFV1). macOS-only VideoToolbox ProRes keys appear only on
 Darwin. Experimental **oxideav** 12-bit ProRes keys (`prores_ox_4444` /
 `prores_ox_xq`) appear when the `exr_prores` extension is built
 (`make oxideav-prores`). Full key list and bit depths:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.7"
+version = "0.9.8"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -389,6 +389,56 @@ def available_video_codecs() -> list[VideoCodecSpec]:
     return out
 
 
+# EXR→video codec picker groups (GUI). Keys must match ``VIDEO_CODECS`` order
+# within each group; empty groups are omitted per OS / build.
+VIDEO_CODEC_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "ProRes (software · FFmpeg)",
+        (
+            "prores_proxy",
+            "prores_lt",
+            "prores_422",
+            "prores",
+            "prores_4444",
+            "prores_xq",
+        ),
+    ),
+    (
+        "ProRes (VideoToolbox · macOS)",
+        (
+            "prores_vt_proxy",
+            "prores_vt_lt",
+            "prores_vt_422",
+            "prores_vt_hq",
+            "prores_vt_4444",
+            "prores_vt_xq",
+        ),
+    ),
+    (
+        "ProRes (oxideav · experimental)",
+        (
+            "prores_ox_4444",
+            "prores_ox_xq",
+        ),
+    ),
+    ("CineForm", ("cineform", "cineform_rgb")),
+    ("DNxHR", ("dnxhr_lb", "dnxhr_sq", "dnxhr_hq", "dnxhr_hqx", "dnxhr_444")),
+    ("H.264 / HEVC", ("h264", "hevc", "hevc_12", "hevc_8")),
+    ("FFV1 (lossless)", ("ffv1", "ffv1_12")),
+)
+
+
+def available_video_codecs_grouped() -> list[tuple[str, list[VideoCodecSpec]]]:
+    """``available_video_codecs()`` partitioned for the GUI codec picker."""
+    by_key = {c.key: c for c in available_video_codecs()}
+    grouped: list[tuple[str, list[VideoCodecSpec]]] = []
+    for label, keys in VIDEO_CODEC_GROUPS:
+        specs = [by_key[k] for k in keys if k in by_key]
+        if specs:
+            grouped.append((label, specs))
+    return grouped
+
+
 def video_codec_by_key(key: str) -> VideoCodecSpec | None:
     for c in VIDEO_CODECS:
         if c.key == key:

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -7,7 +7,7 @@ from .oxideav_prores import is_available as oxideav_prores_available
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.9.7"
+APP_VERSION = "0.9.8"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/src/gui/widgets.py
+++ b/src/gui/widgets.py
@@ -90,6 +90,7 @@ from ..core.constants import (
     OCIO_SOURCE_FILE,
     SCALE_OPTIONS,
     available_video_codecs,
+    available_video_codecs_grouped,
     is_image_sequence_ext,
     video_codec_by_key,
 )
@@ -4023,6 +4024,56 @@ class _InputProbeWorker(QObject):
             self.failed.emit(str(e))
 
 
+def _set_codec_combo_header_row(combo: QComboBox, index: int) -> None:
+    """Non-selectable bold group label row in the codec picker."""
+    from PySide6.QtGui import QStandardItemModel
+
+    model = combo.model()
+    if not isinstance(model, QStandardItemModel):
+        return
+    item = model.item(index)
+    if item is None:
+        return
+    item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEnabled & ~Qt.ItemFlag.ItemIsSelectable)
+    font = item.font()
+    font.setBold(True)
+    item.setFont(font)
+
+
+def _populate_video_codec_combo(combo: QComboBox) -> None:
+    """Fill *combo* with OS-filtered codecs grouped by family."""
+    combo.clear()
+    first_group = True
+    for group_label, specs in available_video_codecs_grouped():
+        if not first_group:
+            combo.insertSeparator(combo.count())
+        first_group = False
+
+        combo.addItem(group_label, None)
+        _set_codec_combo_header_row(combo, combo.count() - 1)
+
+        for spec in specs:
+            tip = spec.format_label
+            if spec.platforms:
+                tip += f" · {', '.join(spec.platforms)} only"
+            combo.addItem(spec.display_name, spec.key)
+            idx = combo.count() - 1
+            combo.setItemData(idx, tip, Qt.ItemDataRole.ToolTipRole)
+
+
+def _select_video_codec_combo_key(
+    combo: QComboBox,
+    key: str,
+    *,
+    fallback: str = DEFAULT_VIDEO_CODEC,
+) -> None:
+    for codec_key in (key, fallback):
+        for i in range(combo.count()):
+            if combo.itemData(i) == codec_key:
+                combo.setCurrentIndex(i)
+                return
+
+
 class ConvertTab(QWidget):
     log_message = Signal(str)
     readiness_changed = Signal(bool)
@@ -4253,18 +4304,9 @@ class ConvertTab(QWidget):
             opts_layout.addRow("Frame rate", self.fps_widget)
 
             self.codec_combo = QComboBox()
-            for spec in available_video_codecs():
-                tip = spec.format_label
-                if spec.platforms:
-                    tip += f" · {', '.join(spec.platforms)} only"
-                self.codec_combo.addItem(spec.display_name, spec.key)
-                idx = self.codec_combo.count() - 1
-                self.codec_combo.setItemData(idx, tip, Qt.ItemDataRole.ToolTipRole)
+            _populate_video_codec_combo(self.codec_combo)
             saved_codec = settings.value(f"{mode}/video_codec", DEFAULT_VIDEO_CODEC)
-            for i in range(self.codec_combo.count()):
-                if self.codec_combo.itemData(i) == saved_codec:
-                    self.codec_combo.setCurrentIndex(i)
-                    break
+            _select_video_codec_combo_key(self.codec_combo, str(saved_codec))
             self.codec_combo.currentIndexChanged.connect(
                 lambda _: self._settings.setValue(
                     f"{self._mode}/video_codec",

--- a/src/gui/window.py
+++ b/src/gui/window.py
@@ -54,7 +54,7 @@ from .preferences import (
     reveal_in_file_manager,
 )
 from .size_grip import SizeGrip
-from .widgets import ConvertTab, OcioConfigPanel
+from .widgets import ConvertTab, OcioConfigPanel, _select_video_codec_combo_key
 
 
 class AboutDialog(QDialog):
@@ -1244,10 +1244,10 @@ class MainWindow(QMainWindow):
                         tab_widget.scale_combo.setCurrentIndex(i)
                         break
         if "e2v_codec" in data and self._e2v_tab.codec_combo:
-            for i in range(self._e2v_tab.codec_combo.count()):
-                if self._e2v_tab.codec_combo.itemData(i) == data["e2v_codec"]:
-                    self._e2v_tab.codec_combo.setCurrentIndex(i)
-                    break
+            _select_video_codec_combo_key(
+                self._e2v_tab.codec_combo,
+                str(data["e2v_codec"]),
+            )
 
     # -- Drag and drop --
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -26,6 +26,7 @@ from src.core.constants import (
     VIDEO_CODECS,
     VideoCodecSpec,
     available_video_codecs,
+    available_video_codecs_grouped,
     video_codec_by_key,
 )
 from src.core.convert import _default_codec_opts
@@ -120,6 +121,22 @@ class TestVideoCodecSpecs:
             assert OXIDEAV_PRORES_KEYS <= avail_keys
         else:
             assert not (OXIDEAV_PRORES_KEYS & avail_keys)
+
+    def test_available_video_codecs_grouped_covers_all(self):
+        flat = {c.key for c in available_video_codecs()}
+        grouped: set[str] = set()
+        labels: list[str] = []
+        for label, specs in available_video_codecs_grouped():
+            labels.append(label)
+            for spec in specs:
+                assert spec.key not in grouped
+                grouped.add(spec.key)
+        assert grouped == flat
+        assert labels == sorted(labels, key=labels.index)  # stable order
+        if sys.platform == "darwin":
+            assert any(label.startswith("ProRes (VideoToolbox") for label in labels)
+        else:
+            assert not any(label.startswith("ProRes (VideoToolbox") for label in labels)
 
     def test_dnxhr_full_ladder(self):
         for k, bit, chroma in (

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.7"
+version = "0.9.8"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Patch **0.9.8** ships experimental **12-bit ProRes** via in-process oxideav PyO3 bindings (`exr_prores`) in release builds, plus a grouped EXR → Video codec picker in the GUI.

### Added
- `prores_ox_4444` / `prores_ox_xq` — cross-platform RDD-36 ProRes-compatible encode (Nuitka includes `exr_prores`). Not Apple-certified. Software FFmpeg ProRes remains honest 10-bit.

### Changed
- EXR → Video codec dropdown grouped by family (ProRes software / VideoToolbox / oxideav, CineForm, DNxHR, H.264/HEVC, FFV1).
- README and docs site index updated for oxideav and codec menu.

## Test plan
- [x] `make lint`
- [ ] CI green on this PR
- [ ] After merge: Auto-tag creates `v0.9.8` and dispatches Release

Replaces stale open PR #29 (`release/0.9.8`) which targeted an older feature set not on `main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0244c-58af-7f3d-afe4-1e24541620ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0244c-58af-7f3d-afe4-1e24541620ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

