### PR TITLE
release: 0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ## [Unreleased]
 
+---
+
+## [0.9.9] — 2026-08-25
+
 ### Security
 
 - **oxideav PyO3 extension:** bump ``pyo3`` 0.25 → 0.29 (fixes
@@ -664,7 +668,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.8...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.9...HEAD
+[0.9.9]: https://github.com/derek-rein/exr-converter/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/derek-rein/exr-converter/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/derek-rein/exr-converter/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/derek-rein/exr-converter/compare/v0.9.5...v0.9.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.8"
+version = "0.9.9"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -7,7 +7,7 @@ from .oxideav_prores import is_available as oxideav_prores_available
 
 APP_ORG = "VFXTools"
 APP_NAME = "EXRConverter"
-APP_VERSION = "0.9.8"
+APP_VERSION = "0.9.9"
 
 GITHUB_REPO = "derek-rein/exr-converter"
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.8"
+version = "0.9.9"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Patch release **0.9.9** for the oxideav PyO3 security bump (GHSA-36hh-v3qg-5jq4) already on `main`, plus the post-0.9.8 README changelog entry.

## Changes

- Bump `pyproject.toml` / `APP_VERSION` / `uv.lock` → **0.9.9**
- Roll `[Unreleased]` → `## [0.9.9] — 2026-08-25` with compare link

## After merge

Auto-tag should create `v0.9.9` and dispatch the Release workflow. Do **not** also push the local tag unless Auto-tag fails.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: Auto-tag + Release publish all four platform artifacts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0244c-58af-7f3d-afe4-1e24541620ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0244c-58af-7f3d-afe4-1e24541620ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

