### PR TITLE
fix(ci): macOS Intel Nuitka LTO OOM on Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,6 +342,12 @@ jobs:
           else
             EXTRA_FLAGS+=("--linux-icon=${{ steps.icon.outputs.path }}")
           fi
+          # macos-26-intel runners OOM during Nuitka LTO link once exr_prores is
+          # included; arm64/linux/windows tolerate --lto=yes.
+          LTO_FLAG="--lto=yes"
+          if [ "${{ matrix.os }}" == "macos-26-intel" ]; then
+            LTO_FLAG="--lto=no"
+          fi
           # Flags kept in sync with `make bundle` (shared strip set + LTO).
           uv run python -m nuitka \
             $MODE \
@@ -349,7 +355,7 @@ jobs:
             --output-filename=exr_converter \
             --assume-yes-for-downloads \
             --python-flag=-OO \
-            --lto=yes \
+            "$LTO_FLAG" \
             --enable-plugin=pyside6 \
             --nofollow-import-to=tkinter \
             --nofollow-import-to=unittest \
@@ -447,8 +453,10 @@ jobs:
               sh -c 'lipo -info "$1" 2>/dev/null | grep -q "universal\|two arch" && lipo -thin '"$ARCH"' "$1" -output "$1.thin" && mv "$1.thin" "$1" || true' _ {} \;
           fi
 
-          # Strip debug symbols (never strip private RED redistributables under r3d/).
-          find "$APP" -type f \( -name '*.dylib' -o -name '*.so' \) ! -path '*/r3d/*' -exec strip -x {} +
+          # Strip debug symbols (never strip private RED redistributables under r3d/
+          # or the oxideav PyO3 extension — strip can break extension load).
+          find "$APP" -type f \( -name '*.dylib' -o -name '*.so' \) \
+            ! -path '*/r3d/*' ! -path '*exr_prores*' -exec strip -x {} +
 
           echo "Bundle size after slimming:"
           du -sh "$APP"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release **v0.9.8** failed on the **macOS Intel** matrix job during **Build with Nuitka** (~55 min, step 18). Linux, macOS arm64, and Windows all succeeded.

Root cause: Nuitka **LTO link OOM / runner kill** on `macos-26-intel` once `--include-module=exr_prores` is enabled. arm64 tolerates LTO.

## Fix
- Use `--lto=no` only for `macos-26-intel` (keep LTO elsewhere)
- Skip `strip` on `exr_prores` native module (same as R3D redistributables)

## After merge
Re-dispatch Release for existing tag:

```bash
gh workflow run Release --ref main -f tag=v0.9.8
```

No version bump — completes the unpublished **0.9.8** release.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0244c-58af-7f3d-afe4-1e24541620ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0244c-58af-7f3d-afe4-1e24541620ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

