### PR TITLE
release: 0.9.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ r3d_sdk/
 .r3d-sdk-location.example
 
 native/exr_prores/target/
+
+# Local R3D sample copies (do not commit camera originals)
+.tmp-r3d-sample/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ site/                   # Hugo config + theme; mounts docs/ → GitHub Pages
 | Area | Start here |
 |------|------------|
 | Convert pipeline | `src/core/convert.py`, `src/core/video.py`, `src/core/exr_io.py` |
-| Optional R3D / N-RAW | `src/core/r3d.py`, `native/r3d/`, `scripts/build_r3d_bridge.py`, `scripts/fetch_r3d_sdk.py`, `scripts/install_r3d_into_bundle.py`, [docs/r3d.md](./docs/r3d.md) |
+| Optional R3D / N-RAW | `src/core/r3d/`, `native/r3d/` (macOS Metal; Win/Linux CUDA then OpenCL; CPU fallback), `scripts/build_r3d_bridge.py`, `scripts/fetch_r3d_sdk.py`, `scripts/install_r3d_into_bundle.py`, [docs/r3d.md](./docs/r3d.md) |
 | Optional 12-bit ProRes (oxideav) | `native/exr_prores/` (PyO3), `src/core/oxideav_prores.py`, `make oxideav-prores`, [docs/plan-12bit-prores-oxideav.md](./docs/plan-12bit-prores-oxideav.md) |
 | Private full SDK (local) | `~/code/r3d-sdk-private/R3DSDKv9_2_1` — never commit; CI feed = private repo `derek-rein/r3d-sdk-private` release `sdk-9.2.1` |
 | Codec ladder / bit depth labels | `src/core/constants.py` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ rolling the `[Unreleased]` section into a versioned heading.
 
 ---
 
+## [0.9.12] — 2026-09-05
+
+### Fixed
+
+- **Built-in player / preview:** oxideav ProRes MOVs open again. Decoded YUV
+  frames were tagged ``colorspace=RGB``, so libswscale refused ``rgb48le`` /
+  ``rgb24`` (``ENOTSUP``) and the viewer stayed empty. Preview, thumbs, and
+  Video→EXR now copy planes into a swscale-compatible frame when that happens.
+
+### Changed
+
+- **R3D → EXR GPU decode:** macOS uses Metal (`GpuDecoder` + REDMetal) for
+  classic R3D (including KOMODO 6K). Windows and Linux use the SDK
+  ``R3DDecoder`` (CUDA, then OpenCL). Convert log reports ``Metal GPU`` /
+  ``CUDA GPU`` / ``OpenCL GPU`` vs ``CPU``. Set ``EXR_CONVERTER_R3D_CPU=1``
+  to force the CPU path.
+
+---
+
 ## [0.9.11] — 2026-08-26
 
 ### Added
@@ -710,7 +729,8 @@ hardening (QImage/QBuffer; exclude PIL from bundles).
 - Releases: https://github.com/derek-rein/exr-converter/releases
 - Compare tags: `https://github.com/derek-rein/exr-converter/compare/vA.B.C...vX.Y.Z`
 
-[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.11...HEAD
+[Unreleased]: https://github.com/derek-rein/exr-converter/compare/v0.9.12...HEAD
+[0.9.12]: https://github.com/derek-rein/exr-converter/compare/v0.9.11...v0.9.12
 [0.9.11]: https://github.com/derek-rein/exr-converter/compare/v0.9.10...v0.9.11
 [0.9.10]: https://github.com/derek-rein/exr-converter/compare/v0.9.9...v0.9.10
 [0.9.9]: https://github.com/derek-rein/exr-converter/compare/v0.9.8...v0.9.9

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -24,7 +24,7 @@ from a Read — see [nuke.md](./nuke.md).
 
 | Tab | Direction | Notes |
 |-----|-----------|--------|
-| **Video → EXR** | Decode video → OCIO → EXR sequence | **Ingest only** — never slate / burn-in / watermark. Output field uses ``name.####.exr``; that basename is written (not forced to the video stem). Accepts common video containers plus optional **`.r3d` / `.nev`** when the [R3D SDK bridge](./r3d.md) is available (browser thumbs + player preview use low-res R3D decode; convert is full quality; camera/timecode metadata lands on EXRs). |
+| **Video → EXR** | Decode video → OCIO → EXR sequence | **Ingest only** — never slate / burn-in / watermark. Output field uses ``name.####.exr``; that basename is written (not forced to the video stem). Accepts common video containers plus optional **`.r3d` / `.nev`** when the [R3D SDK bridge](./r3d.md) is available (browser thumbs + player preview use low-res R3D decode; convert is full quality — **Metal GPU** on macOS, **CUDA / OpenCL** on Windows and Linux; camera/timecode metadata lands on EXRs). |
 | **EXR → Video** | Image sequence → OCIO → video | OpenEXR primary; also DPX, PNG, JPEG, WebP. Slate / burn-in / watermark via that tab’s controls. Sequences may use ``name.####.ext`` or ``name_####.ext`` pads. |
 
 Dragging the **Log** splitter up does not squash Input / Output / Options

--- a/docs/prores.md
+++ b/docs/prores.md
@@ -116,6 +116,10 @@ call it “Apple ProRes.” Full ladder (not only 4444/XQ):
 Implementation status and tests:
 [plan-12bit-prores-oxideav.md](./plan-12bit-prores-oxideav.md).
 
+The built-in player, browser thumbs, and Video→EXR decode these MOVs through
+PyAV. FFmpeg may present oxideav frames as YUV with an RGB colorspace tag;
+the app strips that before RGB convert so preview is not blank.
+
 ---
 
 ## Quick picks

--- a/docs/r3d.md
+++ b/docs/r3d.md
@@ -18,16 +18,22 @@ Related: [CLI](./cli.md) · [GUI](./gui.md) · [AGENTS.md](../AGENTS.md)
 | Item | Behavior |
 |------|----------|
 | Formats | `.r3d` (classic multi-part + R3D NE), `.nev` (N-RAW) |
-| Decode | CPU path via R3D SDK (IPP2 **Primary Development** → **REDWideGamutRGB + Log3G10**) |
+| Decode | R3D SDK IPP2 **Primary Development** → **REDWideGamutRGB + Log3G10** |
 | OCIO | Auto-detect source space prefers Log3G10 / RWG names on the active config |
 | Output | Same video→EXR pipeline (EXR compression, scale ladder, frame range, workers) |
-| GPU | Not used in this integration yet (CUDA / Metal / OpenCL left for a later pass) |
+| GPU | **macOS Metal** (`GpuDecoder` + REDMetal) for classic R3D GPU decompress. **Windows / Linux:** SDK `R3DDecoder` — CUDA if an NVIDIA device is present, otherwise OpenCL. CPU fallback when no GPU init, or for clips Metal cannot GPU-decompress (N-RAW / R3D NE / RED ONE on macOS). Force CPU with `EXR_CONVERTER_R3D_CPU=1`. |
 | Preview | Sequence player + video browser (half-res decode for scrub) |
 | Thumbnails | Grid thumbs via sixteenth-res decode (fast ID, not full premium) |
 | Metadata | Clip + per-frame timecode written to EXR as ``exrconverter:r3d:*`` attrs |
 
 Scale maps to the SDK resolution ladder (full / half / quarter / …) for faster
 proxies; odd scale factors may apply a small software resize after decode.
+
+The SDK is cross-platform, but GPU APIs are not one path: **Metal** on macOS
+(full GPU decompress), **CUDA then OpenCL** on Windows/Linux via managed
+`R3DDecoder` (CPU decompress + GPU IPP2). CUDA needs an NVIDIA driver and the
+CUDA runtime (`cudart`) on the library path; OpenCL needs a GPU ICD. No extra
+compile-time CUDA/OpenCL SDK is required to build the bridge.
 
 ---
 
@@ -105,6 +111,7 @@ Override discovery:
 | `R3D_SDK_ROOT` | Unpacked SDK root for **building** the bridge |
 | `EXR_CONVERTER_R3D_BRIDGE` | Path to `libr3d_bridge.*` (or its directory) |
 | `EXR_CONVERTER_R3D_LIBS` / `R3D_SDK_LIBS` | Folder containing `REDR3D.*` redistributables |
+| `EXR_CONVERTER_R3D_CPU` | Set to `1` to skip GPU decode (CPU only) |
 | `R3D_SDK_READ_TOKEN` | PAT that can download the private Release asset |
 
 Convert:
@@ -158,6 +165,7 @@ Windows:<dist>/r3d/
 | Multi-part classic R3D | Point at any part (e.g. `…_001.R3D`); the SDK loads siblings |
 | `._….R3D` in browser | macOS AppleDouble metadata next to the real clip — hidden from the video browser (not media) |
 | `.RMD` next to clip | RED metadata recipe sidecar — not listed as video (open the `.R3D`) |
+| Convert log says `CPU` on a KOMODO `.R3D` | GPU init failed (Metal / CUDA / OpenCL). Rebuild `make r3d-bridge`. CUDA needs a NVIDIA driver + `cudart` next to the RED libs; OpenCL needs a GPU ICD. Force CPU with `EXR_CONVERTER_R3D_CPU=1` to compare. |
 
 Sample clips (from RED / Nikon, not this repo):
 

--- a/native/r3d/r3d_bridge.cpp
+++ b/native/r3d/r3d_bridge.cpp
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT
  *
- * C ABI bridge for the RED R3D SDK (CPU decode path).
+ * C ABI bridge for the RED R3D SDK (CPU decode + optional GPU: Metal / CUDA / OpenCL).
  * Links against RED static lib + loads redistributable dylibs at InitializeSdk.
  *
  * Redistribute only this bridge object code + RED Redistributable/ dynamic
@@ -9,6 +9,8 @@
  */
 
 #include "r3d_bridge.h"
+#include "r3d_bridge_internal.h"
+#include "r3d_gpu.h"
 
 #include "R3DSDK.h"
 
@@ -18,7 +20,9 @@
 #include <new>
 #include <string>
 
-using namespace R3DSDK;
+#ifdef _WIN32
+#include <malloc.h>
+#endif
 
 namespace {
 
@@ -26,49 +30,159 @@ std::mutex g_mu;
 bool g_initialized = false;
 std::string g_last_error;
 
-void set_error(const std::string &msg)
+struct BridgeClip {
+    R3DSDK::Clip *clip = nullptr;
+    bool gpu_supported = false;
+    R3DSDK::ImageProcessingSettings *ip = nullptr;
+    int ip_pipeline = -1;
+    unsigned char *u16 = nullptr;
+    size_t u16_bytes = 0;
+};
+
+unsigned char *aligned_alloc16(size_t size)
+{
+#ifdef _WIN32
+    return static_cast<unsigned char *>(_aligned_malloc(size, 16U));
+#else
+    void *p = nullptr;
+    if (posix_memalign(&p, 16U, size) != 0) {
+        return nullptr;
+    }
+    return static_cast<unsigned char *>(p);
+#endif
+}
+
+void aligned_free16(void *p)
+{
+    if (!p) {
+        return;
+    }
+#ifdef _WIN32
+    _aligned_free(p);
+#else
+    std::free(p);
+#endif
+}
+
+BridgeClip *as_bridge(void *p)
+{
+    return static_cast<BridgeClip *>(p);
+}
+
+R3DSDK::Clip *as_clip(void *p)
+{
+    BridgeClip *b = as_bridge(p);
+    return b ? b->clip : nullptr;
+}
+
+int cpu_decode_frame(
+    BridgeClip *bridge,
+    uint32_t frame_index,
+    int decode_mode,
+    int pipeline,
+    float *out_rgb_f32,
+    size_t out_rgb_bytes,
+    uint32_t *out_w,
+    uint32_t *out_h)
+{
+    R3DSDK::Clip *clip = bridge->clip;
+    if (frame_index >= clip->VideoFrameCount()) {
+        r3d_bridge_set_error("r3d_bridge_decode_frame: frame index out of range");
+        return -2;
+    }
+
+    size_t w = 0, h = 0;
+    r3d_dims_for_mode(clip->Width(), clip->Height(), decode_mode, w, h);
+    const size_t n_pix = w * h * 3U;
+    const size_t need_f32 = n_pix * sizeof(float);
+    if (out_rgb_bytes < need_f32) {
+        r3d_bridge_set_error("r3d_bridge_decode_frame: output buffer too small");
+        return -3;
+    }
+
+    const size_t mem_needed = n_pix * 2U; // 16-bit packed RGB
+    if (bridge->u16_bytes < mem_needed) {
+        aligned_free16(bridge->u16);
+        bridge->u16 = aligned_alloc16(mem_needed);
+        bridge->u16_bytes = bridge->u16 ? mem_needed : 0;
+        if (!bridge->u16) {
+            r3d_bridge_set_error("r3d_bridge_decode_frame: alloc failed");
+            return -4;
+        }
+    }
+
+    if (!bridge->ip) {
+        bridge->ip = new (std::nothrow) R3DSDK::ImageProcessingSettings();
+        if (!bridge->ip) {
+            r3d_bridge_set_error("r3d_bridge_decode_frame: IP alloc failed");
+            return -4;
+        }
+        bridge->ip_pipeline = -1;
+    }
+    if (bridge->ip_pipeline != pipeline) {
+        r3d_apply_pipeline(clip, *bridge->ip, pipeline);
+        bridge->ip_pipeline = pipeline;
+    }
+
+    R3DSDK::VideoDecodeJob job;
+    job.OutputBufferSize = mem_needed;
+    job.OutputBuffer = bridge->u16;
+    job.Mode = r3d_map_mode(decode_mode);
+    job.PixelType = R3DSDK::PixelType_16Bit_RGB_Interleaved;
+    job.ImageProcessing = bridge->ip;
+
+    R3DSDK::DecodeStatus st = clip->DecodeVideoFrame(static_cast<size_t>(frame_index), job);
+    if (st != R3DSDK::DSDecodeOK) {
+        r3d_bridge_set_error(
+            std::string("DecodeVideoFrame failed: ") + std::to_string(static_cast<int>(st)));
+        return static_cast<int>(st);
+    }
+
+    r3d_u16_to_f32(reinterpret_cast<const uint16_t *>(bridge->u16), out_rgb_f32, n_pix);
+
+    if (out_w)
+        *out_w = static_cast<uint32_t>(w);
+    if (out_h)
+        *out_h = static_cast<uint32_t>(h);
+    return 0;
+}
+
+} // namespace
+
+void r3d_bridge_set_error(const std::string &msg)
 {
     g_last_error = msg;
 }
 
-unsigned char *aligned_malloc(size_t &size_needed, size_t &offset_out)
+bool r3d_force_cpu()
 {
-    // R3D requires 16-byte alignment for output buffers.
-    unsigned char *buffer = static_cast<unsigned char *>(std::malloc(size_needed + 15U));
-    if (!buffer) {
-        offset_out = 0;
-        size_needed = 0;
-        return nullptr;
+    const char *e = std::getenv("EXR_CONVERTER_R3D_CPU");
+    if (!e || !e[0]) {
+        return false;
     }
-    uintptr_t ptr = reinterpret_cast<uintptr_t>(buffer);
-    if ((ptr % 16U) == 0U) {
-        offset_out = 0;
-        return buffer;
-    }
-    offset_out = 16U - (ptr % 16U);
-    return buffer + offset_out;
+    return !(e[0] == '0' && e[1] == '\0');
 }
 
-VideoDecodeMode map_mode(int mode)
+R3DSDK::VideoDecodeMode r3d_map_mode(int mode)
 {
     switch (mode) {
     case R3D_DECODE_HALF_PREMIUM:
-        return DECODE_HALF_RES_PREMIUM;
+        return R3DSDK::DECODE_HALF_RES_PREMIUM;
     case R3D_DECODE_HALF_GOOD:
-        return DECODE_HALF_RES_GOOD;
+        return R3DSDK::DECODE_HALF_RES_GOOD;
     case R3D_DECODE_QUARTER_GOOD:
-        return DECODE_QUARTER_RES_GOOD;
+        return R3DSDK::DECODE_QUARTER_RES_GOOD;
     case R3D_DECODE_EIGHTH_GOOD:
-        return DECODE_EIGHT_RES_GOOD;
+        return R3DSDK::DECODE_EIGHT_RES_GOOD;
     case R3D_DECODE_SIXTEENTH_GOOD:
-        return DECODE_SIXTEENTH_RES_GOOD;
+        return R3DSDK::DECODE_SIXTEENTH_RES_GOOD;
     case R3D_DECODE_FULL_PREMIUM:
     default:
-        return DECODE_FULL_RES_PREMIUM;
+        return R3DSDK::DECODE_FULL_RES_PREMIUM;
     }
 }
 
-void dims_for_mode(size_t full_w, size_t full_h, int mode, size_t &w, size_t &h)
+void r3d_dims_for_mode(size_t full_w, size_t full_h, int mode, size_t &w, size_t &h)
 {
     size_t div = 1;
     switch (mode) {
@@ -97,7 +211,8 @@ void dims_for_mode(size_t full_w, size_t full_h, int mode, size_t &w, size_t &h)
         h = 1;
 }
 
-void apply_pipeline(Clip *clip, ImageProcessingSettings &ip, int pipeline)
+void r3d_apply_pipeline(
+    R3DSDK::Clip *clip, R3DSDK::ImageProcessingSettings &ip, int pipeline)
 {
     clip->GetDefaultImageProcessingSettings(ip);
 
@@ -106,15 +221,22 @@ void apply_pipeline(Clip *clip, ImageProcessingSettings &ip, int pipeline)
     }
 
     // IPP2 primary RAW development → REDWideGamutRGB + Log3G10 (ideal for OCIO).
-    // Request ColorVersion3; the SDK raises the floor to MinimumColorVersion() if needed.
-    ip.Version = ColorVersion3;
-    ip.ImagePipelineMode = Primary_Development_Only;
-    // Also set explicit RWG/Log3G10 for legacy clips that cannot use Primary mode.
-    ip.ColorSpace = ImageColorREDWideGamutRGB;
-    ip.GammaCurve = ImageGammaLog3G10;
+    ip.Version = R3DSDK::ColorVersion3;
+    ip.ImagePipelineMode = R3DSDK::Primary_Development_Only;
+    ip.ColorSpace = R3DSDK::ImageColorREDWideGamutRGB;
+    ip.GammaCurve = R3DSDK::ImageGammaLog3G10;
 }
 
-} // namespace
+void r3d_u16_to_f32(const uint16_t *src, float *dst, size_t n)
+{
+    const float scale = 1.0f / 65535.0f;
+#if defined(__clang__)
+#pragma clang loop vectorize(enable) interleave(enable)
+#endif
+    for (size_t i = 0; i < n; ++i) {
+        dst[i] = static_cast<float>(src[i]) * scale;
+    }
+}
 
 extern "C" {
 
@@ -130,15 +252,32 @@ int r3d_bridge_initialize(const char *libs_path)
         return 0;
     }
     if (!libs_path || !libs_path[0]) {
-        set_error("r3d_bridge_initialize: empty libs path");
+        r3d_bridge_set_error("r3d_bridge_initialize: empty libs path");
         return -1;
     }
-    InitializeStatus st = InitializeSdk(libs_path, OPTION_RED_NONE);
-    if (st != ISInitializeOK) {
-        set_error(std::string("InitializeSdk failed: ") + std::to_string(static_cast<int>(st))
-                  + " path=" + libs_path);
-        // Still finalize so a later retry is clean.
-        FinalizeSdk();
+
+    unsigned int components = OPTION_RED_NONE;
+    if (!r3d_force_cpu()) {
+#if defined(__APPLE__)
+        components = OPTION_RED_METAL;
+#else
+        components = OPTION_RED_DECODER;
+#endif
+    }
+
+    R3DSDK::InitializeStatus st = R3DSDK::InitializeSdk(libs_path, components);
+    if (st != R3DSDK::ISInitializeOK && components != OPTION_RED_NONE) {
+        R3DSDK::FinalizeSdk();
+        st = R3DSDK::InitializeSdk(libs_path, OPTION_RED_NONE);
+        if (st == R3DSDK::ISInitializeOK) {
+            r3d_bridge_set_error("InitializeSdk: GPU component unavailable, using CPU");
+        }
+    }
+    if (st != R3DSDK::ISInitializeOK) {
+        r3d_bridge_set_error(
+            std::string("InitializeSdk failed: ") + std::to_string(static_cast<int>(st))
+            + " path=" + libs_path);
+        R3DSDK::FinalizeSdk();
         return static_cast<int>(st);
     }
     g_initialized = true;
@@ -149,8 +288,9 @@ int r3d_bridge_initialize(const char *libs_path)
 void r3d_bridge_finalize(void)
 {
     std::lock_guard<std::mutex> lock(g_mu);
+    r3d_gpu::shutdown();
     if (g_initialized) {
-        FinalizeSdk();
+        R3DSDK::FinalizeSdk();
         g_initialized = false;
     }
 }
@@ -166,7 +306,7 @@ void r3d_bridge_sdk_version(char *buf, size_t buf_len)
     if (!buf || buf_len == 0) {
         return;
     }
-    const char *v = GetSdkVersion();
+    const char *v = R3DSDK::GetSdkVersion();
     if (!v) {
         buf[0] = '\0';
         return;
@@ -180,54 +320,67 @@ int r3d_bridge_identify(const char *utf8_path)
     if (!utf8_path) {
         return R3D_FILE_UNKNOWN;
     }
-    return IdentifyFile(utf8_path);
+    return R3DSDK::IdentifyFile(utf8_path);
 }
 
 void *r3d_bridge_open(const char *utf8_path)
 {
     if (!utf8_path || !utf8_path[0]) {
-        set_error("r3d_bridge_open: empty path");
+        r3d_bridge_set_error("r3d_bridge_open: empty path");
         return nullptr;
     }
     if (!r3d_bridge_is_initialized()) {
-        set_error("r3d_bridge_open: SDK not initialized");
+        r3d_bridge_set_error("r3d_bridge_open: SDK not initialized");
         return nullptr;
     }
-    Clip *clip = new (std::nothrow) Clip(utf8_path);
-    if (!clip) {
-        set_error("r3d_bridge_open: out of memory");
+    BridgeClip *bridge = new (std::nothrow) BridgeClip();
+    if (!bridge) {
+        r3d_bridge_set_error("r3d_bridge_open: out of memory");
         return nullptr;
     }
-    if (clip->Status() != LSClipLoaded) {
-        set_error(std::string("Failed to load clip: ") + utf8_path
-                  + " status=" + std::to_string(static_cast<int>(clip->Status())));
-        delete clip;
+    bridge->clip = new (std::nothrow) R3DSDK::Clip(utf8_path);
+    if (!bridge->clip) {
+        delete bridge;
+        r3d_bridge_set_error("r3d_bridge_open: out of memory");
         return nullptr;
     }
-    return clip;
+    if (bridge->clip->Status() != R3DSDK::LSClipLoaded) {
+        r3d_bridge_set_error(
+            std::string("Failed to load clip: ") + utf8_path
+            + " status=" + std::to_string(static_cast<int>(bridge->clip->Status())));
+        delete bridge->clip;
+        delete bridge;
+        return nullptr;
+    }
+    r3d_gpu::startup();
+    bridge->gpu_supported = r3d_gpu::available() && r3d_gpu::clip_supported(bridge->clip);
+    return bridge;
 }
 
 void r3d_bridge_close(void *clip)
 {
-    if (!clip) {
+    BridgeClip *bridge = as_bridge(clip);
+    if (!bridge) {
         return;
     }
-    delete static_cast<Clip *>(clip);
+    delete bridge->ip;
+    aligned_free16(bridge->u16);
+    delete bridge->clip;
+    delete bridge;
 }
 
 int r3d_bridge_clip_info(void *clip_ptr, R3DBridgeClipInfo *out)
 {
-    if (!clip_ptr || !out) {
-        set_error("r3d_bridge_clip_info: null argument");
+    R3DSDK::Clip *clip = as_clip(clip_ptr);
+    if (!clip || !out) {
+        r3d_bridge_set_error("r3d_bridge_clip_info: null argument");
         return -1;
     }
-    Clip *clip = static_cast<Clip *>(clip_ptr);
     std::memset(out, 0, sizeof(*out));
     out->width = static_cast<uint32_t>(clip->Width());
     out->height = static_cast<uint32_t>(clip->Height());
     out->frame_count = static_cast<uint32_t>(clip->VideoFrameCount());
     out->fps = clip->VideoAudioFramerate();
-    // Hint for OCIO auto-detect (primary Log3G10 / RWG).
     std::strncpy(out->colorspace_hint, "Log3G10 REDWideGamutRGB", sizeof(out->colorspace_hint) - 1);
     r3d_bridge_sdk_version(out->sdk_version, sizeof(out->sdk_version));
     return 0;
@@ -236,17 +389,16 @@ int r3d_bridge_clip_info(void *clip_ptr, R3DBridgeClipInfo *out)
 size_t r3d_bridge_decode_buffer_bytes(
     void *clip_ptr, int decode_mode, uint32_t *out_w, uint32_t *out_h)
 {
-    if (!clip_ptr) {
+    R3DSDK::Clip *clip = as_clip(clip_ptr);
+    if (!clip) {
         return 0;
     }
-    Clip *clip = static_cast<Clip *>(clip_ptr);
     size_t w = 0, h = 0;
-    dims_for_mode(clip->Width(), clip->Height(), decode_mode, w, h);
+    r3d_dims_for_mode(clip->Width(), clip->Height(), decode_mode, w, h);
     if (out_w)
         *out_w = static_cast<uint32_t>(w);
     if (out_h)
         *out_h = static_cast<uint32_t>(h);
-    // 16-bit RGB interleaved
     return w * h * 3U * 2U;
 }
 
@@ -260,74 +412,37 @@ int r3d_bridge_decode_frame(
     uint32_t *out_w,
     uint32_t *out_h)
 {
-    if (!clip_ptr || !out_rgb_f32) {
-        set_error("r3d_bridge_decode_frame: null argument");
+    BridgeClip *bridge = as_bridge(clip_ptr);
+    if (!bridge || !bridge->clip || !out_rgb_f32) {
+        r3d_bridge_set_error("r3d_bridge_decode_frame: null argument");
         return -1;
     }
-    Clip *clip = static_cast<Clip *>(clip_ptr);
-    if (frame_index >= clip->VideoFrameCount()) {
-        set_error("r3d_bridge_decode_frame: frame index out of range");
-        return -2;
+
+    if (bridge->gpu_supported) {
+        int rc = r3d_gpu::decode_frame(
+            bridge->clip,
+            frame_index,
+            decode_mode,
+            pipeline,
+            out_rgb_f32,
+            out_rgb_bytes,
+            out_w,
+            out_h);
+        if (rc == 0) {
+            return 0;
+        }
+        // Infrastructure / process failure: fall back to CPU for the rest of this clip.
+        if (rc < 0) {
+            bridge->gpu_supported = false;
+        } else {
+            // SDK-level decode error (dropped frame, I/O, …) — CPU will likely fail too.
+            return cpu_decode_frame(
+                bridge, frame_index, decode_mode, pipeline, out_rgb_f32, out_rgb_bytes, out_w, out_h);
+        }
     }
 
-    size_t w = 0, h = 0;
-    dims_for_mode(clip->Width(), clip->Height(), decode_mode, w, h);
-    const size_t n_pix = w * h * 3U;
-    const size_t need_f32 = n_pix * sizeof(float);
-    if (out_rgb_bytes < need_f32) {
-        set_error("r3d_bridge_decode_frame: output buffer too small");
-        return -3;
-    }
-
-    size_t mem_needed = n_pix * 2U; // 16-bit
-    size_t align_offset = 0;
-    size_t adjusted = mem_needed;
-    unsigned char *img = aligned_malloc(adjusted, align_offset);
-    if (!img) {
-        set_error("r3d_bridge_decode_frame: alloc failed");
-        return -4;
-    }
-    // Pointer returned by aligned_malloc may be offset; free base separately.
-    unsigned char *base = img - align_offset;
-
-    ImageProcessingSettings *ip = new (std::nothrow) ImageProcessingSettings();
-    if (!ip) {
-        std::free(base);
-        set_error("r3d_bridge_decode_frame: IP alloc failed");
-        return -4;
-    }
-    apply_pipeline(clip, *ip, pipeline);
-
-    VideoDecodeJob job;
-    job.OutputBufferSize = mem_needed;
-    job.OutputBuffer = img;
-    job.Mode = map_mode(decode_mode);
-    job.PixelType = PixelType_16Bit_RGB_Interleaved;
-    job.ImageProcessing = ip;
-
-    DecodeStatus st = clip->DecodeVideoFrame(static_cast<size_t>(frame_index), job);
-    if (st != DSDecodeOK) {
-        delete ip;
-        std::free(base);
-        set_error(std::string("DecodeVideoFrame failed: ") + std::to_string(static_cast<int>(st)));
-        return static_cast<int>(st);
-    }
-
-    // Convert 16-bit interleaved RGB → float32 0–1.
-    const uint16_t *src = reinterpret_cast<const uint16_t *>(img);
-    const float scale = 1.0f / 65535.0f;
-    for (size_t i = 0; i < n_pix; ++i) {
-        out_rgb_f32[i] = static_cast<float>(src[i]) * scale;
-    }
-
-    if (out_w)
-        *out_w = static_cast<uint32_t>(w);
-    if (out_h)
-        *out_h = static_cast<uint32_t>(h);
-
-    delete ip;
-    std::free(base);
-    return 0;
+    return cpu_decode_frame(
+        bridge, frame_index, decode_mode, pipeline, out_rgb_f32, out_rgb_bytes, out_w, out_h);
 }
 
 const char *r3d_bridge_last_error(void)
@@ -335,15 +450,43 @@ const char *r3d_bridge_last_error(void)
     return g_last_error.c_str();
 }
 
+const char *r3d_bridge_decoder_kind(void)
+{
+    if (!g_initialized) {
+        return "";
+    }
+    if (r3d_gpu::ready()) {
+        const char *kind = r3d_gpu::kind();
+        if (kind && kind[0]) {
+            return kind;
+        }
+    }
+#if defined(__APPLE__)
+    if (!r3d_force_cpu()) {
+        return "metal";
+    }
+#endif
+    return "cpu";
+}
+
+int r3d_bridge_clip_uses_gpu(void *clip)
+{
+    BridgeClip *bridge = as_bridge(clip);
+    if (!bridge) {
+        return 0;
+    }
+    return bridge->gpu_supported ? 1 : 0;
+}
+
 int r3d_bridge_metadata_string(
     void *clip_ptr, const char *key, char *buf, size_t buf_len)
 {
-    if (!clip_ptr || !key || !buf || buf_len == 0) {
-        set_error("r3d_bridge_metadata_string: null argument");
+    R3DSDK::Clip *clip = as_clip(clip_ptr);
+    if (!clip || !key || !buf || buf_len == 0) {
+        r3d_bridge_set_error("r3d_bridge_metadata_string: null argument");
         return -1;
     }
     buf[0] = '\0';
-    Clip *clip = static_cast<Clip *>(clip_ptr);
     if (!clip->MetadataExists(key)) {
         return 0;
     }
@@ -359,12 +502,12 @@ int r3d_bridge_metadata_string(
 int r3d_bridge_absolute_timecode(
     void *clip_ptr, uint32_t frame_index, char *buf, size_t buf_len)
 {
-    if (!clip_ptr || !buf || buf_len == 0) {
-        set_error("r3d_bridge_absolute_timecode: null argument");
+    R3DSDK::Clip *clip = as_clip(clip_ptr);
+    if (!clip || !buf || buf_len == 0) {
+        r3d_bridge_set_error("r3d_bridge_absolute_timecode: null argument");
         return -1;
     }
     buf[0] = '\0';
-    Clip *clip = static_cast<Clip *>(clip_ptr);
     if (frame_index >= clip->VideoFrameCount()) {
         return 0;
     }
@@ -380,12 +523,12 @@ int r3d_bridge_absolute_timecode(
 int r3d_bridge_edge_timecode(
     void *clip_ptr, uint32_t frame_index, char *buf, size_t buf_len)
 {
-    if (!clip_ptr || !buf || buf_len == 0) {
-        set_error("r3d_bridge_edge_timecode: null argument");
+    R3DSDK::Clip *clip = as_clip(clip_ptr);
+    if (!clip || !buf || buf_len == 0) {
+        r3d_bridge_set_error("r3d_bridge_edge_timecode: null argument");
         return -1;
     }
     buf[0] = '\0';
-    Clip *clip = static_cast<Clip *>(clip_ptr);
     if (frame_index >= clip->VideoFrameCount()) {
         return 0;
     }

--- a/native/r3d/r3d_bridge.h
+++ b/native/r3d/r3d_bridge.h
@@ -111,6 +111,12 @@ R3D_BRIDGE_API size_t r3d_bridge_decode_buffer_bytes(
 /* Human-readable last error (thread-local best-effort; process-wide is fine). */
 R3D_BRIDGE_API const char *r3d_bridge_last_error(void);
 
+/* Decode backend: "metal", "cuda", "opencl", "cpu", or empty if not initialized. */
+R3D_BRIDGE_API const char *r3d_bridge_decoder_kind(void);
+
+/* 1 if this open clip will use GPU decode. 0 = CPU (or null clip). */
+R3D_BRIDGE_API int r3d_bridge_clip_uses_gpu(void *clip);
+
 /* Clip-level metadata string for *key* (case-insensitive RMD key).
  * Writes NUL-terminated UTF-8 into *buf*. Returns 1 if present and non-empty,
  * 0 if missing / empty, -1 on error. */

--- a/native/r3d/r3d_bridge_decoder.cpp
+++ b/native/r3d/r3d_bridge_decoder.cpp
@@ -1,0 +1,359 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Linux / Windows GPU decode via the SDK's managed R3DDecoder (CUDA, then OpenCL).
+ * No CUDA/OpenCL headers at compile time — REDDecoder loads them at runtime.
+ *
+ * GPU decompression is not part of R3DDecoder (CPU decompress + GPU IPP2).
+ * N-RAW / R3D NE still get GPU image processing when the device works.
+ */
+
+#include "r3d_gpu.h"
+#include "r3d_bridge_internal.h"
+
+#include "R3DSDKDecoder.h"
+
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <new>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <malloc.h>
+#endif
+
+namespace {
+
+std::mutex g_gpu_mu;
+bool g_started = false;
+bool g_ok = false;
+const char *g_kind = "";
+R3DSDK::R3DDecoder *g_decoder = nullptr;
+R3DSDK::R3DDecodeJob *g_job = nullptr;
+R3DSDK::ImageProcessingSettings *g_ip = nullptr;
+int g_ip_pipeline = -1;
+R3DSDK::Clip *g_ip_clip = nullptr;
+unsigned char *g_out = nullptr;
+size_t g_out_bytes = 0;
+
+struct DecodeWait {
+    std::mutex mu;
+    std::condition_variable cv;
+    R3DSDK::R3DStatus status = R3DSDK::R3DStatus_ErrorProcessing;
+    bool done = false;
+};
+
+void decode_callback(R3DSDK::R3DDecodeJob *item, R3DSDK::R3DStatus status)
+{
+    auto *wait = static_cast<DecodeWait *>(item->privateData);
+    if (!wait) {
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(wait->mu);
+        wait->status = status;
+        wait->done = true;
+    }
+    wait->cv.notify_one();
+}
+
+unsigned char *host_aligned(size_t size)
+{
+#ifdef _WIN32
+    return static_cast<unsigned char *>(_aligned_malloc(size, 64U));
+#else
+    void *p = nullptr;
+    if (posix_memalign(&p, 64U, size) != 0) {
+        return nullptr;
+    }
+    return static_cast<unsigned char *>(p);
+#endif
+}
+
+void host_aligned_free(void *p)
+{
+    if (!p) {
+        return;
+    }
+#ifdef _WIN32
+    _aligned_free(p);
+#else
+    std::free(p);
+#endif
+}
+
+void release_gpu_locked()
+{
+    g_ok = false;
+    g_started = false;
+    g_kind = "";
+    if (g_job) {
+        R3DSDK::R3DDecoder::ReleaseDecodeJob(g_job);
+        g_job = nullptr;
+    }
+    if (g_decoder) {
+        R3DSDK::R3DDecoder::ReleaseDecoder(g_decoder);
+        g_decoder = nullptr;
+    }
+    delete g_ip;
+    g_ip = nullptr;
+    g_ip_pipeline = -1;
+    g_ip_clip = nullptr;
+    host_aligned_free(g_out);
+    g_out = nullptr;
+    g_out_bytes = 0;
+}
+
+void apply_option_defaults(R3DSDK::R3DDecoderOptions *opts)
+{
+    opts->setScratchFolder("");
+    opts->setMemoryPoolSize(4096U);
+    opts->setGPUMemoryPoolSize(4096U);
+    opts->setGPUConcurrentFrameCount(1U);
+    opts->setDecompressionThreadCount(0U);
+    opts->setConcurrentImageCount(1U);
+}
+
+bool create_decoder_with_options(R3DSDK::R3DDecoderOptions *opts, const char *kind)
+{
+    R3DSDK::R3DDecoder *dec = nullptr;
+    R3DSDK::R3DStatus st = R3DSDK::R3DDecoder::CreateDecoder(opts, &dec);
+    if (st != R3DSDK::R3DStatus_Ok || !dec) {
+        r3d_bridge_set_error(
+            std::string("R3DDecoder::CreateDecoder failed (") + kind
+            + ") status=" + std::to_string(static_cast<int>(st)));
+        return false;
+    }
+    g_decoder = dec;
+    g_kind = kind;
+    return true;
+}
+
+bool try_cuda()
+{
+    R3DSDK::R3DDecoderOptions *opts = nullptr;
+    R3DSDK::R3DStatus st = R3DSDK::R3DDecoderOptions::CreateOptions(&opts);
+    if (st != R3DSDK::R3DStatus_Ok || !opts) {
+        return false;
+    }
+    apply_option_defaults(opts);
+
+    std::vector<R3DSDK::CudaDeviceInfo> devices;
+    st = R3DSDK::R3DDecoderOptions::GetCudaDeviceList(devices);
+    if (st != R3DSDK::R3DStatus_Ok || devices.empty()) {
+        R3DSDK::R3DDecoderOptions::ReleaseOptions(opts);
+        return false;
+    }
+    opts->useDevice(devices[0]);
+    const bool ok = create_decoder_with_options(opts, "cuda");
+    R3DSDK::R3DDecoderOptions::ReleaseOptions(opts);
+    return ok;
+}
+
+bool try_opencl()
+{
+    R3DSDK::R3DDecoderOptions *opts = nullptr;
+    R3DSDK::R3DStatus st = R3DSDK::R3DDecoderOptions::CreateOptions(&opts);
+    if (st != R3DSDK::R3DStatus_Ok || !opts) {
+        return false;
+    }
+    apply_option_defaults(opts);
+
+    std::vector<R3DSDK::OpenCLDeviceInfo> devices;
+    st = R3DSDK::R3DDecoderOptions::GetOpenCLDeviceList(devices);
+    if (st != R3DSDK::R3DStatus_Ok || devices.empty()) {
+        R3DSDK::R3DDecoderOptions::ReleaseOptions(opts);
+        return false;
+    }
+    opts->useDevice(devices[0]);
+    const bool ok = create_decoder_with_options(opts, "opencl");
+    R3DSDK::R3DDecoderOptions::ReleaseOptions(opts);
+    return ok;
+}
+
+bool startup_locked()
+{
+    if (g_started) {
+        return g_ok;
+    }
+    g_started = true;
+    if (r3d_force_cpu()) {
+        r3d_bridge_set_error("R3D GPU disabled (EXR_CONVERTER_R3D_CPU)");
+        g_ok = false;
+        return false;
+    }
+
+    if (!try_cuda() && !try_opencl()) {
+        release_gpu_locked();
+        g_started = true;
+        r3d_bridge_set_error("R3DDecoder: no CUDA or OpenCL GPU device");
+        return false;
+    }
+
+    R3DSDK::R3DStatus jst = R3DSDK::R3DDecoder::CreateDecodeJob(&g_job);
+    if (jst != R3DSDK::R3DStatus_Ok || !g_job) {
+        r3d_bridge_set_error("R3DDecoder::CreateDecodeJob failed");
+        release_gpu_locked();
+        g_started = true;
+        return false;
+    }
+    g_ok = true;
+    r3d_bridge_set_error("");
+    return true;
+}
+
+} // namespace
+
+namespace r3d_gpu {
+
+bool force_cpu()
+{
+    return r3d_force_cpu();
+}
+
+bool startup()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    return startup_locked();
+}
+
+void shutdown()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    release_gpu_locked();
+}
+
+bool available()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    if (!g_started) {
+        startup_locked();
+    }
+    return g_ok;
+}
+
+bool ready()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    return g_ok;
+}
+
+const char *kind()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    return g_ok ? g_kind : "";
+}
+
+bool clip_supported(void *clip_ptr)
+{
+    if (!clip_ptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    return startup_locked();
+}
+
+int decode_frame(
+    void *clip_ptr,
+    uint32_t frame_index,
+    int decode_mode,
+    int pipeline,
+    float *out_rgb_f32,
+    size_t out_rgb_bytes,
+    uint32_t *out_w,
+    uint32_t *out_h)
+{
+    if (!clip_ptr || !out_rgb_f32) {
+        r3d_bridge_set_error("r3d decoder: null argument");
+        return -1;
+    }
+
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    if (!startup_locked() || !g_decoder || !g_job) {
+        return -1;
+    }
+
+    auto *clip = static_cast<R3DSDK::Clip *>(clip_ptr);
+    if (frame_index >= clip->VideoFrameCount()) {
+        r3d_bridge_set_error("r3d decoder: frame index out of range");
+        return -2;
+    }
+
+    size_t w = 0, h = 0;
+    r3d_dims_for_mode(clip->Width(), clip->Height(), decode_mode, w, h);
+    const size_t n_pix = w * h * 3U;
+    const size_t need_f32 = n_pix * sizeof(float);
+    if (out_rgb_bytes < need_f32) {
+        r3d_bridge_set_error("r3d decoder: output buffer too small");
+        return -3;
+    }
+
+    const size_t packed = n_pix * 2U;
+    if (g_out_bytes < packed) {
+        host_aligned_free(g_out);
+        g_out = host_aligned(packed);
+        g_out_bytes = g_out ? packed : 0;
+        if (!g_out) {
+            r3d_bridge_set_error("r3d decoder: output alloc failed");
+            return -4;
+        }
+    }
+
+    if (!g_ip) {
+        g_ip = new (std::nothrow) R3DSDK::ImageProcessingSettings();
+        if (!g_ip) {
+            r3d_bridge_set_error("r3d decoder: IP alloc failed");
+            return -4;
+        }
+        g_ip_pipeline = -1;
+        g_ip_clip = nullptr;
+    }
+    if (g_ip_clip != clip || g_ip_pipeline != pipeline) {
+        r3d_apply_pipeline(clip, *g_ip, pipeline);
+        g_ip_clip = clip;
+        g_ip_pipeline = pipeline;
+    }
+
+    g_job->clip = clip;
+    g_job->videoTrackNo = 0;
+    g_job->videoFrameNo = static_cast<size_t>(frame_index);
+    g_job->callback = decode_callback;
+    g_job->mode = r3d_map_mode(decode_mode);
+    g_job->pixelType = R3DSDK::PixelType_16Bit_RGB_Interleaved;
+    g_job->outputBuffer = g_out;
+    g_job->bytesPerRow = w * 3U * 2U;
+    g_job->outputBufferSize = packed;
+    g_job->imageProcessingSettings = g_ip;
+    g_job->outputFrameMetadata = nullptr;
+
+    DecodeWait wait;
+    g_job->privateData = &wait;
+
+    R3DSDK::R3DStatus st = g_decoder->decode(g_job);
+    if (st != R3DSDK::R3DStatus_Ok) {
+        r3d_bridge_set_error(
+            std::string("R3DDecoder::decode failed: ") + std::to_string(static_cast<int>(st)));
+        return -6;
+    }
+    {
+        std::unique_lock<std::mutex> ul(wait.mu);
+        wait.cv.wait(ul, [&] { return wait.done; });
+        st = wait.status;
+    }
+    if (st != R3DSDK::R3DStatus_Ok) {
+        r3d_bridge_set_error(
+            std::string("R3DDecoder callback failed: ") + std::to_string(static_cast<int>(st)));
+        return -6;
+    }
+
+    r3d_u16_to_f32(reinterpret_cast<const uint16_t *>(g_out), out_rgb_f32, n_pix);
+    if (out_w)
+        *out_w = static_cast<uint32_t>(w);
+    if (out_h)
+        *out_h = static_cast<uint32_t>(h);
+    return 0;
+}
+
+} // namespace r3d_gpu

--- a/native/r3d/r3d_bridge_internal.h
+++ b/native/r3d/r3d_bridge_internal.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Shared helpers for the R3D C ABI bridge (CPU + optional Metal).
+ * Not installed; not a public API.
+ */
+#pragma once
+
+#include "r3d_bridge.h"
+
+#include "R3DSDK.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+void r3d_bridge_set_error(const std::string &msg);
+
+/* True when EXR_CONVERTER_R3D_CPU is set to a non-empty / non-zero value. */
+bool r3d_force_cpu();
+
+R3DSDK::VideoDecodeMode r3d_map_mode(int mode);
+
+void r3d_dims_for_mode(size_t full_w, size_t full_h, int mode, size_t &w, size_t &h);
+
+void r3d_apply_pipeline(R3DSDK::Clip *clip, R3DSDK::ImageProcessingSettings &ip, int pipeline);
+
+void r3d_u16_to_f32(const uint16_t *src, float *dst, size_t n);

--- a/native/r3d/r3d_bridge_metal.mm
+++ b/native/r3d/r3d_bridge_metal.mm
@@ -1,0 +1,400 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * macOS Metal GPU decode: GpuDecoder (decompress) + REDMetal (debayer / IPP2).
+ * Falls back to CPU when the clip or GPU is unsupported.
+ *
+ * Do not copy RED sample sources; this is project-owned glue over the SDK headers.
+ */
+
+#include "r3d_gpu.h"
+
+#import <Metal/Metal.h>
+
+#include "r3d_bridge_internal.h"
+#include "R3DSDKMetal.h"
+
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <new>
+#include <string>
+
+namespace {
+
+std::mutex g_gpu_mu;
+bool g_started = false;
+bool g_ok = false;
+R3DSDK::EXT_METAL_API g_metal_api;
+R3DSDK::REDMetal *g_red_metal = nullptr;
+R3DSDK::GpuDecoder *g_gpu_decoder = nullptr;
+id<MTLDevice> g_device = nil;
+id<MTLCommandQueue> g_queue = nil;
+id<MTLBuffer> g_raw_buf = nil;
+id<MTLBuffer> g_out_buf = nil;
+unsigned char *g_host_raw = nullptr;
+size_t g_host_raw_bytes = 0;
+R3DSDK::ImageProcessingSettings *g_ip = nullptr;
+int g_ip_pipeline = -1;
+R3DSDK::Clip *g_ip_clip = nullptr;
+bool g_unified = true;
+
+struct DecompressWait {
+    std::mutex mu;
+    std::condition_variable cv;
+    R3DSDK::DecodeStatus status = R3DSDK::DSUnknownError;
+    bool done = false;
+};
+
+void decompress_callback(R3DSDK::AsyncDecompressJob *item, R3DSDK::DecodeStatus status)
+{
+    auto *wait = static_cast<DecompressWait *>(item->PrivateData);
+    if (!wait) {
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(wait->mu);
+        wait->status = status;
+        wait->done = true;
+    }
+    wait->cv.notify_one();
+}
+
+
+
+unsigned char *host_aligned(size_t size)
+{
+    void *p = nullptr;
+    if (posix_memalign(&p, 64U, size) != 0) {
+        return nullptr;
+    }
+    return static_cast<unsigned char *>(p);
+}
+
+id<MTLBuffer> ensure_mtl_buffer(id<MTLBuffer> existing, size_t size)
+{
+    if (existing && [existing length] >= size) {
+        return existing;
+    }
+    const size_t alloc = (size + 4095U) & ~static_cast<size_t>(4095U);
+    MTLResourceOptions opts = g_unified ? MTLResourceStorageModeShared
+                                        : MTLResourceStorageModeManaged;
+    return [g_device newBufferWithLength:alloc options:opts];
+}
+
+void release_gpu_locked()
+{
+    g_ok = false;
+    g_started = false;
+    if (g_gpu_decoder) {
+        g_gpu_decoder->Close();
+        delete g_gpu_decoder;
+        g_gpu_decoder = nullptr;
+    }
+    if (g_red_metal) {
+        delete g_red_metal;
+        g_red_metal = nullptr;
+    }
+    delete g_ip;
+    g_ip = nullptr;
+    g_ip_pipeline = -1;
+    g_ip_clip = nullptr;
+    if (g_host_raw) {
+        std::free(g_host_raw);
+        g_host_raw = nullptr;
+        g_host_raw_bytes = 0;
+    }
+    g_raw_buf = nil;
+    g_out_buf = nil;
+    g_queue = nil;
+    g_device = nil;
+}
+
+bool startup_locked()
+{
+    if (g_started) {
+        return g_ok;
+    }
+    g_started = true;
+    if (r3d_force_cpu()) {
+        r3d_bridge_set_error("R3D Metal disabled (EXR_CONVERTER_R3D_CPU)");
+        g_ok = false;
+        return false;
+    }
+
+    @autoreleasepool {
+        g_device = MTLCreateSystemDefaultDevice();
+        if (!g_device) {
+            r3d_bridge_set_error("R3D Metal: no MTLDevice");
+            return false;
+        }
+        g_unified = g_device.hasUnifiedMemory;
+        g_queue = [g_device newCommandQueue];
+        if (!g_queue) {
+            r3d_bridge_set_error("R3D Metal: failed to create command queue");
+            g_device = nil;
+            return false;
+        }
+
+        g_red_metal = new (std::nothrow) R3DSDK::REDMetal(g_metal_api);
+        if (!g_red_metal) {
+            r3d_bridge_set_error("R3D Metal: REDMetal alloc failed");
+            return false;
+        }
+        int err = 0;
+        R3DSDK::REDMetal::Status cst = g_red_metal->checkCompatibility(g_queue, err);
+        if (cst != R3DSDK::REDMetal::Status_Ok) {
+            r3d_bridge_set_error(
+                std::string("R3D Metal: checkCompatibility failed status=")
+                + std::to_string(static_cast<int>(cst)) + " err=" + std::to_string(err));
+            release_gpu_locked();
+            g_started = true;
+            return false;
+        }
+
+        g_gpu_decoder = new (std::nothrow) R3DSDK::GpuDecoder();
+        if (!g_gpu_decoder) {
+            r3d_bridge_set_error("R3D Metal: GpuDecoder alloc failed");
+            release_gpu_locked();
+            g_started = true;
+            return false;
+        }
+        g_gpu_decoder->Open();
+        g_ok = true;
+        return true;
+    }
+}
+
+} // namespace
+
+namespace r3d_gpu {
+
+bool force_cpu()
+{
+    return r3d_force_cpu();
+}
+
+bool startup()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    return startup_locked();
+}
+
+void shutdown()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    release_gpu_locked();
+}
+
+bool available()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    if (!g_started) {
+        startup_locked();
+    }
+    return g_ok;
+}
+
+bool ready()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    return g_ok;
+}
+
+const char *kind()
+{
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    return g_ok ? "metal" : "";
+}
+
+bool clip_supported(void *clip_ptr)
+{
+    if (!clip_ptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    if (!startup_locked()) {
+        return false;
+    }
+    auto *clip = static_cast<R3DSDK::Clip *>(clip_ptr);
+    return R3DSDK::GpuDecoder::DecodeSupportedForClip(*clip) == R3DSDK::DSDecodeOK;
+}
+
+int decode_frame(
+    void *clip_ptr,
+    uint32_t frame_index,
+    int decode_mode,
+    int pipeline,
+    float *out_rgb_f32,
+    size_t out_rgb_bytes,
+    uint32_t *out_w,
+    uint32_t *out_h)
+{
+    if (!clip_ptr || !out_rgb_f32) {
+        r3d_bridge_set_error("r3d metal decode: null argument");
+        return -1;
+    }
+
+    std::lock_guard<std::mutex> lock(g_gpu_mu);
+    if (!startup_locked()) {
+        return -1;
+    }
+
+    auto *clip = static_cast<R3DSDK::Clip *>(clip_ptr);
+    if (frame_index >= clip->VideoFrameCount()) {
+        r3d_bridge_set_error("r3d metal decode: frame index out of range");
+        return -2;
+    }
+
+    size_t w = 0, h = 0;
+    r3d_dims_for_mode(clip->Width(), clip->Height(), decode_mode, w, h);
+    const size_t n_pix = w * h * 3U;
+    const size_t need_f32 = n_pix * sizeof(float);
+    if (out_rgb_bytes < need_f32) {
+        r3d_bridge_set_error("r3d metal decode: output buffer too small");
+        return -3;
+    }
+
+    @autoreleasepool {
+        R3DSDK::AsyncDecompressJob job;
+        job.Clip = clip;
+        job.Mode = r3d_map_mode(decode_mode);
+        job.VideoFrameNo = static_cast<size_t>(frame_index);
+        job.VideoTrackNo = 0;
+        job.AbortDecode = false;
+        job.OutputFrameMetadata = nullptr;
+        job.Callback = decompress_callback;
+
+        const size_t raw_need = R3DSDK::GpuDecoder::GetSizeBufferNeeded(job);
+        if (raw_need == 0) {
+            r3d_bridge_set_error("r3d metal decode: GetSizeBufferNeeded returned 0");
+            return -4;
+        }
+        if (g_host_raw_bytes < raw_need) {
+            if (g_host_raw) {
+                std::free(g_host_raw);
+            }
+            g_host_raw = host_aligned(raw_need);
+            g_host_raw_bytes = g_host_raw ? raw_need : 0;
+            if (!g_host_raw) {
+                r3d_bridge_set_error("r3d metal decode: host raw alloc failed");
+                return -4;
+            }
+        }
+
+        job.OutputBuffer = g_host_raw;
+        job.OutputBufferSize = raw_need;
+
+        DecompressWait wait;
+        job.PrivateData = &wait;
+
+        R3DSDK::DecodeStatus ds = g_gpu_decoder->DecodeForGpuSdk(job);
+        if (ds != R3DSDK::DSDecodeOK) {
+            r3d_bridge_set_error(
+                std::string("GpuDecoder::DecodeForGpuSdk failed: ")
+                + std::to_string(static_cast<int>(ds)));
+            return static_cast<int>(ds);
+        }
+        {
+            std::unique_lock<std::mutex> ul(wait.mu);
+            wait.cv.wait(ul, [&] { return wait.done; });
+            ds = wait.status;
+        }
+        if (ds != R3DSDK::DSDecodeOK) {
+            r3d_bridge_set_error(
+                std::string("GpuDecoder callback failed: ") + std::to_string(static_cast<int>(ds)));
+            return static_cast<int>(ds);
+        }
+
+        if (!g_ip) {
+            g_ip = new (std::nothrow) R3DSDK::ImageProcessingSettings();
+            if (!g_ip) {
+                r3d_bridge_set_error("r3d metal decode: IP alloc failed");
+                return -4;
+            }
+            g_ip_pipeline = -1;
+            g_ip_clip = nullptr;
+        }
+        if (g_ip_clip != clip || g_ip_pipeline != pipeline) {
+            r3d_apply_pipeline(clip, *g_ip, pipeline);
+            g_ip_clip = clip;
+            g_ip_pipeline = pipeline;
+        }
+
+        R3DSDK::DebayerMetalJob *debayer = g_red_metal->createDebayerJob();
+        if (!debayer) {
+            r3d_bridge_set_error("r3d metal decode: createDebayerJob failed");
+            return -5;
+        }
+        debayer->imageProcessingSettings = g_ip;
+        debayer->mode = r3d_map_mode(decode_mode);
+        debayer->pixelType = R3DSDK::PixelType_16Bit_RGB_Interleaved;
+        debayer->raw_host_mem = g_host_raw;
+        debayer->batchMode = false;
+        debayer->debayerJobCallback = nullptr;
+        debayer->output_device_image = nil;
+
+        const size_t result_size = R3DSDK::DebayerMetalJob::ResultFrameSize(*debayer);
+        if (result_size == 0) {
+            g_red_metal->releaseDebayerJob(debayer);
+            r3d_bridge_set_error("r3d metal decode: ResultFrameSize is 0");
+            return -5;
+        }
+
+        g_raw_buf = ensure_mtl_buffer(g_raw_buf, raw_need);
+        g_out_buf = ensure_mtl_buffer(g_out_buf, result_size);
+        if (!g_raw_buf || !g_out_buf) {
+            g_red_metal->releaseDebayerJob(debayer);
+            r3d_bridge_set_error("r3d metal decode: MTLBuffer alloc failed");
+            return -4;
+        }
+
+        std::memcpy([g_raw_buf contents], g_host_raw, raw_need);
+        if (!g_unified) {
+            [g_raw_buf didModifyRange:NSMakeRange(0, raw_need)];
+        }
+
+        debayer->raw_device_mem = g_raw_buf;
+        debayer->output_device_mem = g_out_buf;
+        debayer->output_device_mem_size = result_size;
+
+        int err = 0;
+        R3DSDK::REDMetal::Status pst = g_red_metal->process(g_queue, debayer, err);
+        if (pst != R3DSDK::REDMetal::Status_Ok) {
+            const int code = static_cast<int>(pst);
+            g_red_metal->releaseDebayerJob(debayer);
+            r3d_bridge_set_error(
+                std::string("REDMetal::process failed status=") + std::to_string(code)
+                + " err=" + std::to_string(err));
+            return -6;
+        }
+
+        if (!g_unified) {
+            id<MTLCommandBuffer> cmd = [g_queue commandBuffer];
+            id<MTLBlitCommandEncoder> blit = [cmd blitCommandEncoder];
+            [blit synchronizeResource:g_out_buf];
+            [blit endEncoding];
+            [cmd commit];
+            [cmd waitUntilCompleted];
+        }
+
+        const uint16_t *src = static_cast<const uint16_t *>([g_out_buf contents]);
+        const size_t packed = n_pix * 2U;
+        if (result_size < packed) {
+            g_red_metal->releaseDebayerJob(debayer);
+            r3d_bridge_set_error("r3d metal decode: result smaller than packed RGB");
+            return -6;
+        }
+        r3d_u16_to_f32(src, out_rgb_f32, n_pix);
+
+        g_red_metal->releaseDebayerJob(debayer);
+    }
+
+    if (out_w)
+        *out_w = static_cast<uint32_t>(w);
+    if (out_h)
+        *out_h = static_cast<uint32_t>(h);
+    return 0;
+}
+
+} // namespace r3d_gpu

--- a/native/r3d/r3d_gpu.h
+++ b/native/r3d/r3d_gpu.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Optional GPU decode:
+ *   macOS        — Metal (GpuDecoder + REDMetal) in r3d_bridge_metal.mm
+ *   Linux/Windows — R3DDecoder (CUDA, then OpenCL) in r3d_bridge_decoder.cpp
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace r3d_gpu {
+
+bool force_cpu();
+
+bool startup();
+
+void shutdown();
+
+bool available();
+
+/* True only if GPU decode is already running (does not start it). */
+bool ready();
+
+/* "metal", "cuda", "opencl", or empty if GPU is not running. */
+const char *kind();
+
+/* *clip* is an R3DSDK::Clip*. */
+bool clip_supported(void *clip);
+
+/* Decode into float32 RGB. Returns 0 on success; non-zero to fall back to CPU. */
+int decode_frame(
+    void *clip,
+    uint32_t frame_index,
+    int decode_mode,
+    int pipeline,
+    float *out_rgb_f32,
+    size_t out_rgb_bytes,
+    uint32_t *out_w,
+    uint32_t *out_h);
+
+} // namespace r3d_gpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exr-converter"
-version = "0.9.11"
+version = "0.9.12"
 description = "A cross-platform GUI tool for converting and transcoding EXR and video files."
 authors = [
     {name = "Derek Rein", email = "derek@derekvfx.ca"},

--- a/scripts/build_r3d_bridge.py
+++ b/scripts/build_r3d_bridge.py
@@ -31,6 +31,8 @@ from packaging_util import ignore_macos_junk, is_macos_junk_name, safe_print  # 
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "native" / "r3d" / "r3d_bridge.cpp"
+METAL_SRC = ROOT / "native" / "r3d" / "r3d_bridge_metal.mm"
+DECODER_SRC = ROOT / "native" / "r3d" / "r3d_bridge_decoder.cpp"
 HDR_DIR = ROOT / "native" / "r3d"
 OUT_DIR = ROOT / "build" / "r3d"
 
@@ -139,8 +141,9 @@ def build(sdk: Path, out_dir: Path, verbose: bool) -> Path:
         # Must match the RED static lib CRT: R3DSDK-*-MD.lib → /MD (DLL runtime).
         # Without explicit /MD, some CI images default to /MT and LNK2038.
         # Prefer /Fo + /Fe into out_dir so intermediates stay out of the source tree.
-        obj = out_dir / "r3d_bridge.obj"
-        cmd = [
+        if not DECODER_SRC.is_file():
+            raise SystemExit(f"Missing decoder bridge source: {DECODER_SRC}")
+        win_common = [
             "cl.exe",
             "/nologo",
             "/O2",
@@ -150,24 +153,76 @@ def build(sdk: Path, out_dir: Path, verbose: bool) -> Path:
             f"/I{include}",
             f"/I{HDR_DIR}",
             "/DR3D_BRIDGE_EXPORTS",
+            "/c",
+        ]
+        objs: list[Path] = []
+        for src in (SRC, DECODER_SRC):
+            obj = out_dir / f"{src.stem}.obj"
+            cmd = [*win_common, str(src), f"/Fo{obj}"]
+            if verbose:
+                print(" ".join(cmd), file=sys.stderr)
+            subprocess.check_call(cmd)
+            objs.append(obj)
+        cmd = [
+            "cl.exe",
+            "/nologo",
             "/LD",
-            str(SRC),
+            "/MD",
+            *[str(o) for o in objs],
             str(static),
-            f"/Fo{obj}",
             f"/Fe{out_lib}",
         ]
+        if verbose:
+            print(" ".join(cmd), file=sys.stderr)
+        subprocess.check_call(cmd)
     else:
         cxx = os.environ.get("CXX", "c++")
-        cmd = [
-            cxx,
+        common = [
             "-std=c++17",
             "-O2",
             "-fPIC",
-            "-shared",
             f"-I{include}",
             f"-I{HDR_DIR}",
             "-DR3D_BRIDGE_EXPORTS",
-            str(SRC),
+        ]
+        obj = out_dir / "r3d_bridge.o"
+        compile_cpp = [cxx, *common, "-c", str(SRC), "-o", str(obj)]
+        if verbose:
+            print(" ".join(compile_cpp), file=sys.stderr)
+        subprocess.check_call(compile_cpp)
+        link_inputs = [str(obj)]
+        if system == "Darwin":
+            if not METAL_SRC.is_file():
+                raise SystemExit(f"Missing Metal bridge source: {METAL_SRC}")
+            metal_obj = out_dir / "r3d_bridge_metal.o"
+            compile_mm = [
+                cxx,
+                *common,
+                "-fobjc-arc",
+                "-x",
+                "objective-c++",
+                "-c",
+                str(METAL_SRC),
+                "-o",
+                str(metal_obj),
+            ]
+            if verbose:
+                print(" ".join(compile_mm), file=sys.stderr)
+            subprocess.check_call(compile_mm)
+            link_inputs.append(str(metal_obj))
+        else:
+            if not DECODER_SRC.is_file():
+                raise SystemExit(f"Missing decoder bridge source: {DECODER_SRC}")
+            decoder_obj = out_dir / "r3d_bridge_decoder.o"
+            compile_dec = [cxx, *common, "-c", str(DECODER_SRC), "-o", str(decoder_obj)]
+            if verbose:
+                print(" ".join(compile_dec), file=sys.stderr)
+            subprocess.check_call(compile_dec)
+            link_inputs.append(str(decoder_obj))
+        cmd = [
+            cxx,
+            "-shared",
+            *link_inputs,
             str(static),
             "-o",
             str(out_lib),
@@ -183,11 +238,9 @@ def build(sdk: Path, out_dir: Path, verbose: bool) -> Path:
             )
         elif system == "Linux":
             cmd.extend(["-Wl,-rpath,$ORIGIN", "-Wl,-rpath,$ORIGIN/redistributable"])
-
-    if verbose:
-        print(" ".join(cmd), file=sys.stderr)
-
-    subprocess.check_call(cmd)
+        if verbose:
+            print(" ".join(cmd), file=sys.stderr)
+        subprocess.check_call(cmd)
 
     # Copy only Redistributable dynamic libraries (allowed by RED license).
     # Skip macOS AppleDouble (._*) / .DS_Store junk that can ride along in tarballs

--- a/src/core/frame_source.py
+++ b/src/core/frame_source.py
@@ -194,11 +194,13 @@ class VideoPreviewDecoder:
             pass
 
     def _frame_to_rgb_f32(self, frame) -> np.ndarray:
+        from .video import av_frame_to_rgb_ndarray
+
         try:
-            arr = frame.to_ndarray(format="rgb48le")
+            arr = av_frame_to_rgb_ndarray(frame, pix_fmt="rgb48le")
             rgb = np.ascontiguousarray(arr.astype(np.float32) * (1.0 / 65535.0))
         except Exception:
-            arr = frame.to_ndarray(format="rgb24")
+            arr = av_frame_to_rgb_ndarray(frame, pix_fmt="rgb24")
             rgb = np.ascontiguousarray(arr.astype(np.float32) * (1.0 / 255.0))
         self._decode_w = int(rgb.shape[1])
         self._decode_h = int(rgb.shape[0])
@@ -493,7 +495,7 @@ class VideoIngestSource:
     ) -> Iterator[tuple[int, np.ndarray, dict[str, str]]]:
         import av
 
-        from .video import decode_video_frames
+        from .video import av_frame_reformat, av_frame_to_rgb_ndarray, decode_video_frames
 
         do_resize = self._scale < 1.0
         ow, oh = self._out_w, self._out_h
@@ -518,8 +520,8 @@ class VideoIngestSource:
                             break
                         continue
                 if do_resize:
-                    frame = frame.reformat(width=ow, height=oh)
-                rgb_u16 = frame.to_ndarray(format="rgb48le")
+                    frame = av_frame_reformat(frame, width=ow, height=oh)
+                rgb_u16 = av_frame_to_rgb_ndarray(frame, pix_fmt="rgb48le")
                 rgb_f32 = np.ascontiguousarray(rgb_u16.astype(np.float32) * (1.0 / 65535.0))
                 yield idx, rgb_f32, {}
                 submitted += 1
@@ -587,10 +589,20 @@ class R3DIngestSource:
     def log_header(self, log_fn: Callable[[str], None] | None) -> None:
         if not log_fn:
             return
-        from .r3d import sdk_version
+        from .r3d import decoder_kind, sdk_version
 
         log_fn(f"R3D SDK: {sdk_version() or self._sdk_version}")
-        log_fn(f"R3D decode: mode={self._mode} pipeline=IPP2 primary Log3G10/RWG")
+
+        if self._clip.uses_gpu():
+            kind = decoder_kind()
+            backend = {
+                "metal": "Metal GPU",
+                "cuda": "CUDA GPU",
+                "opencl": "OpenCL GPU",
+            }.get(kind, "GPU")
+        else:
+            backend = "CPU"
+        log_fn(f"R3D decode: {backend} mode={self._mode} pipeline=IPP2 primary Log3G10/RWG")
         cam = self._base_attrs.get("exrconverter:r3d:camera_model")
         if cam:
             log_fn(f"R3D camera: {cam}")

--- a/src/core/r3d/__init__.py
+++ b/src/core/r3d/__init__.py
@@ -34,7 +34,7 @@ from .constants import (
     decode_mode_for_scale,
     scale_for_decode_mode,
 )
-from .native import is_available, sdk_version, unavailable_reason
+from .native import decoder_kind, is_available, sdk_version, unavailable_reason
 from .paths import bridge_candidates, bridge_names
 
 # Tests / advanced callers still poke private helpers under these names.
@@ -81,6 +81,7 @@ __all__ = [
     "R3D_SRC_COLORSPACE_CANDIDATES",
     "R3D_SUFFIXES",
     "decode_mode_for_scale",
+    "decoder_kind",
     "is_available",
     "is_r3d_path",
     "probe_r3d",

--- a/src/core/r3d/clip.py
+++ b/src/core/r3d/clip.py
@@ -80,6 +80,15 @@ class R3DClip:
             self._lib.r3d_bridge_close(self._handle)
             self._handle = None
 
+    def uses_gpu(self) -> bool:
+        """True when this clip decodes on GPU (Metal / CUDA / OpenCL)."""
+        if not self._handle or self._lib is None:
+            return False
+        try:
+            return bool(self._lib.r3d_bridge_clip_uses_gpu(self._handle))
+        except AttributeError:
+            return False
+
     def __enter__(self) -> R3DClip:
         return self
 

--- a/src/core/r3d/native.py
+++ b/src/core/r3d/native.py
@@ -81,6 +81,12 @@ def _bind(lib: ctypes.CDLL) -> None:
     lib.r3d_bridge_last_error.restype = ctypes.c_char_p
     lib.r3d_bridge_last_error.argtypes = []
 
+    lib.r3d_bridge_decoder_kind.restype = ctypes.c_char_p
+    lib.r3d_bridge_decoder_kind.argtypes = []
+
+    lib.r3d_bridge_clip_uses_gpu.restype = ctypes.c_int
+    lib.r3d_bridge_clip_uses_gpu.argtypes = [ctypes.c_void_p]
+
     lib.r3d_bridge_metadata_string.restype = ctypes.c_int
     lib.r3d_bridge_metadata_string.argtypes = [
         ctypes.c_void_p,
@@ -212,6 +218,19 @@ def sdk_version() -> str:
     buf = ctypes.create_string_buffer(256)
     _lib.r3d_bridge_sdk_version(buf, 256)
     return buf.value.decode("utf-8", errors="replace")
+
+
+def decoder_kind() -> str:
+    """``metal``, ``cuda``, ``opencl``, ``cpu``, or empty if not initialized."""
+    if not ensure_initialized() or _lib is None:
+        return ""
+    try:
+        raw = _lib.r3d_bridge_decoder_kind()
+    except AttributeError:
+        return "cpu"
+    if not raw:
+        return ""
+    return raw.decode("utf-8", errors="replace")
 
 
 def get_lib() -> ctypes.CDLL | None:

--- a/src/core/video.py
+++ b/src/core/video.py
@@ -174,6 +174,38 @@ def _make_deint_graph(frame, time_base, deint: str):
     return graph
 
 
+def av_frame_sws_compatible(frame):
+    """Copy *frame* planes into a new VideoFrame with default colour metadata.
+
+    oxideav ProRes (and some other bitstreams) decode as YUV but tag
+    ``colorspace=RGB`` / reserved-0 primaries. libswscale then returns
+    ``ENOTSUP`` on ``rgb24`` / ``rgb48le``. A plane copy drops that metadata
+    so swscale can convert. Cheap relative to the convert itself.
+    """
+    import av
+
+    clean = av.VideoFrame(int(frame.width), int(frame.height), frame.format.name)
+    for i, plane in enumerate(frame.planes):
+        clean.planes[i].update(plane)
+    return clean
+
+
+def av_frame_reformat(frame, **kwargs):
+    """``VideoFrame.reformat`` with a swscale-compatible fallback."""
+    try:
+        return frame.reformat(**kwargs)
+    except Exception:
+        return av_frame_sws_compatible(frame).reformat(**kwargs)
+
+
+def av_frame_to_rgb_ndarray(frame, pix_fmt: str = "rgb48le"):
+    """RGB numpy array from a PyAV frame (``rgb48le`` / ``rgb24``, …)."""
+    try:
+        return frame.to_ndarray(format=pix_fmt)
+    except Exception:
+        return av_frame_sws_compatible(frame).to_ndarray(format=pix_fmt)
+
+
 def decode_video_frames(container, stream, deinterlace: str = "auto", log=None):
     """Yield decoded video frames, deinterlacing interlaced sources.
 

--- a/src/gui/browser_thumbs.py
+++ b/src/gui/browser_thumbs.py
@@ -79,8 +79,10 @@ def load_video_thumbnail_rgb(
 
         container = av.open(path)
         try:
+            from ..core.video import av_frame_to_rgb_ndarray
+
             for frame in container.decode(video=0):
-                rgb = frame.to_ndarray(format="rgb24")
+                rgb = av_frame_to_rgb_ndarray(frame, pix_fmt="rgb24")
                 return _downscale_uint8_rgb(rgb, max_edge)
         finally:
             container.close()

--- a/src/gui/window.py
+++ b/src/gui/window.py
@@ -87,12 +87,18 @@ class AboutDialog(QDialog):
 
         r3d_line = ""
         try:
+            from ..core.r3d import decoder_kind, sdk_version
             from ..core.r3d import is_available as r3d_available
-            from ..core.r3d import sdk_version
 
             if r3d_available():
                 ver = sdk_version() or "loaded"
-                r3d_line = f"<br>RED R3D SDK: {ver}"
+                kind = decoder_kind()
+                gpu = {
+                    "metal": " · Metal GPU",
+                    "cuda": " · CUDA GPU",
+                    "opencl": " · OpenCL GPU",
+                }.get(kind, "")
+                r3d_line = f"<br>RED R3D SDK: {ver}{gpu}"
             else:
                 r3d_line = "<br>RED R3D: not available (optional)"
         except Exception:

--- a/tests/test_av_frame_rgb.py
+++ b/tests/test_av_frame_rgb.py
@@ -1,0 +1,44 @@
+"""PyAV RGB convert fallback for YUV frames tagged with RGB colorspace."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+av = pytest.importorskip("av")
+
+from src.core.video import av_frame_to_rgb_ndarray  # noqa: E402
+
+
+def _yuv422p10_rgb_matrix_frame(*, width: int = 32, height: int = 32):
+    """Build a YUV422P10 frame whose colour tags make libswscale reject RGB."""
+    rgb = np.full((height, width, 3), 128, dtype=np.uint8)
+    src = av.VideoFrame.from_ndarray(rgb, format="rgb24")
+    yuv = src.reformat(format="yuv422p10le")
+    yuv.colorspace = 0  # AVCOL_SPC_RGB
+    yuv.color_primaries = 0
+    yuv.color_trc = 0
+    yuv.color_range = 1
+    return yuv
+
+
+def test_direct_rgb24_raises_on_yuv_with_rgb_colorspace() -> None:
+    frame = _yuv422p10_rgb_matrix_frame()
+    with pytest.raises(OSError):
+        frame.to_ndarray(format="rgb24")
+
+
+def test_av_frame_to_rgb_ndarray_recovers_rgb24() -> None:
+    frame = _yuv422p10_rgb_matrix_frame()
+    rgb = av_frame_to_rgb_ndarray(frame, pix_fmt="rgb24")
+    assert rgb.shape == (32, 32, 3)
+    assert rgb.dtype == np.uint8
+    assert rgb.mean() > 1
+
+
+def test_av_frame_to_rgb_ndarray_recovers_rgb48le() -> None:
+    frame = _yuv422p10_rgb_matrix_frame()
+    rgb = av_frame_to_rgb_ndarray(frame, pix_fmt="rgb48le")
+    assert rgb.shape == (32, 32, 3)
+    assert rgb.dtype == np.uint16
+    assert rgb.mean() > 1

--- a/tests/test_oxideav_prores.py
+++ b/tests/test_oxideav_prores.py
@@ -138,6 +138,25 @@ class TestOxideavEncode:
         assert probe.streams.video[0].codec_context.codec_tag == "ap4x"
         probe.close()
 
+    def test_preview_decoder_reads_hq_mov(self, tmp_path: Path):
+        """Built-in player must RGB-convert oxideav HQ (swscale ENOTSUP otherwise)."""
+        from src.core.frame_source import open_preview_decoder
+
+        out = tmp_path / "hq_preview.mov"
+        w, h = 64, 48
+        with open_writer(out, w, h, 24, 1, "prores_ox_hq") as writer:
+            write_rgb48_frame(writer, np.full((h, w, 3), 22000, dtype=np.uint16))
+            write_rgb48_frame(writer, np.full((h, w, 3), 40000, dtype=np.uint16))
+        dec = open_preview_decoder(str(out), fps=24.0)
+        try:
+            rgb = dec.get_frame(1)
+        finally:
+            dec.close()
+        assert rgb is not None
+        assert rgb.shape == (h, w, 3)
+        assert rgb.dtype == np.float32
+        assert float(rgb.mean()) > 0.05
+
     def test_422_hq_fourcc(self, tmp_path: Path):
         out = tmp_path / "hq.mov"
         w, h = 64, 48

--- a/tests/test_r3d.py
+++ b/tests/test_r3d.py
@@ -41,6 +41,32 @@ def test_decode_mode_for_scale() -> None:
     assert decode_mode_for_scale(0.25) == DECODE_QUARTER_GOOD
 
 
+def test_decoder_kind_when_unavailable() -> None:
+    from src.core.r3d import native as native_mod
+
+    prev = (
+        native_mod._init_attempted,
+        native_mod._init_ok,
+        native_mod._init_error,
+        native_mod._lib,
+    )
+    native_mod._init_attempted = True
+    native_mod._init_ok = False
+    native_mod._init_error = "test: bridge missing"
+    native_mod._lib = None
+    try:
+        from src.core.r3d import decoder_kind
+
+        assert decoder_kind() == ""
+    finally:
+        (
+            native_mod._init_attempted,
+            native_mod._init_ok,
+            native_mod._init_error,
+            native_mod._lib,
+        ) = prev
+
+
 def test_src_colorspace_candidates_include_log3g10() -> None:
     cands = r3d_src_colorspace_candidates("x.R3D")
     assert any("Log3G10" in c or "log3g10" in c.lower() for c in cands)

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "exr-converter"
-version = "0.9.11"
+version = "0.9.12"
 source = { virtual = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary
- R3D → EXR GPU decode: Metal on macOS, CUDA then OpenCL on Windows/Linux (CPU fallback).
- Built-in player/preview can open oxideav ProRes MOVs (swscale ENOTSUP workaround).

## Release
Patch **0.9.12**. CHANGELOG has `## [0.9.12]` + compare link. After merge, Auto-tag should create `v0.9.12` and dispatch Release. Do not also push the local tag unless Auto-tag fails.